### PR TITLE
fix: spawn claude CLI via cmd.exe on Windows

### DIFF
--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -10,6 +10,17 @@ export interface ClaudeAdapterOptions {
   binary?: string;
 }
 
+const IS_WIN = process.platform === 'win32';
+
+function winSpawn(
+  cmd: string,
+  args: readonly string[],
+  opts: Parameters<typeof spawn>[2],
+): ReturnType<typeof spawn> {
+  if (!IS_WIN) return spawn(cmd, args, opts);
+  return spawn('cmd.exe', ['/c', cmd, ...args], opts);
+}
+
 type ClaudeChild = ChildProcessByStdio<null, Readable, Readable>;
 
 const BRIDGE_SYSTEM_PROMPT = `# lark-channel-bridge 运行约定
@@ -96,7 +107,7 @@ export class ClaudeAdapter implements AgentAdapter {
 
   async isAvailable(): Promise<boolean> {
     return new Promise((resolve) => {
-      const child = spawn(this.binary, ['--version'], { stdio: 'ignore' });
+      const child = winSpawn(this.binary, ['--version'], { stdio: 'ignore' });
       child.on('error', () => resolve(false));
       child.on('exit', (code) => resolve(code === 0));
     });
@@ -117,7 +128,7 @@ export class ClaudeAdapter implements AgentAdapter {
     if (opts.sessionId) args.push('--resume', opts.sessionId);
     if (opts.model) args.push('--model', opts.model);
 
-    const child = spawn(this.binary, args, {
+    const child = winSpawn(this.binary, args, {
       cwd: opts.cwd,
       env: { ...process.env, LARK_CHANNEL: '1' },
       stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary

- On Windows, `spawn('claude', ...)` fails with ENOENT because the globally-installed Claude CLI is exposed as `claude.cmd`, and Node.js `spawn()` cannot execute `.cmd` files without a shell.
- Added a `winSpawn` helper that wraps the command through `cmd.exe /c` on Windows (noop on other platforms).
- This avoids both the ENOENT error ("未找到 claude CLI") and the `DEP0190` deprecation warning that `shell: true` triggers in Node 22+.

## Test plan

- [x] Verified on Windows 10 + Node 20: `lark-channel-bridge start` now detects and launches Claude CLI successfully
- [x] No deprecation warnings in output
- [ ] Non-Windows platforms unaffected (winSpawn falls through to plain `spawn`)