### PR TITLE
fix(keepalive): force reconnect on zombie WS where state stays `connected` but event stream dies

### DIFF
--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -26,6 +26,7 @@ import {
   getRequireMentionInGroup,
   getRunIdleTimeoutMs,
   getShowToolCalls,
+  getWsStaleEventReconnectMs,
   isChatAllowed,
   isUserAllowed,
 } from '../config/schema';
@@ -216,8 +217,14 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
   // Counter for stdout reconnect escalation; reset on `reconnected`.
   let consecutiveReconnects = 0;
 
+  // Inbound-activity sensor for the stale-event watchdog. Keepalive is
+  // started after channel.connect(), so we route through a mutable ref —
+  // pre-connect callers see a no-op, post-start they hit the real handle.
+  let recordInbound: () => void = () => {};
+
   channel.on({
     message: async (msg) => {
+      recordInbound();
       await withTrace({ chatId: msg.chatId, msgId: msg.messageId }, () =>
         intakeMessage({
           channel,
@@ -233,9 +240,11 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
       ).catch((err) => log.fail('intake', err));
     },
     reject: (evt) => {
+      recordInbound();
       log.info('intake', 'reject', { chatId: evt.chatId, reason: evt.reason });
     },
     cardAction: async (evt) => {
+      recordInbound();
       await withTrace({ chatId: evt.chatId, msgId: evt.messageId }, async () => {
         await handleCardAction({
           channel,
@@ -251,6 +260,7 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
       }).catch((err) => log.fail('cardAction', err));
     },
     comment: async (evt) => {
+      recordInbound();
       await withTrace({ chatId: 'comment' }, async () => {
         await handleCommentMention({ channel, evt, agent, sessions, workspaces }).catch((err) =>
           log.fail('comment', err),
@@ -268,6 +278,9 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
       }
     },
     reconnected: () => {
+      // Successful reconnect is itself proof of life — re-arm the stale
+      // watchdog so we don't immediately retrigger on the next tick.
+      recordInbound();
       if (consecutiveReconnects > 1) {
         log.info('ws', 'recovered', { afterAttempts: consecutiveReconnects });
       } else {
@@ -314,7 +327,10 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
     channel,
     domain: probeDomain,
     forceReconnect: () => controls.restart(),
+    staleEventReconnectMs: getWsStaleEventReconnectMs(cfg),
   });
+  // Activate the inbound-activity sensor wired into channel.on above.
+  recordInbound = keepalive.recordInbound;
 
   return {
     channel,

--- a/src/bot/keepalive.ts
+++ b/src/bot/keepalive.ts
@@ -39,19 +39,45 @@ export interface KeepaliveDeps {
   domain: string;
   /** Force-reconnect callback. Bridge uses `controls.restart`. */
   forceReconnect: () => Promise<void>;
+  /**
+   * Force reconnect when SDK reports `connected` but no inbound event has
+   * arrived for this long. 0 = disabled (legacy behavior).
+   *
+   * Why: SDK's pingTimeout watchdog only catches TCP-level death. When the
+   * Feishu server keeps the TCP/WS alive but stops pushing application
+   * events ("zombie subscription"), `getConnectionStatus().state` stays
+   * `connected` forever and users see the bot ignore their messages until
+   * a manual restart.
+   */
+  staleEventReconnectMs?: number;
 }
 
 export interface KeepaliveHandle {
   stop(): void;
+  /**
+   * Bump the inbound-activity clock. Wire this into every inbound channel
+   * event handler (message, cardAction, comment, reconnected, etc.) so the
+   * stale-event watchdog sees real-time activity. SDK-level pings are not
+   * exposed at this layer, so this is the bridge's only liveness signal.
+   */
+  recordInbound(): void;
 }
 
 export function startKeepalive(deps: KeepaliveDeps): KeepaliveHandle {
   const { channel, domain, forceReconnect } = deps;
+  const staleEventReconnectMs = deps.staleEventReconnectMs ?? 0;
 
   let lastTick = 0;
   let consecutiveDown = 0;
   let networkDownTicks = 0;
   let stopped = false;
+  // Track the most recent inbound event arrival. Seed at startup so a
+  // freshly-connected bot with no traffic still gets evaluated against the
+  // threshold (otherwise stale-event detection would never fire on a quiet
+  // chat that never received its first message).
+  let lastInboundAt = Date.now();
+  // Suppress repeat reconnects while one is in flight or just completed.
+  let lastStaleReconnectAt = 0;
 
   const tick = async (): Promise<void> => {
     if (stopped) return;
@@ -83,6 +109,31 @@ export function startKeepalive(deps: KeepaliveDeps): KeepaliveHandle {
       }
       consecutiveDown = 0;
       networkDownTicks = 0;
+
+      // App-layer zombie detection — SDK reports `connected` (TCP/ping
+      // alive) but no events have arrived for too long. Cheapest reliable
+      // signal at this layer; SDK's internal ping cadence isn't exposed.
+      if (staleEventReconnectMs > 0) {
+        const sinceInbound = now - lastInboundAt;
+        if (
+          sinceInbound > staleEventReconnectMs &&
+          // Don't immediately re-fire after a reconnect we just triggered
+          // — wait at least one full threshold window for events to arrive.
+          now - lastStaleReconnectAt > staleEventReconnectMs
+        ) {
+          log.warn('keepalive', 'stale-event-reconnect', {
+            sinceInboundMs: sinceInbound,
+            thresholdMs: staleEventReconnectMs,
+          });
+          lastStaleReconnectAt = now;
+          lastInboundAt = now; // reset so the watchdog re-arms post-reconnect
+          try {
+            await forceReconnect();
+          } catch (err) {
+            log.fail('keepalive', err, { step: 'stale-event-reconnect' });
+          }
+        }
+      }
       return;
     }
 
@@ -134,6 +185,9 @@ export function startKeepalive(deps: KeepaliveDeps): KeepaliveHandle {
     stop() {
       stopped = true;
       clearInterval(timer);
+    },
+    recordInbound() {
+      lastInboundAt = Date.now();
     },
   };
 }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -133,6 +133,20 @@ export interface AppPreferences {
   /** Access control — user/chat allowlists + admin gating. See AppAccess. */
   access?: AppAccess;
   /**
+   * Force a WS reconnect when the SDK still reports `connected` but no
+   * inbound event (message, card action, comment, even SDK-level reconnect
+   * notification) has arrived for this long. Guards against application-
+   * layer zombie state: server keeps the TCP connection alive (so SDK
+   * pingTimeout watchdog never fires) but silently stops pushing events.
+   *
+   * Default 1800000 (30 min). Set 0 to disable. Range 60000-86400000.
+   *
+   * Note: legitimate idle periods are normal, but a reconnect is cheap
+   * (~1s blip, no message loss because Feishu queues events server-side)
+   * and far better than the silent-broken state.
+   */
+  wsStaleEventReconnectMs?: number;
+  /**
    * Grace period (ms) between SIGTERM and SIGKILL when killing the claude
    * subprocess. Bumped from a hardcoded 500ms because claude often has its
    * own subprocesses (e.g. lark-cli mid-OAuth) that need a moment to clean
@@ -239,6 +253,19 @@ export function getAgentStopGraceMs(cfg: AppConfig): number {
   const raw = cfg.preferences?.agentStopGraceMs;
   if (typeof raw !== 'number' || !Number.isFinite(raw)) return 5000;
   return Math.min(30_000, Math.max(100, Math.floor(raw)));
+}
+
+/**
+ * Resolve the stale-event-stream force-reconnect threshold in ms.
+ * Returns 0 when disabled. Default 30 min. Clamps to [60_000, 86_400_000]
+ * when set so a typo can't either flap the connection every few seconds
+ * or wait a week.
+ */
+export function getWsStaleEventReconnectMs(cfg: AppConfig): number {
+  const raw = cfg.preferences?.wsStaleEventReconnectMs;
+  if (raw === 0) return 0;
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return 30 * 60 * 1000;
+  return Math.min(86_400_000, Math.max(60_000, Math.floor(raw)));
 }
 
 /** True when `senderId` may interact with the bot. Empty list = allow all. */


### PR DESCRIPTION
## Symptom

Bot processes a request normally, then sits idle. After 6+ minutes of idle (no obvious sleep/wake), the next user message in Feishu is **never delivered** to the bridge — no `intake.enter` line in the log, no `keepalive.ws-stuck`, no `ws.reconnecting`. The only fix is a manual `lark-channel-bridge restart`. Repro'd on macOS 25.5.0, Node 22, v0.1.31, daemon mode (`start`).

Concrete trace (UTC):
- `17:29:22` — last `flush.end` for the prior task
- `17:35` (local) — user sends message in Feishu, sees the green delivered-checkmark
- No `intake.enter` in `~/.lark-channel/logs/*.log` between those times
- `lark-channel-bridge status` shows the daemon still running, just deaf

## Root cause

`channel.getConnectionStatus()` is the only liveness signal the current keepalive uses, and it answers TCP-level questions. The SDK's `pingTimeout: 3` watchdog (in `src/bot/channel.ts`) reinforces that — if pong stops, terminate, reconnect.

But there's a class of failures the TCP layer can't see: **the Feishu server keeps the WS alive (pong replies on time) and silently stops pushing application event frames**. Whether that's a server-side subscription expiry, a load-balancer rebalance that drops the event channel but not the socket, or something else, the symptom from the SDK's perspective is identical to a healthy idle connection. State sits at `connected` forever.

Result: keepalive's `if (status.state === 'connected') return;` early-exits every 15s, no force-reconnect ever triggers.

## Fix

Add a second liveness signal: **time since last inbound application event**.

- New `keepalive` deps field `staleEventReconnectMs`. When `> 0` and `state === 'connected'` and `now - lastInboundAt > threshold`, force-reconnect via the existing `forceReconnect` callback.
- `KeepaliveHandle` exposes `recordInbound()`. `channel.ts` wires it into every inbound handler (`message`, `reject`, `cardAction`, `comment`, `reconnected`) via a mutable ref — keepalive is created after `channel.on`, so the ref starts as a no-op and is swapped in post-startup.
- `lastInboundAt` is seeded at startup. Without that, a quiet bot's threshold check could never fire (no prior inbound to compare against).
- Rate-limited to one stale-reconnect per threshold window — prevents flapping if the reconnect itself drops out before any new event arrives.
- Config knob: `preferences.wsStaleEventReconnectMs`. Default **30 min**, range `[60_000, 86_400_000]`, set to **0 to disable**. Documented inline with the rationale.

The 30 min default is a compromise: long enough that a legitimately quiet personal-use bot won't reconnect-flap; short enough that a real zombie is recovered within a single working session. Operators who want the prior behavior set `wsStaleEventReconnectMs: 0`.

## What this does *not* do

- Doesn't try to detect zombie state proactively (no extra HTTP probes, no scheduled health checks). The signal is just "did anything come in lately." Cheap, no extra traffic.
- Doesn't change the existing `getConnectionStatus`-based path. Both watchdogs run; the new one only fires on top of the existing one's quiet path.
- Doesn't expose the threshold via `/config` slash command. Held that back to keep the surface small; can add in a follow-up if the maintainer wants it.

## Why this can't be reproduced reliably

The triggering condition is server-side (Feishu's event push stops for that subscription) and I can't induce it on demand. The fix is defensive: it can't make the situation worse (an extra reconnect when the zombie was a false alarm is a ~1s blip, no message loss because Feishu queues events server-side), and it does fix the failure mode I observed.

## Verification

- `pnpm typecheck` — passes
- `pnpm build` — passes (no test files present in the repo so `pnpm test` is a no-op)
- Manually walked the tick paths for: healthy / SDK-disconnected / zombie / wake-from-sleep / first-connect-no-traffic

## Draft

Filing as draft because I haven't verified on the production failure mode (see above) and the default threshold (30 min) is a judgment call you may want to tune. Happy to adjust scope or split into smaller commits.