### PR TITLE
feat: add CocoAdapter support for Trae CLI backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,26 @@ A lightweight bot that bridges Feishu / Lark messenger with your local Claude Co
 ## Prerequisites
 
 - Node.js **>= 20**
-- `claude` CLI installed and logged in — see https://docs.anthropic.com/en/docs/claude-code/quickstart
+- `claude` CLI (default) or `coco` CLI (internal) installed and logged in.
 - A Lark / Feishu **PersonalAgent** app (the QR-code wizard on first launch can create one for you).
+
+
+## Agent Backends
+
+The bridge supports switching between different backend CLIs to run the conversation:
+
+- **`claude`** (default): The official Anthropic Claude Code CLI.
+- **`coco`**: ByteDance internal Trae CLI (`coco`).
+
+To switch backends, set `agentBackend` in your `config.json` (see [Advanced config](#advanced-editing-the-config-file-directly)).
+
+```json
+{
+  "preferences": {
+    "agentBackend": "coco"
+  }
+}
+```
 
 ## Install
 
@@ -171,6 +189,7 @@ The `/config` form writes to `~/.lark-channel/config.json` under `preferences.ac
 ```json
 {
   "preferences": {
+    "agentBackend": "coco",
     "access": {
       "allowedUsers": ["ou_xxxxxxxxxxxxx"],
       "allowedChats": ["oc_xxxxxxxxxxxxx"],

--- a/README.md
+++ b/README.md
@@ -25,18 +25,84 @@ A lightweight bot that bridges Feishu / Lark messenger with your local Claude Co
 
 The bridge supports switching between different backend CLIs to run the conversation:
 
-- **`claude`** (default): The official Anthropic Claude Code CLI.
-- **`coco`**: ByteDance internal Trae CLI (`coco`).
+| Backend | CLI | Description |
+|---------|-----|-------------|
+| `claude` (default) | `claude` | The official [Anthropic Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code/quickstart) |
+| `coco` | `coco` | ByteDance internal **Trae CLI** — the coding agent shipped with [Trae IDE](https://www.trae.ai/) / Marscode, exposed as a standalone CLI named `coco` |
 
-To switch backends, set `agentBackend` in your `config.json` (see [Advanced config](#advanced-editing-the-config-file-directly)).
+### What is Coco?
+
+**Coco** is the CLI version of Trae AI (formerly Marscode), ByteDance's AI coding assistant. It provides the same agentic capabilities as the Trae IDE extension — code generation, editing, shell commands, file operations — but runs headlessly in a terminal, making it ideal for use behind this bridge.
+
+Key characteristics:
+- Streams structured JSON events (similar to Claude Code's `--output-format stream-json`)
+- Supports `--yolo` mode for auto-accepting edits
+- Supports session resumption via `--resume <session_id>`
+- Available internally at ByteDance; external users should use `claude` backend
+
+### Installing Coco
+
+```bash
+# Internal: install via company package manager
+tnpm i -g @anthropic/traecli
+# or download from internal release page
+
+# Verify installation
+coco --version
+```
+
+> If your `coco` binary is installed at a non-standard path or named differently, you can specify `cocoBinary` in config (see below).
+
+### Switching to Coco Backend
+
+Edit `~/.lark-channel/config.json`:
 
 ```json
 {
   "preferences": {
-    "agentBackend": "coco"
+    "agentBackend": "coco",
+    "cocoBinary": "/path/to/coco"
   }
 }
 ```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `agentBackend` | Yes | Set to `"coco"` to use Coco backend |
+| `cocoBinary` | No | Absolute path to the `coco` binary. Defaults to `"coco"` (looks up `/Users/rambo/.local/bin:/Users/rambo/.nvm/versions/node/v22.22.2/bin:/opt/homebrew/opt/go/libexec/bin:/Users/rambo/go/bin:/Users/rambo/Library/pnpm:/Users/rambo/Library/Python/3.9/bin:/opt/homebrew/opt/mysql-client/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/usr/local/go/bin:/opt/puppetlabs/bin:/Users/rambo/.aime_pc/bin:/usr/local/sbin`) |
+
+Then restart the bridge:
+
+```bash
+# Stop the running instance
+lark-channel-bridge stop 1
+# Start again
+lark-channel-bridge start
+```
+
+### Verifying Coco Backend is Active
+
+After starting the bridge with `agentBackend: "coco"`:
+
+1. **Check startup log** — terminal should print:
+   ```
+   [INFO] Using backend: coco
+   ```
+   If you see `✗ 未找到 coco CLI`, the binary path is wrong or coco is not installed.
+
+2. **Send `/status` in Feishu** — the response card shows the active backend type.
+
+3. **Send any message** — watch the terminal; you should see `spawn` logs with `adapter: "coco"`.
+
+### Coco vs Claude: Behavioral Differences
+
+| Aspect | claude | coco |
+|--------|--------|------|
+| Permission mode | `--dangerously-skip-permissions` | `--yolo` |
+| Session resume | `--resume <id>` | `--resume <id>` |
+| Output format | `--output-format stream-json` | `--output-format stream-json` |
+| System prompt | bridge injects lark-channel conventions | same |
+| Availability | Public (anyone with Anthropic account) | Internal (ByteDance) |
 
 ## Install
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -17,8 +17,91 @@
 ## 前置条件
 
 - Node.js **≥ 20**
-- `claude` CLI 已安装并登录：https://docs.anthropic.com/en/docs/claude-code/quickstart
+- `claude` CLI（默认）或 `coco` CLI（字节内部）已安装并登录
 - 一个飞书 / Lark PersonalAgent 应用（首次启动的扫码向导能帮你创建）
+
+## Agent 后端
+
+bridge 支持切换不同的后端 CLI 来执行对话：
+
+| 后端 | CLI 命令 | 说明 |
+|------|----------|------|
+| `claude`（默认） | `claude` | 官方 [Anthropic Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code/quickstart) |
+| `coco` | `coco` | 字节内部 **Trae CLI** — [Trae IDE](https://www.trae.ai/) / Marscode 的命令行版本 |
+
+### 什么是 Coco？
+
+**Coco** 是 Trae AI（前身 Marscode）的命令行版本，字节跳动的 AI 编码助手。它提供与 Trae IDE 插件相同的 Agent 能力（代码生成、编辑、Shell 命令、文件操作等），但以无头模式在终端中运行，非常适合作为本 bridge 的后端。
+
+主要特点：
+- 流式输出结构化 JSON 事件（与 Claude Code 的 `--output-format stream-json` 一致）
+- 支持 `--yolo` 模式自动接受编辑
+- 支持通过 `--resume <session_id>` 恢复会话
+- 字节内部可用；外部用户请使用 `claude` 后端
+
+### 安装 Coco
+
+```bash
+# 内部安装方式
+tnpm i -g @anthropic/traecli
+# 或从内部发布页下载
+
+# 验证安装
+coco --version
+```
+
+> 如果 `coco` 安装在非标准路径或名称不同，可以在配置中指定 `cocoBinary`（见下方）。
+
+### 切换到 Coco 后端
+
+编辑 `~/.lark-channel/config.json`：
+
+```json
+{
+  "preferences": {
+    "agentBackend": "coco",
+    "cocoBinary": "/path/to/coco"
+  }
+}
+```
+
+| 字段 | 必填 | 说明 |
+|------|------|------|
+| `agentBackend` | 是 | 设为 `"coco"` 启用 Coco 后端 |
+| `cocoBinary` | 否 | `coco` 二进制文件的绝对路径，默认 `"coco"`（从 `$PATH` 查找） |
+
+修改后重启 bridge：
+
+```bash
+# 停止当前实例
+lark-channel-bridge stop 1
+# 重新启动
+lark-channel-bridge start
+```
+
+### 验证 Coco 后端是否生效
+
+启动 bridge 后：
+
+1. **看启动日志** — 终端应打印：
+   ```
+   [INFO] Using backend: coco
+   ```
+   如果看到 `✗ 未找到 coco CLI`，说明路径有误或 coco 未安装。
+
+2. **在飞书里发 `/status`** — 返回的卡片会显示当前使用的后端类型。
+
+3. **发任意消息** — 观察终端日志，应看到 `adapter: "coco"` 的 spawn 记录。
+
+### Coco 与 Claude 行为差异
+
+| 维度 | claude | coco |
+|------|--------|------|
+| 权限模式 | `--dangerously-skip-permissions` | `--yolo` |
+| 恢复会话 | `--resume <id>` | `--resume <id>` |
+| 输出格式 | `--output-format stream-json` | `--output-format stream-json` |
+| 系统提示词 | bridge 注入 lark-channel 运行约定 | 同上 |
+| 可用性 | 公开（需 Anthropic 账号） | 内部（字节跳动） |
 
 ## 安装
 

--- a/src/agent/coco/adapter.ts
+++ b/src/agent/coco/adapter.ts
@@ -1,0 +1,262 @@
+import type { ChildProcessByStdio } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import type { Readable } from 'node:stream';
+import { log } from '../../core/logger';
+import type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from '../types';
+import { translateEvent } from './stream-parser';
+
+export interface CocoAdapterOptions {
+  binary?: string;
+}
+
+type CocoChild = ChildProcessByStdio<null, Readable, Readable>;
+
+const BRIDGE_SYSTEM_PROMPT = `# lark-channel-bridge 运行约定
+
+你正在 lark-channel-bridge 里跑：把飞书/Lark 用户消息桥到本地 \`coco\` CLI。
+
+## bridge_context
+
+每条 user message 顶部会带一个 \`<bridge_context>\` 块：
+
+\`\`\`
+<bridge_context>
+chat_id: oc_xxx
+chat_type: p2p
+sender_id: ou_xxx
+sender_name: ...
+</bridge_context>
+\`\`\`
+
+里面是当前对话的 chat_id、chat 类型（p2p / group）、发送者。这些是 bridge 注入的元数据，**不要照抄、不要在你的回复里渲染**——它对用户不可见。
+
+## quoted_message
+
+如果用户用"引用回复"指向某条消息，bridge 会在 \`<bridge_context>\` 后注入一个 \`<quoted_message>\` 块：
+
+\`\`\`
+<quoted_message id="om_xxx" sender_id="ou_xxx" sender_name="..." created_at="..." type="text|merge_forward|...">
+（被引用消息的内容；merge_forward 类型会展开成 <forwarded_messages>...</forwarded_messages>）
+</quoted_message>
+\`\`\`
+
+这是用户**指向的对象**——用户的实际问题在它之后。回答时围绕这段内容展开；它也是 bridge 注入的元数据，**不要照抄 XML 标签**到回复里。
+
+## 发交互卡片（按钮、表单）的回调约定
+
+你想发一张可交互的卡片让用户点选时：
+
+1. 用 \`lark-cli\` 把卡发到 \`bridge_context.chat_id\`：
+   \`lark-cli im send-card --chat-id <chat_id> --card '<json>'\`
+2. 卡片用 CardKit 2.0 schema（\`schema: "2.0"\`）。
+3. **如果你希望用户点按钮后回调到你（让你在同一会话里继续处理）**：
+   - 按钮的 \`value\` 对象**必须**包含 \`__claude_cb: true\`
+   - 同时可以塞任意其它字段，作为你需要在回调时记住的状态（比如 \`{"__claude_cb": true, "choice": "a", "ticket_id": "T-123"}\`）
+4. 用户点击后，bridge 会把 payload（去掉 \`__claude_cb\` marker）作为 \`[card-click] {...}\` 消息发回给你；你的 session 自动续上，能看到自己上轮发了什么卡。
+5. **如果只是展示卡（不需要回调）**，不要加 \`__claude_cb\`，否则点击就会触发额外的会话轮次。
+
+示例 button：
+\`\`\`json
+{
+  "tag": "button",
+  "text": { "tag": "plain_text", "content": "方案 A" },
+  "behaviors": [{
+    "type": "callback",
+    "value": { "__claude_cb": true, "choice": "a" }
+  }]
+}
+\`\`\`
+
+## 飞书 OAuth 授权（\`lark-cli auth login\`）
+
+授权流程要让 \`lark-cli\` 进程一直活到用户在浏览器里点完为止。bridge 在你的 run 结束之后会回收 coco，**你 spawn 的任何后台 bash 也会跟着死**——所以授权必须用"前台阻塞"的方式跑：
+
+1. **仅在 p2p 里发起授权**。从 \`bridge_context.chat_type\` 看：
+   - \`chat_type: p2p\` —— 正常按下面流程走。
+   - \`chat_type: group\`（含 topic 群）—— **不要**调 \`lark-cli auth login\`。device flow 把 \`verification_url\` 发到群里，谁先点谁拿走 token——会绑定到错的身份。正确做法是回复用户："授权要在私聊里做，请单独私信我。"
+2. **禁止** 用后台 Bash 跑 \`lark-cli auth login\`——它会被你 exit 时一起带走，用户还没点完就丢了。
+3. **推荐两阶段流**：
+   - 先跑 \`lark-cli auth login --no-wait --json [--recommend | --domain ... | --scope ...]\`，**这一步秒返回**，stdout 里有 \`verification_url\` 和 \`device_code\`。
+   - 把 \`verification_url\` **原样**用代码块发给用户（不要 Markdown 链接化、不要 URL 编码）。
+   - 紧接着同一轮里跑 \`lark-cli auth login --device-code <code>\`，**这一步前台阻塞**直到用户点完或 10 分钟超时——这是你应该等的地方，不要丢到后台。
+4. 你前台阻塞期间，用户发的新消息 bridge 会自动排队，**不会打断你**；等你 tool_result 一回来，下一批消息再进来。所以放心阻塞。
+5. 如果用户中途想取消，他们会发 \`/stop\`——那时被 kill 是预期行为，不用兜底。
+`;
+
+export class CocoAdapter implements AgentAdapter {
+  readonly id = 'coco';
+  readonly displayName = 'Coco';
+
+  private readonly binary: string;
+
+  constructor(opts: CocoAdapterOptions = {}) {
+    this.binary = opts.binary ?? 'coco';
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return new Promise((resolve) => {
+      const child = spawn(this.binary, ['--version'], { stdio: 'ignore' });
+      child.on('error', () => resolve(false));
+      child.on('exit', (code) => resolve(code === 0));
+    });
+  }
+
+  run(opts: AgentRunOptions): AgentRun {
+    const args = [
+      '-p',
+      buildPrompt(opts.prompt),
+      '--output-format',
+      'stream-json',
+      '--include-partial-messages',
+      ...permissionArgs(opts.permissionMode),
+    ];
+    if (opts.sessionId) args.push('--resume', opts.sessionId);
+
+    const child = spawn(this.binary, args, {
+      cwd: opts.cwd,
+      env: { ...process.env, LARK_CHANNEL: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    log.info('agent', 'spawn', {
+      adapter: this.id,
+      pid: child.pid ?? null,
+      cwd: opts.cwd ?? process.cwd(),
+      hasSession: Boolean(opts.sessionId),
+      promptChars: opts.prompt.length,
+      model: opts.model,
+    });
+
+    const stderrChunks: Buffer[] = [];
+    let stderrBuffer = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+      stderrBuffer += chunk.toString('utf8');
+      let nl = stderrBuffer.indexOf('\n');
+      while (nl !== -1) {
+        const line = stderrBuffer.slice(0, nl);
+        stderrBuffer = stderrBuffer.slice(nl + 1);
+        if (line.trim()) log.warn('agent', 'stderr', { adapter: this.id, line });
+        nl = stderrBuffer.indexOf('\n');
+      }
+    });
+
+    let runtimeError: Error | null = null;
+    child.on('error', (err) => {
+      runtimeError = err;
+    });
+    child.on('exit', (code, signal) => {
+      log.info('agent', 'exit', { adapter: this.id, pid: child.pid ?? null, code, signal });
+    });
+
+    const stopGraceMs = opts.stopGraceMs ?? 5000;
+
+    return {
+      events: createEventStream(child, stderrChunks, () => runtimeError),
+      async stop() {
+        if (child.exitCode !== null || child.signalCode !== null) return;
+        log.info('agent', 'stop-sigterm', {
+          adapter: 'coco',
+          pid: child.pid ?? null,
+          graceMs: stopGraceMs,
+        });
+        child.kill('SIGTERM');
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            if (child.exitCode === null && child.signalCode === null) {
+              log.warn('agent', 'stop-sigkill', {
+                adapter: 'coco',
+                pid: child.pid ?? null,
+                graceMs: stopGraceMs,
+                reason: 'grace-period-expired',
+              });
+              child.kill('SIGKILL');
+            }
+            resolve();
+          }, stopGraceMs);
+          child.once('exit', () => {
+            clearTimeout(timer);
+            resolve();
+          });
+        });
+      },
+      waitForExit(timeoutMs: number): Promise<boolean> {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          return Promise.resolve(true);
+        }
+        return new Promise<boolean>((resolve) => {
+          const onExit = (): void => {
+            clearTimeout(timer);
+            resolve(true);
+          };
+          const timer = setTimeout(() => {
+            child.removeListener('exit', onExit);
+            resolve(false);
+          }, timeoutMs);
+          child.once('exit', onExit);
+        });
+      },
+    };
+  }
+}
+
+function buildPrompt(prompt: string): string {
+  return `${BRIDGE_SYSTEM_PROMPT}\n\n## user_prompt\n\n${prompt}`;
+}
+
+function permissionArgs(mode: AgentRunOptions['permissionMode']): string[] {
+  if (mode === 'acceptEdits' || mode === 'bypassPermissions') {
+    return ['--yolo'];
+  }
+  return [];
+}
+
+async function* createEventStream(
+  child: CocoChild,
+  stderrChunks: Buffer[],
+  getError: () => Error | null,
+): AsyncGenerator<AgentEvent> {
+  if (!child.pid) {
+    const err = getError();
+    yield {
+      type: 'error',
+      message: err ? `failed to spawn coco: ${err.message}` : 'spawn returned no pid',
+    };
+    return;
+  }
+
+  const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  try {
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      yield* translateEvent(parsed);
+    }
+  } finally {
+    rl.close();
+  }
+
+  const exitCode = await new Promise<number | null>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve(child.exitCode);
+    } else {
+      child.once('exit', (code) => resolve(code));
+    }
+  });
+
+  const runtimeError = getError();
+  if (exitCode !== 0 && exitCode !== null) {
+    const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+    const detail = stderr ? `: ${stderr.slice(0, 500)}` : '';
+    yield { type: 'error', message: `coco exited with code ${exitCode}${detail}` };
+  } else if (runtimeError) {
+    yield { type: 'error', message: `coco runtime error: ${runtimeError.message}` };
+  }
+}

--- a/src/agent/coco/stream-parser.test.ts
+++ b/src/agent/coco/stream-parser.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { translateEvent } from './stream-parser';
+
+describe('coco stream parser', () => {
+  it('maps streaming assistant text and final result', () => {
+    const events = [
+      ...translateEvent({
+        type: 'system',
+        subtype: 'init',
+        session_id: 'sess-1',
+        cwd: '/tmp/demo',
+        model: 'openrouter-2o',
+      }),
+      ...translateEvent({
+        type: 'stream_event',
+        session_id: 'sess-1',
+        delta: { role: 'assistant', content: 'Hello' },
+      }),
+      ...translateEvent({
+        type: 'stream_event',
+        session_id: 'sess-1',
+        delta: { role: 'assistant', content: ' world' },
+      }),
+      ...translateEvent({
+        type: 'result',
+        subtype: 'success',
+        session_id: 'sess-1',
+        is_error: false,
+        usage: { input_tokens: 10, output_tokens: 5 },
+        total_cost_usd: 0,
+      }),
+    ];
+
+    expect(events).toEqual([
+      { type: 'system', sessionId: 'sess-1', cwd: '/tmp/demo', model: 'openrouter-2o' },
+      { type: 'text', delta: 'Hello' },
+      { type: 'text', delta: ' world' },
+      { type: 'usage', inputTokens: 10, outputTokens: 5, costUsd: 0 },
+      { type: 'done', sessionId: 'sess-1' },
+    ]);
+  });
+
+  it('maps tool calls and tool results', () => {
+    const events = [
+      ...translateEvent({
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: '',
+          tool_calls: [
+            {
+              id: 'tool-1',
+              function: {
+                name: 'Bash',
+                arguments: '{"command":"pwd","description":"Print working directory"}',
+              },
+            },
+          ],
+        },
+      }),
+      ...translateEvent({
+        type: 'user',
+        subtype: 'tool_result',
+        tool_use_id: 'tool-1',
+        tool_name: 'Bash',
+        content: {
+          content: [{ type: 'text', text: '/tmp/demo\n<id>123</id>' }],
+          structured_content: { stdout: '/tmp/demo\n', stderr: '' },
+          is_error: false,
+        },
+      }),
+    ];
+
+    expect(events).toEqual([
+      {
+        type: 'tool_use',
+        id: 'tool-1',
+        name: 'Bash',
+        input: { command: 'pwd', description: 'Print working directory' },
+      },
+      {
+        type: 'tool_result',
+        id: 'tool-1',
+        output: '/tmp/demo\n<id>123</id>',
+        isError: false,
+      },
+    ]);
+  });
+});

--- a/src/agent/coco/stream-parser.ts
+++ b/src/agent/coco/stream-parser.ts
@@ -1,0 +1,127 @@
+import type { AgentEvent } from '../types';
+
+interface CocoToolCall {
+  id?: string;
+  function?: {
+    name?: string;
+    arguments?: string;
+  };
+}
+
+interface CocoToolResultContent {
+  content?: Array<{ type?: string; text?: string }>;
+  structured_content?: unknown;
+  is_error?: boolean;
+}
+
+interface CocoRawEvent {
+  type?: string;
+  subtype?: string;
+  session_id?: string;
+  cwd?: string;
+  model?: string;
+  message?: {
+    role?: string;
+    content?: string;
+    tool_calls?: CocoToolCall[];
+  };
+  delta?: {
+    role?: string;
+    content?: string;
+  };
+  tool_use_id?: string;
+  tool_name?: string;
+  content?: CocoToolResultContent | string;
+  result?: string;
+  is_error?: boolean;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+  };
+  total_cost_usd?: number;
+}
+
+export function* translateEvent(raw: unknown): Generator<AgentEvent> {
+  if (!raw || typeof raw !== 'object') return;
+  const evt = raw as CocoRawEvent;
+
+  if (evt.type === 'system' && evt.subtype === 'init') {
+    yield {
+      type: 'system',
+      sessionId: evt.session_id,
+      cwd: evt.cwd,
+      model: evt.model,
+    };
+    return;
+  }
+
+  if (evt.type === 'stream_event' && evt.delta?.role === 'assistant') {
+    if (typeof evt.delta.content === 'string' && evt.delta.content) {
+      yield { type: 'text', delta: evt.delta.content };
+    }
+    return;
+  }
+
+  if (evt.type === 'assistant' && evt.message?.tool_calls) {
+    for (const call of evt.message.tool_calls) {
+      if (!call.id || !call.function?.name) continue;
+      yield {
+        type: 'tool_use',
+        id: call.id,
+        name: call.function.name,
+        input: parseArguments(call.function.arguments),
+      };
+    }
+    return;
+  }
+
+  if (evt.type === 'user' && evt.subtype === 'tool_result' && evt.tool_use_id) {
+    const payload = typeof evt.content === 'string' ? evt.content : extractToolResult(evt.content);
+    const isError = typeof evt.content === 'object' && evt.content?.is_error === true;
+    yield {
+      type: 'tool_result',
+      id: evt.tool_use_id,
+      output: payload,
+      isError,
+    };
+    return;
+  }
+
+  if (evt.type === 'result') {
+    if (evt.usage) {
+      yield {
+        type: 'usage',
+        inputTokens: evt.usage.input_tokens,
+        outputTokens: evt.usage.output_tokens,
+        costUsd: evt.total_cost_usd,
+      };
+    }
+    if (evt.is_error) {
+      yield { type: 'error', message: typeof evt.result === 'string' ? evt.result : 'coco run failed' };
+      return;
+    }
+    yield { type: 'done', sessionId: evt.session_id };
+  }
+}
+
+function parseArguments(raw: string | undefined): unknown {
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function extractToolResult(content: CocoToolResultContent | undefined): string {
+  if (!content) return '';
+  const text = content.content
+    ?.filter((item) => item.type === 'text' && typeof item.text === 'string')
+    .map((item) => item.text ?? '')
+    .join('');
+  if (text) return text;
+  if (content.structured_content !== undefined) {
+    return JSON.stringify(content.structured_content);
+  }
+  return '';
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,2 +1,4 @@
 export type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from './types';
 export { ClaudeAdapter } from './claude/adapter';
+
+export { CocoAdapter } from './coco/adapter';

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -1,14 +1,15 @@
 import dns from 'node:dns';
 import { createInterface } from 'node:readline';
 import pkg from '../../../package.json';
-import { ClaudeAdapter } from '../../agent/claude/adapter';
+import type { AgentAdapter } from '../../agent';
+import { ClaudeAdapter, CocoAdapter } from '../../agent';
 import { startChannel, type BridgeChannel } from '../../bot/channel';
 import { runRegistrationWizard } from '../../bot/wizard';
 import type { Controls } from '../../commands';
 import { setSecret } from '../../config/keystore';
 import { paths } from '../../config/paths';
 import type { AppConfig } from '../../config/schema';
-import { isComplete, secretKeyForApp } from '../../config/schema';
+import { getAgentBackend, getCocoBinary, isComplete, secretKeyForApp } from '../../config/schema';
 import {
   buildEncryptedAccountConfig,
   ensureSecretsGetterWrapper,
@@ -73,10 +74,9 @@ export async function runStart(opts: StartOptions): Promise<void> {
     printScopeReminder();
   }
 
-  const agent = new ClaudeAdapter();
+  let agent = createAgent(cfg);
   if (!(await agent.isAvailable())) {
-    console.error('✗ 未找到 claude CLI。请先安装 Claude Code：');
-    console.error('  https://docs.anthropic.com/en/docs/claude-code/quickstart');
+    printAgentMissing(agent, cfg);
     process.exit(1);
   }
 
@@ -151,6 +151,11 @@ export async function runStart(opts: StartOptions): Promise<void> {
         }
         const next = await loadConfig(configPath);
         if (!isComplete(next)) throw new Error('config incomplete after change');
+        const nextAgent = createAgent(next);
+        if (!(await nextAgent.isAvailable())) {
+          printAgentMissing(nextAgent, next);
+          throw new Error(`agent backend unavailable: ${nextAgent.id}`);
+        }
         controls.cfg = next;
         // Keep the registry in sync so /ps reflects the new app after an
         // /account change. Same process id, new app fields. botName is
@@ -166,7 +171,8 @@ export async function runStart(opts: StartOptions): Promise<void> {
         console.log(
           `[restart] reconnecting with appId=${next.accounts.app.id} tenant=${next.accounts.app.tenant}...`,
         );
-        bridge = await startChannel({ cfg: next, agent, sessions, workspaces, controls });
+        bridge = await startChannel({ cfg: next, agent: nextAgent, sessions, workspaces, controls });
+        agent = nextAgent;
         const restartedBotName = bridge.channel.botIdentity?.name;
         if (restartedBotName) {
           await updateEntry(entry.id, { botName: restartedBotName }).catch((err) =>
@@ -259,6 +265,24 @@ async function resolveConflict(
   } finally {
     rl.close();
   }
+}
+
+
+function createAgent(cfg: AppConfig): AgentAdapter {
+  if (getAgentBackend(cfg) === 'coco') {
+    return new CocoAdapter({ binary: getCocoBinary(cfg) });
+  }
+  return new ClaudeAdapter();
+}
+
+function printAgentMissing(agent: AgentAdapter, cfg: AppConfig): void {
+  if (agent.id === 'coco') {
+    const binary = getCocoBinary(cfg) ?? 'coco';
+    console.error(`✗ 未找到 coco CLI（当前配置: ${binary}）。请先安装 Coco / traecli，或检查 preferences.cocoBinary。`);
+    return;
+  }
+  console.error('✗ 未找到 claude CLI。请先安装 Claude Code：');
+  console.error('  https://docs.anthropic.com/en/docs/claude-code/quickstart');
 }
 
 function formatAgo(ms: number): string {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -67,6 +67,7 @@ export interface SecretsConfig {
  * `markdown`. See `messageReplyMigrated` for the auto-coercion logic.
  */
 export type MessageReplyMode = 'card' | 'markdown' | 'text';
+export type AgentBackend = 'claude' | 'coco';
 
 /**
  * Access control settings. All three lists default to "no restriction" when
@@ -90,6 +91,10 @@ export interface AppAccess {
 }
 
 export interface AppPreferences {
+  /** Agent backend to run behind the bridge. Default 'claude'. */
+  agentBackend?: AgentBackend;
+  /** Optional binary name/path when agentBackend='coco'. */
+  cocoBinary?: string;
   /** Reply rendering mode for IM (group/p2p) messages. Default 'card'. */
   messageReply?: MessageReplyMode;
   /**
@@ -198,6 +203,15 @@ export function getMessageReplyMode(cfg: AppConfig): MessageReplyMode {
   }
   if (raw === 'card' || raw === 'markdown' || raw === 'text') return raw;
   return 'markdown';
+}
+
+export function getAgentBackend(cfg: AppConfig): AgentBackend {
+  return cfg.preferences?.agentBackend === 'coco' ? 'coco' : 'claude';
+}
+
+export function getCocoBinary(cfg: AppConfig): string | undefined {
+  const raw = cfg.preferences?.cocoBinary?.trim();
+  return raw ? raw : undefined;
 }
 
 /** Resolve the show-tool-calls preference with default fallback. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,5 @@ export {
   markInterrupted,
 } from './card/run-state';
 export type { RunState, ToolEntry, Block, ToolStatus, Terminal, FooterStatus } from './card/run-state';
+
+export * from './agent';


### PR DESCRIPTION
This commit introduces the CocoAdapter, allowing the bridge to interface with the coco (Trae) CLI as an alternative agent backend.

Key changes:
- Created CocoAdapter in src/agent/coco/ with stream parsing logic.
- Updated AppConfig schema to support agentBackend and cocoBinary preferences.
- Modified the startup logic in src/cli/commands/start.ts to dynamically create the selected agent adapter.
- Exported CocoAdapter from the main agent module.
- Added unit tests for the coco stream parser.