### PR TITLE
chore: drop unused printScopeReminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,23 +41,6 @@ The first run detects there's no app configured and **opens a QR-code wizard**:
 3. Pick or create a PersonalAgent app.
 4. Credentials are written to `~/.lark-channel/config.json`.
 
-### Granting scopes and event subscriptions
-
-The wizard creates the app shell, but you still need to confirm a few things on the Lark Developer Console:
-
-**Permission scopes:**
-- `im:message`
-- `im:message:send_as_bot`
-- `im:resource`
-
-**Event subscriptions (over long-lived WebSocket):**
-- `im.message.receive_v1`
-- `card.action.trigger`
-- `im.message.reaction.created_v1` / `deleted_v1` (optional)
-- `im.chat.member.bot.added_v1` (optional)
-
-After enabling those, run `lark-channel-bridge start` again. Once you see `✓ Connected`, find the bot in Feishu / Lark and start chatting.
-
 ## Commands
 
 ### Host CLI

--- a/README.zh.md
+++ b/README.zh.md
@@ -41,23 +41,6 @@ lark-channel-bridge start
 3. 选择 / 创建 PersonalAgent 应用
 4. 成功后凭据写入 `~/.lark-channel/config.json`
 
-### 开放平台补齐 scope 和事件订阅
-
-向导只负责创建应用，平台侧还需要手动确认：
-
-**权限 scope**：
-- `im:message`
-- `im:message:send_as_bot`
-- `im:resource`
-
-**事件订阅（使用长连接接收）**：
-- `im.message.receive_v1`
-- `card.action.trigger`
-- `im.message.reaction.created_v1` / `deleted_v1`（可选）
-- `im.chat.member.bot.added_v1`（可选）
-
-启用以后再次 `lark-channel-bridge start`，看到 `✓ 已连接` 就可以在飞书里找 bot 对话了。
-
 ## 命令速查
 
 ### 宿主 CLI

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -70,7 +70,6 @@ export async function runStart(opts: StartOptions): Promise<void> {
     // immediately encrypt before persisting so disk never holds the raw value.
     cfg = await persistEncrypted(fresh, configPath);
     console.log(`配置已保存到 ${configPath}\n`);
-    printScopeReminder();
   }
 
   const agent = new ClaudeAdapter();
@@ -366,18 +365,3 @@ async function persistEncrypted(cfg: AppConfig, configPath: string): Promise<App
   return next;
 }
 
-function printScopeReminder(): void {
-  console.log('请到开放平台为该应用确认以下能力：\n');
-  console.log('  权限 scope:');
-  console.log('    - im:message');
-  console.log('    - im:message:send_as_bot');
-  console.log('    - im:resource');
-  console.log('    - im:chat (创建群需要)');
-  console.log('    - drive:drive (读写云文档评论需要)\n');
-  console.log('  事件订阅（长连接模式）:');
-  console.log('    - im.message.receive_v1');
-  console.log('    - card.action.trigger');
-  console.log('    - drive.notice.comment_add_v1 (云文档 @bot 需要)');
-  console.log('    - im.message.reaction.created_v1 / deleted_v1（可选）');
-  console.log('    - im.chat.member.bot.added_v1（可选）\n');
-}


### PR DESCRIPTION
The function only fired on first-run wizard completion and duplicated the scope/event list already maintained in the README. Remove the function plus the now-redundant README section in both languages.