### PR TITLE
Add Codex CLI agent + per-config data dir + start shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ A lightweight bot that bridges Feishu / Lark messenger with your local Claude Co
 ## Prerequisites
 
 - Node.js **>= 20**
-- `claude` CLI installed and logged in — see https://docs.anthropic.com/en/docs/claude-code/quickstart
+- One of the supported coding-agent CLIs, installed and logged in:
+  - `claude` (Claude Code) — see https://docs.anthropic.com/en/docs/claude-code/quickstart  *(default)*
+  - `codex` (OpenAI Codex CLI) — `codex login` to authenticate
 - A Lark / Feishu **PersonalAgent** app (the QR-code wizard on first launch can create one for you).
 
 ## Install
@@ -58,15 +60,33 @@ The wizard creates the app shell, but you still need to confirm a few things on 
 
 After enabling those, run `lark-channel-bridge start` again. Once you see `✓ Connected`, find the bot in Feishu / Lark and start chatting.
 
+### Bridging Codex instead of Claude
+
+Run two bots side-by-side (one per agent) with separate data dirs and separate Lark apps:
+
+```bash
+# original Claude bot — ~/.lark-channel/, agent=claude
+lark-channel-bridge start            # or: start --claude
+
+# second bot wired to Codex — ~/.lark-codex/, agent=codex
+lark-channel-bridge start --codex
+```
+
+`--codex` auto-uses `~/.lark-codex/config.json`, fires the QR-code wizard on first run so you can bind a **second** PersonalAgent app, and persists `preferences.agent = "codex"` into that config. Both processes use the same `processes.json` mechanism, so `lark-channel-bridge ps` lists them both. Sessions, workspaces, logs, and media cache stay fully isolated between the two data dirs.
+
+For a fully custom location, `-c <path>` still works: the data dir is `dirname(path)`. You can combine `-c` with `--codex` if you want a non-default codex install (`-c` wins on path, `--codex` still writes the agent preference).
+
+> Codex 0.128 does not emit incremental text tokens on `exec --json`, so the card content updates once per turn rather than typewriter-style. Tool-call panels (`command_execution` / `file_change`) still render incrementally.
+
 ## Commands
 
 ### Host CLI
 
 ```
-lark-channel-bridge start [-c <config>]   Start the bot
-lark-channel-bridge ps                    List all running start processes on this machine
-lark-channel-bridge stop <id|#>           Stop a start process (SIGTERM, SIGKILL after 2s)
-lark-channel-bridge --help                List all commands
+lark-channel-bridge start [-c <config>] [--claude|--codex]   Start the bot
+lark-channel-bridge ps                                       List all running start processes on this machine
+lark-channel-bridge stop <id|#>                              Stop a start process (SIGTERM, SIGKILL after 2s)
+lark-channel-bridge --help                                   List all commands
 ```
 
 > When the same app is started multiple times, Lark's open platform routes events to one of the live WebSocket connections at random. `start` detects existing processes for the same app and (in a TTY) prompts: `[c]ontinue / [k]ill old / [a]bort`. In non-TTY mode it warns and continues.

--- a/README.zh.md
+++ b/README.zh.md
@@ -17,7 +17,9 @@
 ## 前置条件
 
 - Node.js **≥ 20**
-- `claude` CLI 已安装并登录：https://docs.anthropic.com/en/docs/claude-code/quickstart
+- 任选其一的 coding-agent CLI，已安装并登录：
+  - `claude`（Claude Code）：https://docs.anthropic.com/en/docs/claude-code/quickstart  *（默认）*
+  - `codex`（OpenAI Codex CLI）：`codex login` 完成认证
 - 一个飞书 / Lark PersonalAgent 应用（首次启动的扫码向导能帮你创建）
 
 ## 安装
@@ -58,15 +60,33 @@ lark-channel-bridge start
 
 启用以后再次 `lark-channel-bridge start`，看到 `✓ 已连接` 就可以在飞书里找 bot 对话了。
 
+### 同时跑 Claude 和 Codex 两个 bot
+
+每个 agent 用独立的数据目录和独立的飞书 app 同机并行：
+
+```bash
+# 原 Claude bot — ~/.lark-channel/，agent=claude
+lark-channel-bridge start            # 或：start --claude
+
+# 新加一个 Codex bot — ~/.lark-codex/，agent=codex
+lark-channel-bridge start --codex
+```
+
+`--codex` 自动指向 `~/.lark-codex/config.json`，首次跑触发扫码向导让你绑定**第二个** PersonalAgent 应用，并把 `preferences.agent = "codex"` 写进那份 config。两个进程共用 `processes.json` 注册机制，`lark-channel-bridge ps` 都能看到。两个数据目录里的 sessions / workspaces / logs / media 互不干扰。
+
+需要更自定义的位置时 `-c <path>` 依然可用：数据目录就是 `dirname(path)`。`-c` 和 `--codex` 可以叠加——`-c` 决定路径，`--codex` 负责写 agent 偏好。
+
+> Codex 0.128 的 `exec --json` 不输出文本 delta，所以卡片内容是整段一次性出现，不是打字机式增量；不过工具调用（`command_execution` / `file_change`）依然有 started/completed 双事件，panel 会实时更新。
+
 ## 命令速查
 
 ### 宿主 CLI
 
 ```
-lark-channel-bridge start [-c <config>]   启动 bot
-lark-channel-bridge ps                    列出本机所有正在跑的 start 进程
-lark-channel-bridge stop <id|#>           终止指定 start 进程（SIGTERM，2s 后 SIGKILL）
-lark-channel-bridge --help                列所有命令
+lark-channel-bridge start [-c <config>] [--claude|--codex]   启动 bot
+lark-channel-bridge ps                                       列出本机所有正在跑的 start 进程
+lark-channel-bridge stop <id|#>                              终止指定 start 进程（SIGTERM，2s 后 SIGKILL）
+lark-channel-bridge --help                                   列所有命令
 ```
 
 > 多开同一个 app 时，开放平台会把事件随机推到其中一个长连接。`start` 启动前会检测同 app 已有的进程，TTY 下提示 `[c]ontinue / [k]ill old / [a]bort` 三选；非 TTY 只 warn 并继续。

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@types/node": "^22.10.0",
     "@types/qrcode-terminal": "^0.12.2",
     "tsup": "^8.3.5",
+    "tsx": "^4.22.0",
     "typescript": "^5.6.3",
     "vitest": "^2.1.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,10 @@ importers:
         version: 0.12.2
       tsup:
         specifier: ^8.3.5
-        version: 8.5.1(postcss@8.5.10)(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.10)(tsx@4.22.0)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.22.0
+        version: 4.22.0
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -51,6 +54,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -59,6 +68,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -75,6 +90,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -83,6 +104,12 @@ packages:
 
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -99,6 +126,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
@@ -107,6 +140,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -123,6 +162,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
@@ -131,6 +176,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -147,6 +198,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
@@ -155,6 +212,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -171,6 +234,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
@@ -179,6 +248,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -195,6 +270,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
@@ -203,6 +284,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -219,6 +306,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -227,6 +320,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -243,8 +342,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -261,8 +372,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -279,8 +402,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -297,6 +432,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
@@ -305,6 +446,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -321,6 +468,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -329,6 +482,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -413,66 +572,79 @@ packages:
     resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.2':
     resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.2':
     resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.2':
     resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.2':
     resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.2':
     resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.2':
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.2':
     resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.2':
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.2':
     resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.2':
     resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.2':
     resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.2':
     resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.2':
     resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
@@ -660,6 +832,11 @@ packages:
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -965,6 +1142,11 @@ packages:
       typescript:
         optional: true
 
+  tsx@4.22.0:
+    resolution: {integrity: sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -1062,10 +1244,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
@@ -1074,10 +1262,16 @@ snapshots:
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
@@ -1086,10 +1280,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
@@ -1098,10 +1298,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
@@ -1110,10 +1316,16 @@ snapshots:
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
@@ -1122,10 +1334,16 @@ snapshots:
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
@@ -1134,10 +1352,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
@@ -1146,10 +1370,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
@@ -1158,7 +1388,13 @@ snapshots:
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -1167,7 +1403,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -1176,7 +1418,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
@@ -1185,10 +1433,16 @@ snapshots:
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.21.5':
@@ -1197,10 +1451,16 @@ snapshots:
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -1524,6 +1784,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -1661,11 +1950,12 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(postcss@8.5.10):
+  postcss-load-config@6.0.1(postcss@8.5.10)(tsx@4.22.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       postcss: 8.5.10
+      tsx: 4.22.0
 
   postcss@8.5.10:
     dependencies:
@@ -1806,7 +2096,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(postcss@8.5.10)(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.10)(tsx@4.22.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -1817,7 +2107,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.10)
+      postcss-load-config: 6.0.1(postcss@8.5.10)(tsx@4.22.0)
       resolve-from: 5.0.0
       rollup: 4.60.2
       source-map: 0.7.6
@@ -1833,6 +2123,12 @@ snapshots:
       - supports-color
       - tsx
       - yaml
+
+  tsx@4.22.0:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   typescript@5.9.3: {}
 

--- a/src/agent/codex/adapter.ts
+++ b/src/agent/codex/adapter.ts
@@ -1,0 +1,256 @@
+import type { ChildProcessByStdio } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import type { Readable } from 'node:stream';
+import { log } from '../../core/logger';
+import type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from '../types';
+import { createCodexTranslator } from './stream-json';
+
+export interface CodexAdapterOptions {
+  binary?: string;
+  /** Default 'danger-full-access' to mirror Claude bridge's bypassPermissions
+   *  experience. Override per-install via CodexAdapter options when wiring
+   *  up the agent factory. */
+  sandbox?: 'read-only' | 'workspace-write' | 'danger-full-access';
+}
+
+type CodexChild = ChildProcessByStdio<null, Readable, Readable>;
+
+const BRIDGE_PROMPT_PREFIX = `# lark-channel-bridge 运行约定
+
+你正在 lark-channel-bridge 里跑：把飞书/Lark 用户消息桥到本地 \`codex\` CLI。
+
+## bridge_context
+
+每条 user message 顶部会带一个 \`<bridge_context>\` 块：
+
+\`\`\`
+<bridge_context>
+chat_id: oc_xxx
+chat_type: p2p
+sender_id: ou_xxx
+sender_name: ...
+</bridge_context>
+\`\`\`
+
+里面是当前对话的 chat_id、chat 类型（p2p / group）、发送者。这些是 bridge 注入的元数据，**不要照抄、不要在你的回复里渲染**——它对用户不可见。
+
+## quoted_message
+
+如果用户用"引用回复"指向某条消息，bridge 会在 \`<bridge_context>\` 后注入一个 \`<quoted_message>\` 块：
+
+\`\`\`
+<quoted_message id="om_xxx" sender_id="ou_xxx" sender_name="..." created_at="..." type="text|merge_forward|...">
+（被引用消息的内容；merge_forward 类型会展开成 <forwarded_messages>...</forwarded_messages>）
+</quoted_message>
+\`\`\`
+
+这是用户**指向的对象**——用户的实际问题在它之后。回答时围绕这段内容展开；它也是 bridge 注入的元数据，**不要照抄 XML 标签**到回复里。
+
+## 发交互卡片（按钮、表单）的回调约定
+
+你想发一张可交互的卡片让用户点选时：
+
+1. 用 \`lark-cli\` 把卡发到 \`bridge_context.chat_id\`：
+   \`lark-cli im send-card --chat-id <chat_id> --card '<json>'\`
+2. 卡片用 CardKit 2.0 schema（\`schema: "2.0"\`）。
+3. **如果你希望用户点按钮后回调到你（让你在同一会话里继续处理）**：
+   - 按钮的 \`value\` 对象**必须**包含 \`__codex_cb: true\`
+   - 同时可以塞任意其它字段，作为你需要在回调时记住的状态（比如 \`{"__codex_cb": true, "choice": "a", "ticket_id": "T-123"}\`）
+4. 用户点击后，bridge 会把 payload（去掉 \`__codex_cb\` marker）作为 \`[card-click] {...}\` 消息发回给你；你的 session 自动续上，能看到自己上轮发了什么卡。
+5. **如果只是展示卡（不需要回调）**，不要加 \`__codex_cb\`，否则点击就会触发额外的会话轮次。
+
+示例 button：
+\`\`\`json
+{
+  "tag": "button",
+  "text": { "tag": "plain_text", "content": "方案 A" },
+  "behaviors": [{
+    "type": "callback",
+    "value": { "__codex_cb": true, "choice": "a" }
+  }]
+}
+\`\`\`
+
+---
+
+以下是用户的真实输入：
+
+`;
+
+export class CodexAdapter implements AgentAdapter {
+  readonly id = 'codex';
+  readonly displayName = 'Codex CLI';
+
+  private readonly binary: string;
+  private readonly sandbox: 'read-only' | 'workspace-write' | 'danger-full-access';
+
+  constructor(opts: CodexAdapterOptions = {}) {
+    this.binary = opts.binary ?? 'codex';
+    this.sandbox = opts.sandbox ?? 'danger-full-access';
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return new Promise((resolve) => {
+      const child = spawn(this.binary, ['--version'], { stdio: 'ignore' });
+      child.on('error', () => resolve(false));
+      child.on('exit', (code) => resolve(code === 0));
+    });
+  }
+
+  run(opts: AgentRunOptions): AgentRun {
+    const promptWithPrefix = `${BRIDGE_PROMPT_PREFIX}${opts.prompt}`;
+
+    // Codex argv differs significantly between fresh and resume:
+    //   fresh:   codex exec --json --skip-git-repo-check -s <sandbox> -C <cwd> [-m <model>] <prompt>
+    //   resume:  codex exec resume --json --skip-git-repo-check
+    //              --dangerously-bypass-approvals-and-sandbox [-m <model>] <sid> <prompt>
+    // The resume subcommand has no `-s` / `-C` flag — it inherits the cwd from
+    // the stored session and uses --dangerously-bypass-approvals-and-sandbox to
+    // achieve the same "no prompts, full access" behavior. We pre-check at the
+    // bridge layer that the stored session's cwd matches opts.cwd, so this is
+    // safe.
+    let args: string[];
+    if (opts.sessionId) {
+      args = [
+        'exec',
+        'resume',
+        '--json',
+        '--skip-git-repo-check',
+      ];
+      if (this.sandbox === 'danger-full-access') {
+        args.push('--dangerously-bypass-approvals-and-sandbox');
+      } else {
+        // resume doesn't take -s; the closest we can do is pass via -c.
+        args.push('-c', `sandbox_mode="${this.sandbox}"`);
+      }
+      if (opts.model) args.push('-m', opts.model);
+      args.push(opts.sessionId, promptWithPrefix);
+    } else {
+      args = [
+        'exec',
+        '--json',
+        '--skip-git-repo-check',
+        '-s',
+        this.sandbox,
+        '-C',
+        opts.cwd ?? process.cwd(),
+      ];
+      if (this.sandbox === 'danger-full-access') {
+        args.push('--dangerously-bypass-approvals-and-sandbox');
+      }
+      if (opts.model) args.push('-m', opts.model);
+      args.push(promptWithPrefix);
+    }
+
+    const child = spawn(this.binary, args, {
+      cwd: opts.cwd,
+      env: { ...process.env, LARK_CHANNEL: '1' },
+      // ignore stdin: codex exec otherwise prints "Reading additional input
+      // from stdin..." and waits indefinitely when invoked from a TTY context.
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    log.info('agent', 'spawn', {
+      pid: child.pid ?? null,
+      cwd: opts.cwd ?? process.cwd(),
+      hasSession: Boolean(opts.sessionId),
+      promptChars: opts.prompt.length,
+      model: opts.model,
+      sandbox: this.sandbox,
+    });
+
+    // See ClaudeAdapter for why these listeners must attach synchronously here.
+    const stderrChunks: Buffer[] = [];
+    let stderrBuffer = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+      stderrBuffer += chunk.toString('utf8');
+      let nl = stderrBuffer.indexOf('\n');
+      while (nl !== -1) {
+        const line = stderrBuffer.slice(0, nl);
+        stderrBuffer = stderrBuffer.slice(nl + 1);
+        if (line.trim()) log.warn('agent', 'stderr', { line });
+        nl = stderrBuffer.indexOf('\n');
+      }
+    });
+
+    let runtimeError: Error | null = null;
+    child.on('error', (err) => {
+      runtimeError = err;
+    });
+    child.on('exit', (code, signal) => {
+      log.info('agent', 'exit', { pid: child.pid ?? null, code, signal });
+    });
+
+    return {
+      events: createEventStream(child, stderrChunks, () => runtimeError),
+      async stop() {
+        if (child.exitCode !== null || child.signalCode !== null) return;
+        child.kill('SIGTERM');
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            if (child.exitCode === null && child.signalCode === null) {
+              child.kill('SIGKILL');
+            }
+            resolve();
+          }, 500);
+          child.once('exit', () => {
+            clearTimeout(timer);
+            resolve();
+          });
+        });
+      },
+    };
+  }
+}
+
+async function* createEventStream(
+  child: CodexChild,
+  stderrChunks: Buffer[],
+  getError: () => Error | null,
+): AsyncGenerator<AgentEvent> {
+  if (!child.pid) {
+    const err = getError();
+    yield {
+      type: 'error',
+      message: err ? `failed to spawn codex: ${err.message}` : 'spawn returned no pid',
+    };
+    return;
+  }
+
+  const translator = createCodexTranslator();
+  const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  try {
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      yield* translator.translate(parsed);
+    }
+  } finally {
+    rl.close();
+  }
+
+  const exitCode = await new Promise<number | null>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve(child.exitCode);
+    } else {
+      child.once('exit', (code) => resolve(code));
+    }
+  });
+
+  const runtimeError = getError();
+  if (exitCode !== 0 && exitCode !== null) {
+    const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+    const detail = stderr ? `: ${stderr.slice(0, 500)}` : '';
+    yield { type: 'error', message: `codex exited with code ${exitCode}${detail}` };
+  } else if (runtimeError) {
+    yield { type: 'error', message: `codex runtime error: ${runtimeError.message}` };
+  }
+}

--- a/src/agent/codex/stream-json.ts
+++ b/src/agent/codex/stream-json.ts
@@ -1,0 +1,179 @@
+import type { AgentEvent } from '../types';
+
+// Codex CLI emits one JSON object per line via `codex exec --json`. The
+// event surface is small and stable as of codex-cli 0.128:
+//
+//   thread.started   { thread_id }
+//   turn.started     {}
+//   item.started     { item: { id, type, status, ... } }
+//   item.completed   { item: { id, type, status, ... } }
+//   turn.completed   { usage: { input_tokens, cached_input_tokens,
+//                               output_tokens, reasoning_output_tokens } }
+//   turn.failed      { error?: { message } }              (inferred; not sampled)
+//
+// Unlike Claude, codex does NOT emit incremental text deltas — `agent_message`
+// arrives whole on `item.completed`. We surface it as a single `text` event
+// so the card renderer just appends it once.
+//
+// Item types observed:
+//   agent_message       { text }
+//   command_execution   { command, aggregated_output, exit_code, status }
+//   file_change         { changes: [{path, kind}], status }
+//   reasoning           (not emitted by exec --json on the wire as of 0.128;
+//                       only reflected in usage.reasoning_output_tokens)
+//
+// Unknown item types are silently ignored — better to lose detail than crash
+// when codex adds a new type.
+
+interface CodexItemBase {
+  id?: string;
+  type?: string;
+  status?: string;
+}
+
+interface CodexAgentMessageItem extends CodexItemBase {
+  type: 'agent_message';
+  text?: string;
+}
+
+interface CodexCommandExecutionItem extends CodexItemBase {
+  type: 'command_execution';
+  command?: string;
+  aggregated_output?: string;
+  exit_code?: number | null;
+}
+
+interface CodexFileChangeItem extends CodexItemBase {
+  type: 'file_change';
+  changes?: Array<{ path?: string; kind?: string }>;
+}
+
+type CodexItem =
+  | CodexAgentMessageItem
+  | CodexCommandExecutionItem
+  | CodexFileChangeItem
+  | CodexItemBase;
+
+interface CodexUsage {
+  input_tokens?: number;
+  cached_input_tokens?: number;
+  output_tokens?: number;
+  reasoning_output_tokens?: number;
+}
+
+interface CodexRawEvent {
+  type?: string;
+  thread_id?: string;
+  item?: CodexItem;
+  usage?: CodexUsage;
+  error?: { message?: string };
+}
+
+export interface CodexTranslatorState {
+  /** Last thread_id observed on this stream — emitted again on 'done'. */
+  threadId?: string;
+}
+
+export function createCodexTranslator() {
+  const state: CodexTranslatorState = {};
+  return {
+    *translate(raw: unknown): Generator<AgentEvent> {
+      yield* translateEvent(raw, state);
+    },
+  };
+}
+
+function* translateEvent(raw: unknown, state: CodexTranslatorState): Generator<AgentEvent> {
+  if (!raw || typeof raw !== 'object') return;
+  const evt = raw as CodexRawEvent;
+
+  switch (evt.type) {
+    case 'thread.started': {
+      if (typeof evt.thread_id === 'string') {
+        state.threadId = evt.thread_id;
+        yield { type: 'system', sessionId: evt.thread_id };
+      }
+      return;
+    }
+
+    case 'turn.started':
+      return;
+
+    case 'item.started': {
+      const item = evt.item;
+      if (!item || typeof item.id !== 'string') return;
+      if (item.type === 'command_execution') {
+        const ci = item as CodexCommandExecutionItem;
+        yield {
+          type: 'tool_use',
+          id: item.id,
+          name: 'shell',
+          input: { command: ci.command ?? '' },
+        };
+      } else if (item.type === 'file_change') {
+        const fc = item as CodexFileChangeItem;
+        yield {
+          type: 'tool_use',
+          id: item.id,
+          name: 'edit',
+          input: { changes: fc.changes ?? [] },
+        };
+      }
+      // agent_message has no useful payload on item.started; ignore.
+      return;
+    }
+
+    case 'item.completed': {
+      const item = evt.item;
+      if (!item) return;
+      if (item.type === 'agent_message') {
+        const am = item as CodexAgentMessageItem;
+        if (typeof am.text === 'string' && am.text) {
+          yield { type: 'text', delta: am.text };
+        }
+      } else if (item.type === 'command_execution' && typeof item.id === 'string') {
+        const ci = item as CodexCommandExecutionItem;
+        yield {
+          type: 'tool_result',
+          id: item.id,
+          output: ci.aggregated_output ?? '',
+          isError: typeof ci.exit_code === 'number' && ci.exit_code !== 0,
+        };
+      } else if (item.type === 'file_change' && typeof item.id === 'string') {
+        const fc = item as CodexFileChangeItem;
+        yield {
+          type: 'tool_result',
+          id: item.id,
+          output: summarizeFileChanges(fc.changes),
+          isError: false,
+        };
+      }
+      return;
+    }
+
+    case 'turn.completed': {
+      if (evt.usage) {
+        yield {
+          type: 'usage',
+          inputTokens: evt.usage.input_tokens,
+          outputTokens: evt.usage.output_tokens,
+        };
+      }
+      yield { type: 'done', sessionId: state.threadId };
+      return;
+    }
+
+    case 'turn.failed': {
+      yield {
+        type: 'error',
+        message: evt.error?.message ?? 'codex turn failed',
+      };
+      return;
+    }
+  }
+}
+
+function summarizeFileChanges(changes: Array<{ path?: string; kind?: string }> | undefined): string {
+  if (!changes || changes.length === 0) return '(no changes)';
+  return changes.map((c) => `${c.kind ?? '?'} ${c.path ?? '?'}`).join('\n');
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,2 +1,17 @@
 export type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from './types';
 export { ClaudeAdapter } from './claude/adapter';
+export { CodexAdapter } from './codex/adapter';
+
+import type { AgentKind } from '../config/schema';
+import { ClaudeAdapter } from './claude/adapter';
+import { CodexAdapter } from './codex/adapter';
+import type { AgentAdapter } from './types';
+
+/**
+ * Construct the agent adapter selected by config. Centralized so callers
+ * don't grow long switch statements on agent kind.
+ */
+export function createAgent(kind: AgentKind): AgentAdapter {
+  if (kind === 'codex') return new CodexAdapter();
+  return new ClaudeAdapter();
+}

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -1,13 +1,16 @@
 import dns from 'node:dns';
+import { mkdir } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
 import { createInterface } from 'node:readline';
 import pkg from '../../../package.json';
-import { ClaudeAdapter } from '../../agent/claude/adapter';
+import { createAgent } from '../../agent';
 import { startChannel, type BridgeChannel } from '../../bot/channel';
 import { runRegistrationWizard } from '../../bot/wizard';
 import type { Controls } from '../../commands';
-import { paths } from '../../config/paths';
-import type { AppConfig } from '../../config/schema';
-import { isComplete } from '../../config/schema';
+import { configurePaths, paths } from '../../config/paths';
+import type { AgentKind, AppConfig } from '../../config/schema';
+import { getAgentKind, isComplete } from '../../config/schema';
 import { loadConfig, saveConfig } from '../../config/store';
 import { gcOldLogs, log } from '../../core/logger';
 import { gcMediaCache } from '../../media/cache';
@@ -44,10 +47,50 @@ const MEDIA_GC_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 export interface StartOptions {
   config?: string;
+  /** Shortcut to select agent + default data dir. Ignored if --config is also
+   *  passed; otherwise `--codex` → ~/.lark-codex/, `--claude` (or omitted) →
+   *  ~/.lark-channel/. Persisted to preferences.agent in the saved config so
+   *  subsequent runs without the flag pick up the same agent. */
+  agent?: AgentKind;
+}
+
+/**
+ * Resolve the config path + data dir from the start options.
+ *
+ * Precedence:
+ *   1. Explicit -c <path>  → data dir = dirname(path). agent flag still
+ *      applies (persists to preferences.agent) but does NOT change the path.
+ *   2. --codex             → ~/.lark-codex/config.json
+ *   3. --claude or nothing → ~/.lark-channel/config.json  (default)
+ */
+function resolveDataLocation(opts: StartOptions): {
+  configPath: string;
+  customized: boolean;
+} {
+  if (opts.config) {
+    return { configPath: resolve(opts.config), customized: true };
+  }
+  if (opts.agent === 'codex') {
+    return {
+      configPath: join(homedir(), '.lark-codex', 'config.json'),
+      customized: true,
+    };
+  }
+  return { configPath: paths.configFile, customized: false };
 }
 
 export async function runStart(opts: StartOptions): Promise<void> {
-  const configPath = opts.config ?? paths.configFile;
+  // The data dir for this process is the directory containing the config
+  // file. All sessions / workspaces / logs / media / processes.json land
+  // there, so multiple `start` instances (one per agent / bot) stay fully
+  // isolated. --codex picks ~/.lark-codex by default; --claude (or no flag)
+  // picks ~/.lark-channel.
+  const { configPath, customized } = resolveDataLocation(opts);
+  if (customized) {
+    configurePaths(dirname(configPath));
+  }
+  await mkdir(paths.appDir, { recursive: true });
+
   const existing = await loadConfig(configPath);
 
   let cfg: AppConfig;
@@ -60,10 +103,40 @@ export async function runStart(opts: StartOptions): Promise<void> {
     printScopeReminder();
   }
 
-  const agent = new ClaudeAdapter();
+  // Persist agent shortcut into preferences so subsequent runs from this
+  // same data dir don't need the flag again. Also bail clearly if the user
+  // asks for an agent that doesn't match the on-disk preference — we don't
+  // silently flip it, because preferences.agent on disk is the source of
+  // truth for `/status` etc., and a mismatch usually means the user pointed
+  // the shortcut at the wrong data dir.
+  if (opts.agent) {
+    const onDisk = cfg.preferences?.agent;
+    if (onDisk && onDisk !== opts.agent) {
+      console.error(
+        `✗ ${configPath} 里 preferences.agent 是 "${onDisk}"，但你用了 --${opts.agent}。`,
+      );
+      console.error(`  改 config 或换 --${onDisk} 启动。`);
+      process.exit(1);
+    }
+    if (onDisk !== opts.agent) {
+      cfg = {
+        ...cfg,
+        preferences: { ...(cfg.preferences ?? {}), agent: opts.agent },
+      };
+      await saveConfig(cfg, configPath);
+      console.log(`已写入 preferences.agent = "${opts.agent}"\n`);
+    }
+  }
+
+  const agentKind = getAgentKind(cfg);
+  const agent = createAgent(agentKind);
   if (!(await agent.isAvailable())) {
-    console.error('✗ 未找到 claude CLI。请先安装 Claude Code：');
-    console.error('  https://docs.anthropic.com/en/docs/claude-code/quickstart');
+    if (agentKind === 'codex') {
+      console.error('✗ 未找到 codex CLI。请先安装 OpenAI Codex CLI 并 `codex login`。');
+    } else {
+      console.error('✗ 未找到 claude CLI。请先安装 Claude Code：');
+      console.error('  https://docs.anthropic.com/en/docs/claude-code/quickstart');
+    }
     process.exit(1);
   }
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,9 +15,18 @@ program
   .command('start')
   .description('Start the bot (runs first-run wizard if bot config is missing)')
   .option('-c, --config <path>', 'path to config file')
-  .action(async (opts: { config?: string }) => {
-    await runStart(opts);
-  });
+  .option('--claude', 'shortcut: use ~/.lark-channel/ data dir + agent=claude (default)')
+  .option('--codex', 'shortcut: use ~/.lark-codex/ data dir + agent=codex')
+  .action(
+    async (opts: { config?: string; claude?: boolean; codex?: boolean }) => {
+      if (opts.claude && opts.codex) {
+        console.error('✗ --claude 和 --codex 不能同时指定');
+        process.exit(1);
+      }
+      const agent = opts.codex ? 'codex' : opts.claude ? 'claude' : undefined;
+      await runStart({ config: opts.config, agent });
+    },
+  );
 
 program
   .command('migrate')

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,17 +1,51 @@
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
-const appDir = join(homedir(), '.lark-channel');
+// All paths derive from a single mutable `appDir`. Callers reach paths via
+// the `paths` object's getters, so the derived values reflect whatever the
+// current `appDir` is at access time.
+//
+// Default: `~/.lark-channel`. To run multiple bridge processes side-by-side
+// (e.g. one bot per coding agent), each `start` invocation calls
+// `configurePaths(<per-config-dir>)` early in boot, before any store / log
+// / registry call. After that, all paths.* lookups in the process resolve
+// under that directory — sessions, workspaces, logs, media cache, and the
+// process-registry file are then per-app, with no cross-talk.
+
+let appDir = join(homedir(), '.lark-channel');
 
 export const paths = {
-  appDir,
-  cacheDir: appDir,
-  configFile: join(appDir, 'config.json'),
-  sessionsFile: join(appDir, 'sessions.json'),
-  workspacesFile: join(appDir, 'workspaces.json'),
-  processesFile: join(appDir, 'processes.json'),
-  mediaDir: join(appDir, 'media'),
+  get appDir(): string {
+    return appDir;
+  },
+  get cacheDir(): string {
+    return appDir;
+  },
+  get configFile(): string {
+    return join(appDir, 'config.json');
+  },
+  get sessionsFile(): string {
+    return join(appDir, 'sessions.json');
+  },
+  get workspacesFile(): string {
+    return join(appDir, 'workspaces.json');
+  },
+  get processesFile(): string {
+    return join(appDir, 'processes.json');
+  },
+  get mediaDir(): string {
+    return join(appDir, 'media');
+  },
 };
+
+/**
+ * Override the runtime appDir. Call this exactly once during boot, before
+ * any store / logger / registry access. Subsequent `paths.*` reads return
+ * paths under `dir`.
+ */
+export function configurePaths(dir: string): void {
+  appDir = dir;
+}
 
 /**
  * Pre-0.1.11 paths (XDG-style). Kept here only so the `migrate` command

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -17,9 +17,26 @@ export interface AppCredentials {
  */
 export type MessageReplyMode = 'card' | 'markdown' | 'text';
 
+/**
+ * Which local agent CLI to bridge to. Default `'claude'`.
+ *
+ * - `'claude'`: spawns `claude -p ... --output-format stream-json ...` (the
+ *   original behavior; requires Claude Code installed and logged in).
+ * - `'codex'`: spawns `codex exec --json ...` (requires `codex` CLI installed
+ *   and authenticated). Text-streaming delta is unavailable on codex 0.128 —
+ *   replies arrive whole on `item.completed`. Tool-call panels (command
+ *   execution / file edits) still render incrementally.
+ *
+ * Switching agents resets per-chat session ids (the two CLIs have separate
+ * session stores). Workspaces and cwd bindings stay.
+ */
+export type AgentKind = 'claude' | 'codex';
+
 export interface AppPreferences {
   /** Reply rendering mode for IM (group/p2p) messages. Default 'card'. */
   messageReply?: MessageReplyMode;
+  /** Which agent CLI to bridge to. Default 'claude'. */
+  agent?: AgentKind;
   /**
    * Internal marker: pre-0.1.27 the value `'text'` meant "lightweight
    * streaming markdown card" (what's now called `'markdown'`). On upgrade
@@ -102,6 +119,11 @@ export function getMessageReplyMode(cfg: AppConfig): MessageReplyMode {
 /** Resolve the show-tool-calls preference with default fallback. */
 export function getShowToolCalls(cfg: AppConfig): boolean {
   return cfg.preferences?.showToolCalls !== false;
+}
+
+/** Resolve the active agent kind with default fallback. */
+export function getAgentKind(cfg: AppConfig): AgentKind {
+  return cfg.preferences?.agent === 'codex' ? 'codex' : 'claude';
 }
 
 /** Resolve the max-concurrent-runs preference with default + sanity clamp. */


### PR DESCRIPTION
## Summary

Adds OpenAI Codex CLI as a selectable coding agent alongside Claude Code, plus the plumbing to run multiple bridge instances (one per agent) side-by-side.

### Codex agent
- New `CodexAdapter` (`src/agent/codex/`) implementing the existing `AgentAdapter` interface against `codex exec --json`. Event translator maps codex JSONL → the bridge's `AgentEvent` union: `thread.started` → system, `item.completed(agent_message)` → text, `command_execution` / `file_change` → tool_use / tool_result, `turn.completed` → usage + done.
- Fresh vs `codex exec resume` argv split; `--dangerously-bypass-approvals-and-sandbox` to mirror Claude's `bypassPermissions` experience.
- `AgentKind` preference + `createAgent` factory — `preferences.agent` picks the adapter at start time; the `AgentAdapter` abstraction needed no change.

### Per-config data dir
- `paths.appDir` is now runtime-configurable via `configurePaths(dir)`. With `-c <path>`, the data root becomes `dirname(path)` — sessions / workspaces / logs / media / processes.json all land alongside the config, so multiple `start` instances stay fully isolated.

### Start shortcuts
- `start --codex` defaults to `~/.lark-codex/` and auto-persists `preferences.agent = "codex"` on first run. `--claude` (or no flag) keeps the original `~/.lark-channel/` default. Mutually exclusive; a flag that conflicts with the on-disk preference errors out.

### Docs
- README (EN + zh) gains a "Bridging Codex instead of Claude" section.

## Known limitation

codex 0.128 emits `agent_message` whole on `item.completed` (no streaming text delta), so card content updates once per turn rather than typewriter-style. Tool-call panels still render incrementally.

## Test

- `pnpm typecheck` + `pnpm build` clean.
- Local smoke (`scripts/smoke-codex.ts`, gitignored): fresh run / session resume / mid-flight stop all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)