### PR TITLE
chore: drop unimplemented CLI stub commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,6 @@ lark-channel-bridge --help                List all commands
 
 > When the same app is started multiple times, Lark's open platform routes events to one of the live WebSocket connections at random. `start` detects existing processes for the same app and (in a TTY) prompts: `[c]ontinue / [k]ill old / [a]bort`. In non-TTY mode it warns and continues.
 
-`status` / `doctor` / `handover` / `workspace` / `service` are placeholders, planned for later releases.
-
 ### Slash commands inside Feishu / Lark
 
 | Command | Effect |

--- a/README.zh.md
+++ b/README.zh.md
@@ -54,8 +54,6 @@ lark-channel-bridge --help                列所有命令
 
 > 多开同一个 app 时，开放平台会把事件随机推到其中一个长连接。`start` 启动前会检测同 app 已有的进程，TTY 下提示 `[c]ontinue / [k]ill old / [a]bort` 三选；非 TTY 只 warn 并继续。
 
-其它命令（`status` / `doctor` / `handover` / `workspace` / `service`）是占位，后续版本补。
-
 ### 在飞书里用的斜杠命令
 
 | 命令 | 作用 |

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -85,41 +85,6 @@ secrets
     await runSecretsRemove(opts.appId);
   });
 
-program
-  .command('status')
-  .description('Show runtime status (WS connection, agent availability)')
-  .action(async () => {
-    console.log('status: not implemented yet');
-  });
-
-program
-  .command('doctor')
-  .description('Check config, claude CLI, and required platform scopes')
-  .action(async () => {
-    console.log('doctor: not implemented yet');
-  });
-
-program
-  .command('handover <text>')
-  .description('Hand over a terminal Claude Code session to Feishu')
-  .action(async (_text: string) => {
-    console.log('handover: not implemented yet');
-  });
-
-program
-  .command('workspace <action>')
-  .description('Manage saved workspaces: list | add | remove | default')
-  .action(async (_action: string) => {
-    console.log('workspace: not implemented yet');
-  });
-
-program
-  .command('service <action> <type>')
-  .description('Install or uninstall autostart service: launchd | systemd')
-  .action(async (_action: string, _type: string) => {
-    console.log('service: not implemented yet');
-  });
-
 program.parseAsync(process.argv).catch((err: unknown) => {
   console.error(err);
   process.exit(1);


### PR DESCRIPTION
`status`, `doctor`, `handover`, `workspace`, and `service` were demo-era placeholders that only printed "X: not implemented yet" and exited 0, misleading any automation that ran them. README's matching "planned for later releases" line is removed too.

`doctor` and `workspace` already exist as in-chat slash commands (`/doctor`, `/ws`), so the CLI shells weren't a roadmap either.