### PR TITLE
feat(model): per-chat model override + global default via `/model` command

### DIFF
--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -30,6 +30,7 @@ import { tryHandleCommand, type Controls } from '../commands';
 import type { AppConfig } from '../config/schema';
 import {
   getAgentStopGraceMs,
+  getDefaultModel,
   getMaxConcurrentRuns,
   getMessageReplyMode,
   getRequireMentionInGroup,
@@ -709,6 +710,10 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     executor,
     now: Date.now(),
     stopGraceMs: getAgentStopGraceMs(controls.cfg),
+    // Per-chat model: scope override (set via /model) wins over the global
+    // default (`preferences.defaultModel`). Both undefined → the agent picks
+    // its own. Forwarded through startRunFlow → executor.submit → agent.run.
+    model: sessions.getModel(scope) ?? getDefaultModel(controls.cfg),
     observability: {
       profile: controls.profile,
       agent: capability.agentId,

--- a/src/bot/run-flow.ts
+++ b/src/bot/run-flow.ts
@@ -34,6 +34,9 @@ export interface StartRunFlowInput {
   executor: RunExecutor;
   now: number;
   stopGraceMs?: number;
+  /** Per-chat model override resolved by the caller; forwarded to the
+   * executor (and ultimately `agent.run`). Undefined → agent default. */
+  model?: string;
   observability?: {
     profile: string;
     agent: string;
@@ -143,6 +146,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
       policy,
       sessionId,
       threadId,
+      model: input.model,
       images:
         input.capability.agentId === 'codex'
           ? policy.attachments

--- a/src/card/templates.ts
+++ b/src/card/templates.ts
@@ -190,6 +190,7 @@ export function helpCard(agentName = 'Agent'): object {
         '- `/stop comment:<scopeHash>` — 管理员停止云文档评论任务',
         '- `/timeout [N|off|default]` — 当前 session 的探活分钟数,`/config` 改全局默认',
         '- `/timeout comment:<scopeHash> N` — 管理员设置云文档评论任务探活',
+        '- `/model [sonnet|opus|haiku|<完整名>|default]` — 当前 chat 用哪个模型(留空查看)',
         '- `/ps` — 列出本机所有 bot,标识当前正在回复的那个',
         '- `/exit <id|#>` — 关掉指定 bot(用 `/ps` 看 id/序号)',
         '- `/reconnect` — 强制重连 WebSocket(网络抖动后 bot 没反应时用)',

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -27,6 +27,7 @@ import { helpCard, resumeCard, statusCard, workspacesCard } from '../card/templa
 import type { AppConfig, AppPreferences, MessageReplyMode, TenantBrand } from '../config/schema';
 import {
   getAgentStopGraceMs,
+  getDefaultModel,
   getMaxConcurrentRuns,
   getMessageReplyMode,
   getRequireMentionInGroup,
@@ -169,6 +170,7 @@ const handlers: Record<string, Handler> = {
   '/config': handleConfig,
   '/stop': handleStop,
   '/timeout': handleTimeout,
+  '/model': handleModel,
   '/ps': handlePs,
   '/exit': handleExit,
   '/doctor': handleDoctor,
@@ -931,6 +933,75 @@ function parseTimeoutTarget(input: string, currentScope: string): {
     value: input,
     targeted: false,
   };
+}
+
+/**
+ * Common claude model aliases. Users typing `/model sonnet` get the
+ * verbatim string `sonnet` passed to `claude --model` — claude resolves
+ * its own aliases on the CLI side, so we only need to list the ones the
+ * CLI accepts here for the inline `/model` help. Fully-qualified names
+ * (`claude-sonnet-4-6`, etc.) are also accepted as-is.
+ */
+const MODEL_ALIASES = ['sonnet', 'opus', 'haiku'] as const;
+
+async function handleModel(args: string, ctx: CommandContext): Promise<void> {
+  const trimmed = args.trim();
+  const globalModel = getDefaultModel(ctx.controls.cfg);
+  const formatGlobal = (): string => globalModel ?? 'claude 自带默认';
+
+  const usage =
+    '\n\n用法:\n' +
+    '- `/model sonnet` / `/model opus` / `/model haiku` — 本 chat 切到指定模型\n' +
+    '- `/model claude-sonnet-4-6` — 完整模型名也可以\n' +
+    '- `/model default` — 清除本 chat 覆盖，回退全局默认\n' +
+    '- `/model` — 查看当前 chat 用的什么\n\n' +
+    `_全局默认通过 \`preferences.defaultModel\` 配置;\`/new\` 会清掉本 chat 的覆盖_`;
+
+  // /model — show effective value + source
+  if (!trimmed) {
+    const scopeModel = ctx.sessions.getModel(ctx.scope);
+    if (scopeModel !== undefined) {
+      await reply(
+        ctx,
+        `🤖 当前 chat 模型:\`${scopeModel}\`(本 chat 覆盖)\n全局默认:${formatGlobal()}${usage}`,
+      );
+      return;
+    }
+    await reply(ctx, `🤖 当前 chat 模型:跟随全局(${formatGlobal()})${usage}`);
+    return;
+  }
+
+  if (trimmed === 'default' || trimmed === 'reset') {
+    const cleared = ctx.sessions.clearModelOverride(ctx.scope);
+    log.info('command', 'model-clear', { scope: ctx.scope, cleared });
+    await reply(
+      ctx,
+      cleared
+        ? `✅ 已清除 chat 覆盖,回退到全局默认(${formatGlobal()})。`
+        : `当前 chat 本来就没设过覆盖,跟随全局(${formatGlobal()})。`,
+    );
+    return;
+  }
+
+  // Guard against accidental shell-like values that almost certainly aren't
+  // models. The actual model-name validation lives in claude CLI; we just
+  // bounce obvious noise so the user doesn't spawn a broken run.
+  if (trimmed.length > 80 || /[\s'"`$\\;|<>]/.test(trimmed)) {
+    await reply(
+      ctx,
+      '❌ 模型名看着不对劲(长度超限或含特殊字符)。常用别名:`' +
+        MODEL_ALIASES.join('`、`') +
+        '`',
+    );
+    return;
+  }
+
+  ctx.sessions.setModel(ctx.scope, trimmed);
+  log.info('command', 'model-set', { scope: ctx.scope, model: trimmed });
+  await reply(
+    ctx,
+    `✅ 当前 chat 模型已切到 \`${trimmed}\`。下次发消息开始生效(已经在跑的不变)。`,
+  );
 }
 
 async function handlePs(_args: string, ctx: CommandContext): Promise<void> {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -129,6 +129,14 @@ export interface AppPreferences {
   /** Access control — user/chat allowlists + admin gating. See AppAccess. */
   access?: AppAccess;
   /**
+   * Global default model passed to `claude --model` when a chat has no
+   * per-scope override (set via `/model <name>`). Undefined = let claude
+   * pick its default. Common values: `sonnet`, `opus`, `haiku` (claude
+   * resolves the alias to the current latest), or a fully-qualified name
+   * like `claude-sonnet-4-6`. Per-scope `/model` overrides this.
+   */
+  defaultModel?: string;
+  /**
    * Grace period (ms) between SIGTERM and SIGKILL when killing the claude
    * subprocess. Bumped from a hardcoded 500ms because claude often has its
    * own subprocesses (e.g. lark-cli mid-OAuth) that need a moment to clean
@@ -244,6 +252,15 @@ export function getAgentStopGraceMs(cfg: AppConfig): number {
   const raw = cfg.preferences?.agentStopGraceMs;
   if (typeof raw !== 'number' || !Number.isFinite(raw)) return 5000;
   return Math.min(30_000, Math.max(100, Math.floor(raw)));
+}
+
+/** Global default model (`preferences.defaultModel`). Trimmed and
+ * non-empty; otherwise treated as unset. */
+export function getDefaultModel(cfg: AppConfig): string | undefined {
+  const raw = cfg.preferences?.defaultModel;
+  if (typeof raw !== 'string') return undefined;
+  const t = raw.trim();
+  return t.length > 0 ? t : undefined;
 }
 
 export function getRunIdleTimeoutMs(cfg: AppConfig): number | undefined {

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -14,6 +14,12 @@ export interface SessionEntry {
    * scope, undefined = follow global default. Session resets preserve this
    * scope preference while removing the resumable session id/cwd. */
   idleTimeoutMinutes?: number;
+  /** Per-scope model override. The string is passed verbatim to
+   * `claude --model`. Undefined = follow global default
+   * (`preferences.defaultModel`), or fall through to claude's own default
+   * when neither is set. Like idle-timeout, this survives across runs and
+   * is cleared by /new. */
+  model?: string;
 }
 
 type SessionMap = Record<string, SessionEntry>;
@@ -43,13 +49,15 @@ export class SessionStore {
         const cwd = typeof entry.cwd === 'string' ? entry.cwd : undefined;
         const idleTimeoutMinutes =
           typeof entry.idleTimeoutMinutes === 'number' ? entry.idleTimeoutMinutes : undefined;
+        const model = typeof entry.model === 'string' && entry.model ? entry.model : undefined;
         const hasSession = sessionId !== undefined && cwd !== undefined;
-        if (!hasSession && idleTimeoutMinutes === undefined) continue;
+        if (!hasSession && idleTimeoutMinutes === undefined && model === undefined) continue;
         this.data[chatId] = {
           ...(sessionId !== undefined ? { sessionId } : {}),
           ...(cwd !== undefined ? { cwd } : {}),
           updatedAt: entry.updatedAt,
           ...(idleTimeoutMinutes !== undefined ? { idleTimeoutMinutes } : {}),
+          ...(model !== undefined ? { model } : {}),
         };
       }
     } catch (err) {
@@ -75,8 +83,9 @@ export class SessionStore {
   }
 
   set(chatId: string, sessionId: string, cwd: string): void {
-    // Preserve idleTimeoutMinutes across run starts — it's a per-scope
-    // preference, not per-run-instance state. /new (clear) wipes it.
+    // Preserve per-scope preferences across run starts — idle-timeout and
+    // model are scope state, not per-run-instance state. /new (clear) wipes
+    // both.
     const prev = this.data[chatId];
     this.data[chatId] = {
       sessionId,
@@ -85,6 +94,7 @@ export class SessionStore {
       ...(prev?.idleTimeoutMinutes !== undefined
         ? { idleTimeoutMinutes: prev.idleTimeoutMinutes }
         : {}),
+      ...(prev?.model !== undefined ? { model: prev.model } : {}),
     };
     this.schedulePersist();
   }
@@ -125,6 +135,32 @@ export class SessionStore {
     const prev = this.data[chatId];
     if (!prev || prev.idleTimeoutMinutes === undefined) return false;
     const { idleTimeoutMinutes: _, ...rest } = prev;
+    this.data[chatId] = { ...rest, updatedAt: Date.now() };
+    this.schedulePersist();
+    return true;
+  }
+
+  /** Per-scope model override. `undefined` = follow global default. */
+  getModel(chatId: string): string | undefined {
+    return this.data[chatId]?.model;
+  }
+
+  setModel(chatId: string, model: string): void {
+    const prev = this.data[chatId];
+    this.data[chatId] = {
+      ...(prev ?? { updatedAt: Date.now() }),
+      model,
+      updatedAt: Date.now(),
+    };
+    this.schedulePersist();
+  }
+
+  /** Remove the model override so this scope falls back to the global
+   * default. Returns true if something was actually removed. */
+  clearModelOverride(chatId: string): boolean {
+    const prev = this.data[chatId];
+    if (!prev || prev.model === undefined) return false;
+    const { model: _, ...rest } = prev;
     this.data[chatId] = { ...rest, updatedAt: Date.now() };
     this.schedulePersist();
     return true;


### PR DESCRIPTION
> **Updated 2026-06-18 — rebased onto latest `main`.** This branch was
> rebased on top of the `@larksuite/channel` SDK migration + Codex support.
> The model now flows through the new run pipeline rather than a direct
> `agent.run` call (details in **Implementation** below). `pnpm typecheck`,
> `pnpm build`, and the full `pnpm test` suite (512 tests) all pass on the
> new base. History is linear — no merge commits.

## Motivation

The claude adapter already forwards `opts.model → claude --model <x>`, but
nothing populates `opts.model` in practice: there's no slash command, no
per-chat persistence, no global config field. Users who want sonnet on one
project and opus on another have no way to do it from inside Feishu — the
bridge always falls through to whatever claude picks by default.

## What this adds

- **`/model <name>`** — set the model for the current chat. Bare aliases
  (`sonnet`, `opus`, `haiku`) pass through verbatim; claude CLI resolves
  them. Fully qualified names like `claude-sonnet-4-6` work too.
- **`/model default`** / **`/model reset`** — clear the chat override,
  fall back to the global default.
- **`/model`** (no args) — show the effective model and where it came from
  (chat override vs global vs claude-default).
- **`preferences.defaultModel`** — global default in `config.json`, applied
  to chats with no per-chat override. Undefined preserves the existing
  behavior (claude decides).

## Implementation

Mirrors the existing `/timeout` + `idleTimeoutMinutes` pattern almost
exactly so the surface stays small and consistent:

- `SessionEntry.model?: string` — persisted alongside `idleTimeoutMinutes`,
  preserved across `sessions.set()` so per-run state changes don't clobber
  it. `/new` clears it (same as the timeout override).
- `SessionStore.getModel / setModel / clearModelOverride` — matches the
  timeout shape one-for-one.
- `getDefaultModel(cfg)` in schema, with the same trim + non-empty
  treatment of preferences strings.
- **Plumbing through the new run pipeline (post-rebase):** `channel.ts`
  resolves `sessions.getModel(scope) ?? getDefaultModel(cfg)` and passes it
  as `model` into `startRunFlow(...)`, which forwards it to
  `executor.submit(...)` and on to `agent.run(...)`. `SubmitRunInput`
  already exposed a `model?` field that was never populated from the IM
  channel — this PR adds the `model?` field to `StartRunFlowInput` and wires
  the channel → flow → executor path end to end. The existing `agent.spawn`
  log line already records `model`, so the resolved value shows up in logs.

## Defensive bits

- `/model` is **not** marked admin. A per-chat model swap is the same
  kind of preference as `/timeout`, which already isn't admin. Anyone
  who can talk to the bot picks the model. Happy to flip if you'd
  rather gate it.
- Bounces values longer than 80 chars or containing shell-ish characters
  (`\s '\"\`$\;|<>`). Actual model validation lives in claude CLI; this
  guardrail is just so a typo can't write garbage into the persisted
  config.
- `load()` keeps bare-model entries (no `sessionId/cwd` yet) the same way
  it keeps bare-timeout entries, so a `/model X` in a fresh chat survives
  restart even if no run has set the resume keys.

## Help card

One line added under `/timeout`:

```
- `/model [sonnet|opus|haiku|<完整名>|default]` — 当前 chat 用哪个模型(留空查看)
```

## Verification

- `pnpm typecheck` ✅
- `pnpm build` ✅
- `pnpm test` ✅ — 512 tests pass on the rebased base (incl.
  `cli/index-registration` and `runtime/run-executor`)
- Manually exercised in a live daemon: `/model sonnet`, `/model`,
  `/model default` round-trip, daemon restart picks up persisted state.

## Out of scope (left for follow-up if you want)

- No `/config` form field for `defaultModel` yet — kept this PR small.
  Easy to add later in the same form alongside `messageReply` /
  `showToolCalls`.
- No model-listing API call to validate the name server-side. Bouncing
  shell-ish characters and letting claude's own error bubble back to the
  card felt like the right cost/value.
- No `card/templates.ts` button for `/model`. Cards are mostly status
  affordances, and the model is a typed preference rather than a quick
  toggle.
