### PR TITLE
fix: Windows compatibility for claude binary and /cd command

### DIFF
--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -69,6 +69,27 @@ sender_name: ...
 \`\`\`
 `;
 
+/**
+ * On Windows, npm-installed CLIs are `.cmd` wrappers that require `shell:true`
+ * to execute via Node's spawn. Using `shell:true` for the full agent run breaks
+ * argument passing (cmd.exe concatenates args, mangling long prompts and special
+ * characters). Instead we resolve the actual `.exe` that the wrapper calls.
+ *
+ * The Claude Code npm package always ships a native binary at:
+ *   <npm-global-prefix>\node_modules\@anthropic-ai\claude-code\bin\claude.exe
+ *
+ * The default npm global prefix on Windows is %APPDATA%\npm.
+ */
+function resolveDefaultBinary(): string {
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA;
+    if (appData) {
+      return `${appData}\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe`;
+    }
+  }
+  return 'claude';
+}
+
 export class ClaudeAdapter implements AgentAdapter {
   readonly id = 'claude';
   readonly displayName = 'Claude Code';
@@ -76,7 +97,7 @@ export class ClaudeAdapter implements AgentAdapter {
   private readonly binary: string;
 
   constructor(opts: ClaudeAdapterOptions = {}) {
-    this.binary = opts.binary ?? 'claude';
+    this.binary = opts.binary ?? resolveDefaultBinary();
   }
 
   async isAvailable(): Promise<boolean> {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1,5 +1,6 @@
 import { stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
+import { isAbsolute } from 'node:path';
 import type { LarkChannel, NormalizedMessage } from '@larksuiteoapi/node-sdk';
 import type { AgentAdapter } from '../agent/types';
 import type { ActiveRuns } from '../bot/active-runs';
@@ -210,7 +211,7 @@ async function handleCd(args: string, ctx: CommandContext): Promise<void> {
     await reply(ctx, '用法：`/cd <绝对路径>` 或 `/cd ~/xxx`');
     return;
   }
-  if (!input.startsWith('/') && !input.startsWith('~')) {
+  if (!isAbsolute(input) && !input.startsWith('~')) {
     await reply(ctx, '请使用绝对路径，或 `~/xxx` 表示 home 下的子路径。');
     return;
   }


### PR DESCRIPTION
  ## 问题

  在 Windows 上安装使用时遇到两个问题：

  ### 1. 找不到 claude CLI（`✗ 未找到 claude CLI`）

  Windows 上 npm 全局安装的 CLI 是 `.cmd` 包装脚本，Node.js 的 `spawn()` 无法直接执行 `.cmd` 文件（需要 `shell:true`）。但对完整的 agent 运行使用 `shell:true` 会导致 `cmd.exe` 将所有参数拼接成字符串，破坏长
  prompt 和含特殊字符的参数传递，导致 claude 子进程卡住无响应。

  **修复**：在 Windows 上直接解析 `claude.exe` 的真实路径（`%APPDATA%\npm\node_modules\@anthropic-ai\claude-code\bin\claude.exe`），绕过 `.cmd` 包装。

  ### 2. `/cd` 命令无法切换到 Windows 路径

  `/cd E:\Work` 始终返回"请使用绝对路径"，因为代码只检查 `/` 或 `~` 开头，不认识 Windows 的驱动器路径格式（`E:\`）。

  **修复**：将手动前缀检查替换为 `path.isAbsolute()`，该函数跨平台感知，能正确识别 Windows 绝对路径。

  ## 改动

  - `src/agent/claude/adapter.ts`：新增 `resolveDefaultBinary()` 函数，Windows 下返回 `claude.exe` 完整路径
  - `src/commands/index.ts`：`/cd` 使用 `isAbsolute()` 替代手动前缀检查

  ## 测试环境

  Windows 11 + Node.js v24 + Claude Code CLI（npm 全局安装）