### PR TITLE
feat: default to Claude Code auto permission mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Daemon logs go to `~/.lark-channel/logs/daemon-stdout.log` and `daemon-stderr.lo
 | Command | Effect |
 |---|---|
 | `/new [effort]`, `/reset [effort]` | Clear the current chat's session; `/new low` starts fresh with low reasoning |
+| `/compact [instructions]` | Run Claude Code `/compact` on the current session, keeping the same session id |
 | `/cd <path>` | Switch working directory (resets session) |
 | `/ws list` | List named workspaces (card + buttons) |
 | `/ws save <name>` | Save current cwd as a named workspace |
@@ -119,6 +120,7 @@ Common flows:
 
 - `/effort low`: keep the current context, but make future runs in this session low effort.
 - `/effort default`: clear the current session override and return to the global default.
+- `/compact`: keep the current session id but ask Claude Code to summarize/compress its context. Add optional instructions when some details must survive compaction, e.g. `/compact keep naming criteria and rejected names`.
 - `/new low`: in the **current chat/topic**, clear the Claude session and start the new session with low effort.
 - `/new`: in the current chat/topic, clear the Claude session without setting effort.
 - `/new chat [name]`: create a new Feishu / Lark group chat. This is distinct from `/new low`; if the source chat already has an `/effort` override, the new group inherits it.
@@ -232,7 +234,7 @@ After a manual edit, **restart the bridge** or send **`/reconnect`** from any al
 
 ## FAQ
 
-**The bot stays silent / Claude never replies.** Usually the `claude` CLI itself is not logged in, or the session points to a cwd that no longer exists. Send `/status` to inspect; `/new` to start a fresh session.
+**The bot stays silent / Claude never replies.** Usually the `claude` CLI itself is not logged in, the session points to a cwd that no longer exists, or the resumed Claude session has grown awkward enough to hang. Send `/status` to inspect; try `/compact` to keep the session while reducing context; use `/new` when you want a fresh session.
 
 **Claude subprocess looks frozen (card stuck on the last frame).** Since 0.1.20 there's an idle watchdog: if Claude emits nothing for N minutes the process is killed and the card is annotated `⏱ N min no response, auto-terminated`. Disabled by default. Enable with `/config` (global, in minutes), or `/timeout 10` to set it on the current session; `/timeout off` disables for the session; `/timeout default` clears the session override.
 
@@ -246,7 +248,7 @@ After a manual edit, **restart the bridge** or send **`/reconnect`** from any al
 
 Key files:
 
-- `src/commands/index.ts`: Feishu slash command handlers, including `/effort`, `/new low`, and `/config`.
+- `src/commands/index.ts`: Feishu slash command handlers, including `/compact`, `/effort`, `/new low`, and `/config`.
 - `src/session/store.ts`: per chat/topic session id, cwd, timeout override, and effort override persistence.
 - `src/bot/channel.ts`: message batching, effective effort resolution, and `agent.run()` invocation.
 - `src/agent/claude/adapter.ts`: spawns `claude -p` with `--model`, `--effort`, `--mcp-config`, and allowed tools.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Daemon logs go to `~/.lark-channel/logs/daemon-stdout.log` and `daemon-stderr.lo
 
 | Command | Effect |
 |---|---|
-| `/new`, `/reset` | Clear the current chat's session |
+| `/new [effort]`, `/reset [effort]` | Clear the current chat's session; `/new low` starts fresh with low reasoning |
 | `/cd <path>` | Switch working directory (resets session) |
 | `/ws list` | List named workspaces (card + buttons) |
 | `/ws save <name>` | Save current cwd as a named workspace |
@@ -90,6 +90,7 @@ Daemon logs go to `~/.lark-channel/logs/daemon-stdout.log` and `daemon-stderr.lo
 | `/status` | Current cwd / session / agent (card + buttons) |
 | `/config` | Adjust preferences (reply style, tool-call display, ...) |
 | `/stop` | Stop the run in progress (also the `⏹` button on the card) |
+| `/effort [low\|medium\|high\|xhigh\|max\|default]` | Claude Code reasoning effort for the current session. `extra high` maps to `xhigh`; `ultra` maps to `max`. |
 | `/timeout [N\|off\|default]` | Idle-watchdog (minutes) for the current session. `/config` sets the global default. See FAQ below. |
 | `/ps` | List all `start` processes on this host, marking the one replying |
 | `/exit <id\|#>` | Stop a `start` process (your own → graceful; another's → SIGTERM) |
@@ -105,7 +106,7 @@ Daemon logs go to `~/.lark-channel/logs/daemon-stdout.log` and `daemon-stderr.lo
 | Path | Content |
 |---|---|
 | `~/.lark-channel/config.json` | App credentials (App ID / Secret), mode 600 |
-| `~/.lark-channel/sessions.json` | Claude session id + cwd per chat / topic (+ optional `/timeout` override) |
+| `~/.lark-channel/sessions.json` | Claude session id + cwd per chat / topic (+ optional `/timeout` / `/effort` override) |
 | `~/.lark-channel/workspaces.json` | Named-workspace map |
 | `~/.lark-channel/processes.json` | Process registry for live `start` instances (used by `ps`/`stop`); dead PIDs are auto-pruned |
 | `~/.lark-channel/media/<chatId>/` | Downloaded images / files, cleaned up after 24h |

--- a/README.md
+++ b/README.md
@@ -15,12 +15,16 @@ A lightweight bot that bridges Feishu / Lark messenger with your local Claude Co
 - **Multiple workspaces**: `/ws` switches between named project directories, with sessions tracked per workspace.
 - **Images and files**: send them to the bot directly — Claude reads the locally downloaded paths.
 - **Interactive cards**: `/help`, `/ws list`, `/status` return cards with buttons you can click.
+- **Per-session reasoning effort**: use `low` for quick fitness/check-in chats and `xhigh` / `max` for code or AI research sessions.
+- **Empty-output fallback**: if Claude only emits thinking/tool activity and no visible text, the bridge renders an explicit fallback and logs it.
+- **Optional local GUI automation**: Claude runs spawned from Feishu load the `gui` MCP declared in `bridge-mcp.json`, enabling screenshots, clicks, typing, and other desktop actions.
 
 ## Prerequisites
 
 - Node.js **>= 20**
 - `claude` CLI installed and logged in — see https://docs.anthropic.com/en/docs/claude-code/quickstart
 - A Lark / Feishu **PersonalAgent** app (the QR-code wizard on first launch can create one for you).
+- For GUI automation from Feishu: keep the Mac awake, logged in, and grant the required Accessibility / Screen Recording permissions.
 
 ## Install
 
@@ -101,6 +105,26 @@ Daemon logs go to `~/.lark-channel/logs/daemon-stdout.log` and `daemon-stderr.lo
 
 **Reply policy**: in a DM, the bot replies to anything. In a **group (including topic groups), the bot only replies when `@`-mentioned** (default since 0.1.22); unmentioned messages are ignored. `@all` is never answered. Cloud-doc comments must mention the bot. To restore the older "always answer in groups" behaviour: `/config` → "Require @bot in groups" → No.
 
+### Session effort semantics
+
+The local Claude Code CLI supports these `--effort` values: `low` / `medium` / `high` / `xhigh` / `max`. The bridge also accepts user-friendly aliases: `extra high` / `extra-high` / `x_high` normalize to `xhigh`; `ultra` / `ultra high` normalize to `max`.
+
+Priority:
+
+1. Current chat/topic `/effort` override wins and is persisted in `~/.lark-channel/sessions.json`.
+2. Without a session override, the global `/config` value (`preferences.effort`) is used.
+3. Missing or invalid global values fall back to `xhigh`.
+
+Common flows:
+
+- `/effort low`: keep the current context, but make future runs in this session low effort.
+- `/effort default`: clear the current session override and return to the global default.
+- `/new low`: in the **current chat/topic**, clear the Claude session and start the new session with low effort.
+- `/new`: in the current chat/topic, clear the Claude session without setting effort.
+- `/new chat [name]`: create a new Feishu / Lark group chat. This is distinct from `/new low`; if the source chat already has an `/effort` override, the new group inherits it.
+
+`/status` shows the effective effort and whether it comes from a session override or the global default.
+
 ## Data directories
 
 | Path | Content |
@@ -111,8 +135,27 @@ Daemon logs go to `~/.lark-channel/logs/daemon-stdout.log` and `daemon-stderr.lo
 | `~/.lark-channel/processes.json` | Process registry for live `start` instances (used by `ps`/`stop`); dead PIDs are auto-pruned |
 | `~/.lark-channel/media/<chatId>/` | Downloaded images / files, cleaned up after 24h |
 | `~/.lark-channel/logs/YYYY-MM-DD.log` | Structured run logs (JSONL), rotated daily; older than 7 days are pruned at startup (`LARK_CHANNEL_LOG_DAYS` env var overrides). `/doctor` reads these. |
+| `bridge-mcp.json` | Bridge-local MCP config that lets `claude -p` print mode load the local GUI automation server. |
 
 > Upgrading from before 0.1.11? Run `lark-channel-bridge migrate` once — it moves anything under `~/.config/lark-channel-bridge/` and `~/.cache/lark-channel-bridge/` to the new location and upgrades `config.json` to the new schema.
+
+## GUI automation
+
+The ClaudeAdapter appends these arguments whenever it spawns `claude -p`:
+
+- `--mcp-config /Users/charlesli/code/feishu-claude-code-bridge/bridge-mcp.json`
+- a set of `--allowed-tools mcp__gui__...` entries
+
+That lets Claude runs triggered from Feishu use the `gui` MCP for screenshots, clicks, typing, scrolling, clipboard access, and related desktop actions. This is intended for workflows that cannot be done through CLI/API alone, such as scanning WeCom mail or driving a local desktop client.
+
+Runtime requirements:
+
+- The machine must stay awake; system sleep breaks GUI automation.
+- Keep the user session logged in and preferably unlocked. Locked-screen or clamshell workflows are usually unreliable.
+- First use may require approving macOS Accessibility and Screen Recording permissions.
+- Target apps must be visible and operable in the current user session.
+
+Security note: GUI MCP means anyone allowed to message the bot can potentially drive this Mac's screen, mouse, and keyboard through Claude. Tighten `allowedUsers` / `allowedChats` / `admins` before relying on it. The executable path in `bridge-mcp.json` includes the Codex plugin version; after a Codex update, refresh that path if GUI tools stop loading, then rebuild and restart.
 
 ## Access control (optional)
 
@@ -193,7 +236,35 @@ After a manual edit, **restart the bridge** or send **`/reconnect`** from any al
 
 **Claude subprocess looks frozen (card stuck on the last frame).** Since 0.1.20 there's an idle watchdog: if Claude emits nothing for N minutes the process is killed and the card is annotated `⏱ N min no response, auto-terminated`. Disabled by default. Enable with `/config` (global, in minutes), or `/timeout 10` to set it on the current session; `/timeout off` disables for the session; `/timeout default` clears the session override.
 
+**Feishu says Claude returned no visible text.** This usually means Claude only emitted thinking / tool activity / an empty result. The bridge renders a fallback message and writes `agent.empty-output` to structured logs. Retry the message, or send `/reset` to start a fresh session.
+
+**GUI automation does nothing or screenshots are black.** Check that the Mac is not sleeping or locked, the target app is visible, and computer-use permissions are granted. For long-running remote GUI work, `caffeinate -dimsu` is a practical way to keep the system and display available.
+
 **Claude says it can't see the image I sent.** Upgrade to the latest version — releases before 0.1.0 had a filename-dedup bug.
+
+## Development / handoff checklist
+
+Key files:
+
+- `src/commands/index.ts`: Feishu slash command handlers, including `/effort`, `/new low`, and `/config`.
+- `src/session/store.ts`: per chat/topic session id, cwd, timeout override, and effort override persistence.
+- `src/bot/channel.ts`: message batching, effective effort resolution, and `agent.run()` invocation.
+- `src/agent/claude/adapter.ts`: spawns `claude -p` with `--model`, `--effort`, `--mcp-config`, and allowed tools.
+- `src/card/templates.ts`, `src/card/config-card.ts`: `/status`, `/help`, and `/config` cards.
+- `test/effort.test.ts`: effort normalization and session override persistence coverage.
+
+Recommended pre-release checks:
+
+```bash
+./node_modules/.bin/vitest run
+./node_modules/.bin/tsc --noEmit
+./node_modules/.bin/tsup
+git diff --check
+lark-channel-bridge restart
+lark-channel-bridge status
+```
+
+Some environments do not have global `pnpm`; using `./node_modules/.bin/...` is the most reliable local path. After restart, inspect `~/.lark-channel/logs/$(date +%F).log` and confirm the latest line includes `phase=ws event=connected`.
 
 ## License
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,12 +15,16 @@
 - **多工作空间**：`/ws` 切换不同项目，session 自己重置
 - **图片 / 文件**：直接发给 bot，Claude 会读本地下载的文件路径
 - **卡片按钮**：`/help` `/ws list` `/status` 返回交互卡片，点按钮直接操作
+- **按 session 调 reasoning effort**：健身/随口聊天用 `low`，代码/AI 研究用 `xhigh` 或 `max`
+- **空回复兜底**：如果 Claude 只产出 thinking / tool call 而没有可见文本，bridge 会显示明确提示并写日志
+- **本机 GUI 自动化（可选）**：bridge 启动 Claude 时会挂载 `bridge-mcp.json` 里的 `gui` MCP，可从飞书触发截图、点击、输入等桌面操作
 
 ## 前置条件
 
 - Node.js **≥ 20**
 - `claude` CLI 已安装并登录：https://docs.anthropic.com/en/docs/claude-code/quickstart
 - 一个飞书 / Lark PersonalAgent 应用（首次启动的扫码向导能帮你创建）
+- 如果要从飞书触发 GUI 操作：Mac 需要保持唤醒、已登录且相关辅助功能 / 屏幕录制权限已授权
 
 ## 安装
 
@@ -101,6 +105,26 @@ daemon 的 stdout / stderr 写到 `~/.lark-channel/logs/daemon-stdout.log` 和 `
 
 **消息策略**：私聊 = 不需要 @，任何消息都回；**群（含话题群）= 默认要 @bot 才回**（0.1.22 起的新默认），不 @ 时 bot 完全沉默；@全员永远不响应；云文档评论必须 @bot。要恢复"群里也不强制 @"的老行为：`/config` → "群里需要 @ bot" → 选"否"。
 
+### Session effort 语义
+
+Claude Code 本机支持的 `--effort` 值是 `low` / `medium` / `high` / `xhigh` / `max`。bridge 额外接受一些口语别名：`extra high` / `extra-high` / `x_high` 会规范化成 `xhigh`，`ultra` / `ultra high` 会规范化成 `max`。
+
+优先级：
+
+1. 当前 chat / topic 的 `/effort` 覆盖优先，写入 `~/.lark-channel/sessions.json`
+2. 没有 session 覆盖时，使用 `/config` 表单里的全局默认 `preferences.effort`
+3. 全局默认缺失或非法时，回退到 `xhigh`
+
+常用模式：
+
+- `/effort low`：不清空上下文，只让当前 session 后续 run 用低 effort
+- `/effort default`：清除当前 session 覆盖，回到全局默认
+- `/new low`：在**当前 chat/topic** 里清空 Claude session，并把新 session 设为低 effort
+- `/new`：在当前 chat/topic 里清空 Claude session，不指定 effort
+- `/new chat [name]`：新建一个飞书群聊。它不是 `/new low`；如果当前 chat 已经有 `/effort` 覆盖，新群会继承这个覆盖
+
+`/status` 会显示当前生效的 effort，并标注来源是 session 覆盖还是全局默认。
+
 ## 数据目录
 
 | 路径 | 内容 |
@@ -111,8 +135,27 @@ daemon 的 stdout / stderr 写到 `~/.lark-channel/logs/daemon-stdout.log` 和 `
 | `~/.lark-channel/processes.json` | 当前在跑的 start 进程注册中心（`ps`/`stop` 用），死进程会被自动清理 |
 | `~/.lark-channel/media/<chatId>/` | 下载的图片 / 文件，24h 自动清理 |
 | `~/.lark-channel/logs/YYYY-MM-DD.log` | 结构化运行日志（JSON line），按天滚动；启动时清理超过 7 天的老文件（`LARK_CHANNEL_LOG_DAYS` 环境变量可改）；`/doctor` 命令读它做诊断 |
+| `bridge-mcp.json` | bridge 专用 MCP 配置，让 `claude -p` print 模式也能加载本机 GUI 自动化 server |
 
 > 升级自 0.1.11 之前的版本？跑一次 `lark-channel-bridge migrate` —— 自动把 `~/.config/lark-channel-bridge/` 和 `~/.cache/lark-channel-bridge/` 下的内容搬到新位置，并把 `config.json` 升级到新结构。
+
+## GUI 自动化能力
+
+bridge 的 ClaudeAdapter 会在每次 spawn `claude -p` 时追加：
+
+- `--mcp-config /Users/charlesli/code/feishu-claude-code-bridge/bridge-mcp.json`
+- 一组 `--allowed-tools mcp__gui__...`
+
+这样从飞书来的 Claude run 可以使用 `gui` MCP 做截图、点击、输入、滚动、读写剪贴板等桌面操作。这个能力适合扫企业微信邮件、操作本地客户端、处理必须靠 GUI 的流程。
+
+运行条件：
+
+- 电脑必须保持系统唤醒，不能 sleep
+- 最好保持已登录、未锁屏；锁屏或合盖后 GUI 自动化通常不可靠
+- 首次使用可能需要在 macOS 上批准辅助功能和屏幕录制权限
+- 目标 app 要在当前用户会话里可见、可操作
+
+安全提醒：GUI MCP 等于允许飞书 allowlist 内的人远程驱动这台 Mac 的屏幕、鼠标和键盘。生产使用前务必配置好 `allowedUsers` / `allowedChats` / `admins`。`bridge-mcp.json` 里的 computer-use 可执行路径带 Codex 插件版本号，Codex 更新后如果路径失效，需要同步更新这个文件并 rebuild/restart。
 
 ## 访问控制（可选）
 
@@ -193,7 +236,35 @@ grep '"event":"enter"' ~/.lark-channel/logs/$(date +%Y-%m-%d).log | tail -5
 
 **Claude 子进程假死（卡片停在最后一帧不动）**：从 0.1.20 起支持 idle 探活：claude 一段时间没输出就被 SIGTERM kill，卡片末尾会标 "⏱ N 分钟无响应，已自动终止"。默认关闭。开启方式：`/config` 设全局值（分钟），或 `/timeout 10` 只对当前 session 生效；`/timeout off` 关掉某个 session 的探活；`/timeout default` 清掉 session 覆盖回退到全局。
 
+**飞书里显示 Claude 没有返回可见文本**：这通常说明 Claude 本轮只产出了 thinking / tool call / 空结果。bridge 会显示兜底提示并在结构化日志里写 `agent.empty-output`。可以直接重发，或者 `/reset` 开新 session 后重试。
+
+**GUI 自动化没反应或截图黑屏**：先确认 Mac 没有 sleep / 锁屏，目标 app 在当前桌面可见，computer-use 相关权限已授权。长时间远程跑 GUI 任务时可以用 `caffeinate -dimsu` 保持系统和显示可用。
+
 **图片发过去 Claude 说看不到**：升级到最新版，0.1.0 之前的版本有文件名去重 bug。
+
+## 开发 / 接手检查清单
+
+关键文件：
+
+- `src/commands/index.ts`：飞书 slash command handler，`/effort` / `/new low` / `/config` 都在这里
+- `src/session/store.ts`：每个 chat/topic 的 session id、cwd、timeout override、effort override 持久化
+- `src/bot/channel.ts`：批处理消息、计算最终 effort、调用 `agent.run()`
+- `src/agent/claude/adapter.ts`：spawn `claude -p`，传 `--model` / `--effort` / `--mcp-config` / `--allowed-tools`
+- `src/card/templates.ts`、`src/card/config-card.ts`：`/status`、`/help`、`/config` 卡片
+- `test/effort.test.ts`：effort 规范化和 session override 持久化测试
+
+上线前建议跑：
+
+```bash
+./node_modules/.bin/vitest run
+./node_modules/.bin/tsc --noEmit
+./node_modules/.bin/tsup
+git diff --check
+lark-channel-bridge restart
+lark-channel-bridge status
+```
+
+有些环境没有全局 `pnpm`，直接用 `./node_modules/.bin/...` 更稳。重启后看 `~/.lark-channel/logs/$(date +%F).log`，确认最后有 `phase=ws event=connected`。
 
 ## 许可
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -86,6 +86,7 @@ daemon 的 stdout / stderr 写到 `~/.lark-channel/logs/daemon-stdout.log` 和 `
 | 命令 | 作用 |
 |---|---|
 | `/new [effort]` `/reset [effort]` | 清空当前 chat 的会话；可用 `/new low` 新会话同时设低 reasoning |
+| `/compact [说明]` | 对当前 Claude session 执行 Claude Code `/compact`，压缩上下文但保留同一个 session id |
 | `/cd <path>` | 切换工作目录（会重置 session） |
 | `/ws list` | 列所有命名工作空间（卡片 + 按钮） |
 | `/ws save <name>` | 把当前 cwd 存为命名工作空间 |
@@ -119,6 +120,7 @@ Claude Code 本机支持的 `--effort` 值是 `low` / `medium` / `high` / `xhigh
 
 - `/effort low`：不清空上下文，只让当前 session 后续 run 用低 effort
 - `/effort default`：清除当前 session 覆盖，回到全局默认
+- `/compact`：不清空 session id，让 Claude Code 压缩当前上下文；可以带说明，例如 `/compact 保留起名偏好和已经否掉的名字`
 - `/new low`：在**当前 chat/topic** 里清空 Claude session，并把新 session 设为低 effort
 - `/new`：在当前 chat/topic 里清空 Claude session，不指定 effort
 - `/new chat [name]`：新建一个飞书群聊。它不是 `/new low`；如果当前 chat 已经有 `/effort` 覆盖，新群会继承这个覆盖
@@ -232,7 +234,7 @@ grep '"event":"enter"' ~/.lark-channel/logs/$(date +%Y-%m-%d).log | tail -5
 
 ## 常见问题
 
-**Claude 挂住不回复**：通常是 `claude` CLI 本身没登录，或者 session 指向了不存在的 cwd。发 `/status` 看当前状态；`/new` 重开会话往往就好。
+**Claude 挂住不回复**：通常是 `claude` CLI 本身没登录、session 指向了不存在的 cwd，或者复用的 Claude session 上下文太大 / 状态不佳。发 `/status` 看当前状态；可以先试 `/compact` 保留 session 并压缩上下文；需要彻底重来再用 `/new`。
 
 **Claude 子进程假死（卡片停在最后一帧不动）**：从 0.1.20 起支持 idle 探活：claude 一段时间没输出就被 SIGTERM kill，卡片末尾会标 "⏱ N 分钟无响应，已自动终止"。默认关闭。开启方式：`/config` 设全局值（分钟），或 `/timeout 10` 只对当前 session 生效；`/timeout off` 关掉某个 session 的探活；`/timeout default` 清掉 session 覆盖回退到全局。
 
@@ -246,7 +248,7 @@ grep '"event":"enter"' ~/.lark-channel/logs/$(date +%Y-%m-%d).log | tail -5
 
 关键文件：
 
-- `src/commands/index.ts`：飞书 slash command handler，`/effort` / `/new low` / `/config` 都在这里
+- `src/commands/index.ts`：飞书 slash command handler，`/compact` / `/effort` / `/new low` / `/config` 都在这里
 - `src/session/store.ts`：每个 chat/topic 的 session id、cwd、timeout override、effort override 持久化
 - `src/bot/channel.ts`：批处理消息、计算最终 effort、调用 `agent.run()`
 - `src/agent/claude/adapter.ts`：spawn `claude -p`，传 `--model` / `--effort` / `--mcp-config` / `--allowed-tools`

--- a/README.zh.md
+++ b/README.zh.md
@@ -81,7 +81,7 @@ daemon 的 stdout / stderr 写到 `~/.lark-channel/logs/daemon-stdout.log` 和 `
 
 | 命令 | 作用 |
 |---|---|
-| `/new` `/reset` | 清空当前 chat 的会话 |
+| `/new [effort]` `/reset [effort]` | 清空当前 chat 的会话；可用 `/new low` 新会话同时设低 reasoning |
 | `/cd <path>` | 切换工作目录（会重置 session） |
 | `/ws list` | 列所有命名工作空间（卡片 + 按钮） |
 | `/ws save <name>` | 把当前 cwd 存为命名工作空间 |
@@ -90,6 +90,7 @@ daemon 的 stdout / stderr 写到 `~/.lark-channel/logs/daemon-stdout.log` 和 `
 | `/status` | 当前 cwd / session / agent（卡片 + 按钮） |
 | `/config` | 调整偏好（消息回复方式、工具调用显示等） |
 | `/stop` | 终止当前正在跑的 run（也可点卡片底部 ⏹ 终止 按钮） |
+| `/effort [low\|medium\|high\|xhigh\|max\|default]` | 当前 session 的 Claude Code reasoning effort；`extra high` 会映射为 `xhigh`，`ultra` 会映射为 `max` |
 | `/timeout [N\|off\|default]` | 当前 session 的 idle 探活（分钟）；`/config` 改全局默认。详见下方"常见问题 — Claude 子进程假死" |
 | `/ps` | 列出本机所有 start 进程，标识当前回复的是哪个 |
 | `/exit <id\|#>` | 终止指定 start 进程（自己 = graceful 退出；他人 = SIGTERM） |
@@ -105,7 +106,7 @@ daemon 的 stdout / stderr 写到 `~/.lark-channel/logs/daemon-stdout.log` 和 `
 | 路径 | 内容 |
 |---|---|
 | `~/.lark-channel/config.json` | 应用凭据（App ID / Secret），权限 600 |
-| `~/.lark-channel/sessions.json` | 每个 chat / 话题 的 Claude session id + cwd（+ 可选的 `/timeout` 覆盖） |
+| `~/.lark-channel/sessions.json` | 每个 chat / 话题 的 Claude session id + cwd（+ 可选的 `/timeout` / `/effort` 覆盖） |
 | `~/.lark-channel/workspaces.json` | 工作空间映射 |
 | `~/.lark-channel/processes.json` | 当前在跑的 start 进程注册中心（`ps`/`stop` 用），死进程会被自动清理 |
 | `~/.lark-channel/media/<chatId>/` | 下载的图片 / 文件，24h 自动清理 |

--- a/bridge-mcp.json
+++ b/bridge-mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "gui": {
+      "command": "/Users/charlesli/.codex/plugins/cache/openai-bundled/computer-use/1.0.799/Codex Computer Use.app/Contents/SharedSupport/SkyComputerUseClient.app/Contents/MacOS/SkyComputerUseClient",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -6,8 +6,22 @@ import { log } from '../../core/logger';
 import type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from '../types';
 import { translateEvent } from './stream-json';
 
+type PermissionModeValue = NonNullable<AgentRunOptions['permissionMode']>;
+
 export interface ClaudeAdapterOptions {
   binary?: string;
+  /**
+   * Default `--permission-mode` when an individual `run()` call doesn't pass
+   * one. Bridge defaults this to `'auto'` (safety classifier on) when
+   * constructed from `start.ts` based on the user's config.
+   */
+  defaultPermissionMode?: PermissionModeValue;
+  /**
+   * Default `--model` when an individual `run()` call doesn't pass one.
+   * Required for `'auto'` permission mode to work (auto mode rejects models
+   * older than Sonnet 4.6 / Opus 4.6 / Opus 4.7).
+   */
+  defaultModel?: string;
 }
 
 type ClaudeChild = ChildProcessByStdio<null, Readable, Readable>;
@@ -106,9 +120,13 @@ export class ClaudeAdapter implements AgentAdapter {
   readonly displayName = 'Claude Code';
 
   private readonly binary: string;
+  private readonly defaultPermissionMode: PermissionModeValue;
+  private readonly defaultModel: string | undefined;
 
   constructor(opts: ClaudeAdapterOptions = {}) {
     this.binary = opts.binary ?? 'claude';
+    this.defaultPermissionMode = opts.defaultPermissionMode ?? 'auto';
+    this.defaultModel = opts.defaultModel;
   }
 
   async isAvailable(): Promise<boolean> {
@@ -120,6 +138,11 @@ export class ClaudeAdapter implements AgentAdapter {
   }
 
   run(opts: AgentRunOptions): AgentRun {
+    // auto mode requires Sonnet 4.6 / Opus 4.6 / Opus 4.7; always pass an
+    // explicit --model so we don't fall onto the CLI's default which may
+    // be an older one. Per-call `opts.model` wins over the adapter default.
+    const model = opts.model ?? this.defaultModel;
+    const permissionMode = opts.permissionMode ?? this.defaultPermissionMode;
     const args = [
       '-p',
       opts.prompt,
@@ -127,12 +150,12 @@ export class ClaudeAdapter implements AgentAdapter {
       'stream-json',
       '--verbose',
       '--permission-mode',
-      opts.permissionMode ?? 'bypassPermissions',
+      permissionMode,
       '--append-system-prompt',
       BRIDGE_SYSTEM_PROMPT,
     ];
     if (opts.sessionId) args.push('--resume', opts.sessionId);
-    if (opts.model) args.push('--model', opts.model);
+    if (model) args.push('--model', model);
 
     const child = spawn(this.binary, args, {
       cwd: opts.cwd,
@@ -145,7 +168,8 @@ export class ClaudeAdapter implements AgentAdapter {
       cwd: opts.cwd ?? process.cwd(),
       hasSession: Boolean(opts.sessionId),
       promptChars: opts.prompt.length,
-      model: opts.model,
+      model,
+      permissionMode,
     });
 
     // Listeners MUST be attached synchronously here, before we return.

--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -22,6 +22,11 @@ export interface ClaudeAdapterOptions {
    * older than Sonnet 4.6 / Opus 4.6 / Opus 4.7).
    */
   defaultModel?: string;
+  /**
+   * Default `--effort` (reasoning effort) when an individual `run()` call
+   * doesn't pass one. One of low/medium/high/xhigh/max.
+   */
+  defaultEffort?: string;
 }
 
 type ClaudeChild = ChildProcessByStdio<null, Readable, Readable>;
@@ -44,6 +49,10 @@ sender_name: ...
 \`\`\`
 
 里面是当前对话的 chat_id、chat 类型（p2p / group）、发送者。这些是 bridge 注入的元数据，**不要照抄、不要在你的回复里渲染**——它对用户不可见。
+
+## 可见回复要求
+
+每一轮都必须返回一段用户可见的正文。不要只输出 thinking / tool call / 空消息；如果用户只是报备进度，也至少用一句话确认收到并给出下一步。
 
 ## quoted_message
 
@@ -122,11 +131,13 @@ export class ClaudeAdapter implements AgentAdapter {
   private readonly binary: string;
   private readonly defaultPermissionMode: PermissionModeValue;
   private readonly defaultModel: string | undefined;
+  private readonly defaultEffort: string | undefined;
 
   constructor(opts: ClaudeAdapterOptions = {}) {
     this.binary = opts.binary ?? 'claude';
     this.defaultPermissionMode = opts.defaultPermissionMode ?? 'auto';
     this.defaultModel = opts.defaultModel;
+    this.defaultEffort = opts.defaultEffort;
   }
 
   async isAvailable(): Promise<boolean> {
@@ -142,6 +153,7 @@ export class ClaudeAdapter implements AgentAdapter {
     // explicit --model so we don't fall onto the CLI's default which may
     // be an older one. Per-call `opts.model` wins over the adapter default.
     const model = opts.model ?? this.defaultModel;
+    const effort = opts.effort ?? this.defaultEffort;
     const permissionMode = opts.permissionMode ?? this.defaultPermissionMode;
     const args = [
       '-p',
@@ -156,6 +168,47 @@ export class ClaudeAdapter implements AgentAdapter {
     ];
     if (opts.sessionId) args.push('--resume', opts.sessionId);
     if (model) args.push('--model', model);
+    if (effort) args.push('--effort', effort);
+
+    // gui: enable desktop automation tools (screenshot / click / type / etc.)
+    // so the bridge can drive native desktop apps when triggered from Feishu —
+    // e.g. the wecom-mail-scan skill for 企业微信邮件. Standard mcpServers via
+    // --mcp-config + explicit tool allowlist. Server is named `gui` rather
+    // than `computer-use` because the CLI reserves the latter for its own
+    // plugin-managed instance; print mode (`claude -p`) doesn't load
+    // plugins, so we declare an independent stdio server here.
+    args.push(
+      '--mcp-config',
+      '/Users/charlesli/code/feishu-claude-code-bridge/bridge-mcp.json',
+    );
+    for (const t of [
+      'request_access',
+      'screenshot',
+      'zoom',
+      'left_click',
+      'double_click',
+      'triple_click',
+      'right_click',
+      'middle_click',
+      'type',
+      'key',
+      'scroll',
+      'left_click_drag',
+      'mouse_move',
+      'open_application',
+      'switch_display',
+      'list_granted_applications',
+      'read_clipboard',
+      'write_clipboard',
+      'wait',
+      'cursor_position',
+      'hold_key',
+      'left_mouse_down',
+      'left_mouse_up',
+      'computer_batch',
+    ]) {
+      args.push('--allowed-tools', `mcp__gui__${t}`);
+    }
 
     const child = spawn(this.binary, args, {
       cwd: opts.cwd,
@@ -169,6 +222,7 @@ export class ClaudeAdapter implements AgentAdapter {
       hasSession: Boolean(opts.sessionId),
       promptChars: opts.prompt.length,
       model,
+      effort,
       permissionMode,
     });
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -13,7 +13,7 @@ export interface AgentRunOptions {
   cwd?: string;
   sessionId?: string;
   model?: string;
-  permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan';
+  permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'auto';
   /**
    * Grace period (ms) between SIGTERM and SIGKILL when stop() is called on
    * the returned run. Lets the agent (and any subprocess it spawned, e.g.

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -13,6 +13,8 @@ export interface AgentRunOptions {
   cwd?: string;
   sessionId?: string;
   model?: string;
+  /** Reasoning effort passed to `claude --effort`: low/medium/high/xhigh/max. */
+  effort?: string;
   permissionMode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan' | 'auto';
   /**
    * Grace period (ms) between SIGTERM and SIGKILL when stop() is called on

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -20,6 +20,7 @@ import { renderText } from '../card/text-renderer';
 import { tryHandleCommand, type Controls } from '../commands';
 import type { AppConfig } from '../config/schema';
 import {
+  getAgentEffort,
   getAgentStopGraceMs,
   getMaxConcurrentRuns,
   getMessageReplyMode,
@@ -510,10 +511,18 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     }
   }
 
+  const scopeEffort = sessions.getEffort(scope);
+  const effort = scopeEffort ?? getAgentEffort(controls.cfg);
+  log.info('flush', 'effort', {
+    effort,
+    source: scopeEffort ? 'session' : 'global',
+  });
+
   const run = agent.run({
     prompt,
     sessionId: resumeFrom,
     cwd,
+    effort,
     stopGraceMs: getAgentStopGraceMs(controls.cfg),
   });
   const handle = activeRuns.register(scope, run);
@@ -720,8 +729,15 @@ async function processAgentStream(
     }
   }
   log.info('card', 'final', { terminal: state.terminal, interrupted: handle.interrupted });
+  if (state.terminal === 'done' && !hasVisibleOutput(state)) {
+    log.warn('agent', 'empty-output', {
+      scope,
+      blocks: state.blocks.length,
+      reasoningChars: state.reasoning.content.length,
+    });
+  }
   await flush(state);
-    // Reap the subprocess. Two regimes:
+  // Reap the subprocess. Two regimes:
   //  - Interrupted (user /stop, idle watchdog, disconnect): stop() was already
   //    fire-and-forgotten by whoever set handle.interrupted; this awaits it.
   //  - Natural done: stream-json emits `result` ~1ms before claude actually
@@ -745,6 +761,13 @@ async function processAgentStream(
  * a stall (the card has already rendered terminal state by this point).
  */
 const POST_DONE_EXIT_GRACE_MS = 2000;
+
+function hasVisibleOutput(state: RunState): boolean {
+  return state.blocks.some((b) => {
+    if (b.kind === 'text') return b.content.trim().length > 0;
+    return true;
+  });
+}
 
 /**
  * For interactive-card messages the SDK flattens to text-bearing nodes or
@@ -822,4 +845,3 @@ function stripAttachmentRefs(text: string, fileKeys: string[]): string {
   }
   return out.replace(/\n{3,}/g, '\n\n');
 }
-

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -128,9 +128,13 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
   // so /config bumps take effect for the next run.
   const pool = new ProcessPool(() => getMaxConcurrentRuns(controls.cfg));
 
+  const apiDomain =
+    cfg.accounts.app.tenant === 'lark'
+      ? 'https://open.larksuite.com'
+      : 'https://open.feishu.cn';
   // Apply network-layer overrides (HTTP timeout + proxy from env). Idempotent;
   // safe to call on every startChannel (used by /account change hot-reload too).
-  const netOverrides = configureNetwork();
+  const netOverrides = configureNetwork({ apiHost: apiDomain });
 
   // Resolve the App Secret to plaintext. The config field can be a literal
   // string, a "${VAR}" template, or a {source, id} SecretRef referencing
@@ -307,13 +311,9 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
   // App-level keepalive: 15s probe + wake-up detection + HTTP reachability.
   // Defense-in-depth — the SDK's pingTimeout watchdog handles half-dead WS,
   // this catches anything that the SDK misses (silent state stuck, etc.).
-  const probeDomain =
-    cfg.accounts.app.tenant === 'lark'
-      ? 'https://open.larksuite.com'
-      : 'https://open.feishu.cn';
   const keepalive = startKeepalive({
     channel,
-    domain: probeDomain,
+    domain: apiDomain,
     forceReconnect: () => controls.restart(),
   });
 

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -503,9 +503,9 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     log.info('session', 'resume', { sessionId: resumeFrom, cwd });
   } else {
     const stale = sessions.getRaw(scope);
-    if (stale && stale.cwd !== cwd) {
+    if (stale?.sessionId && stale.cwd !== cwd) {
       log.info('session', 'stale-cleared', { staleCwd: stale.cwd, newCwd: cwd });
-      sessions.clear(scope);
+      sessions.clearSession(scope);
     } else {
       log.info('session', 'fresh', { cwd });
     }
@@ -726,6 +726,13 @@ async function processAgentStream(
       state = markInterrupted(state);
     } else {
       state = finalizeIfRunning(state);
+    }
+  }
+  if (state.terminal === 'idle_timeout' && !hasVisibleOutput(state)) {
+    const cleared = sessions.clearSession(scope);
+    if (cleared) {
+      log.warn('session', 'cleared-after-idle-timeout', { scope });
+      await sessions.flush();
     }
   }
   log.info('card', 'final', { terminal: state.terminal, interrupted: handle.interrupted });

--- a/src/bot/network-config.ts
+++ b/src/bot/network-config.ts
@@ -10,7 +10,8 @@ const HTTP_TIMEOUT_MS = 30_000;
  *  - **HTTP timeout** — mutate SDK's `defaultHttpInstance.defaults.timeout`
  *    so every outbound REST call gets a 30s cap. Without this a slow API
  *    can hang the whole event-handling thread.
- *  - **HTTP(S) proxy** — if `HTTPS_PROXY` / `HTTP_PROXY` env is set, attach
+ *  - **HTTP(S) proxy** — if `HTTPS_PROXY` / `HTTP_PROXY` env is set and the
+ *    target Feishu/Lark API host is not covered by `NO_PROXY`, attach
  *    `HttpsProxyAgent` to both axios (`defaults.httpsAgent`) and WSClient
  *    (`channel.opts.agent`, returned for caller to spread).
  *
@@ -21,7 +22,12 @@ export interface NetworkOverrides {
   agent?: HttpsProxyAgent<string>;
 }
 
-export function configureNetwork(): NetworkOverrides {
+export interface NetworkOptions {
+  /** Feishu/Lark API host or URL this channel talks to. Used for NO_PROXY. */
+  apiHost?: string;
+}
+
+export function configureNetwork(opts: NetworkOptions = {}): NetworkOverrides {
   // Mutate SDK's axios instance defaults. The exported HttpInstance type
   // hides axios's `defaults` field, but the runtime IS a full axios.
   const ax = defaultHttpInstance as unknown as {
@@ -29,14 +35,65 @@ export function configureNetwork(): NetworkOverrides {
   };
   ax.defaults.timeout = HTTP_TIMEOUT_MS;
 
-  const proxyUrl = process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY;
-  if (!proxyUrl) return {};
+  const proxyUrl = process.env.HTTPS_PROXY
+    ?? process.env.https_proxy
+    ?? process.env.HTTP_PROXY
+    ?? process.env.http_proxy;
+  if (!proxyUrl) {
+    ax.defaults.httpsAgent = undefined;
+    return {};
+  }
+
+  const host = normalizeHost(opts.apiHost);
+  const noProxy = process.env.NO_PROXY ?? process.env.no_proxy ?? '';
+  if (host && shouldBypassProxy(host, noProxy)) {
+    ax.defaults.httpsAgent = undefined;
+    log.info('network', 'proxy-bypassed', { host, noProxy });
+    return {};
+  }
 
   const agent = new HttpsProxyAgent(proxyUrl);
   ax.defaults.httpsAgent = agent;
-  log.info('network', 'proxy-detected', { proxy: redact(proxyUrl) });
+  log.info('network', 'proxy-detected', { proxy: redact(proxyUrl), host });
 
   return { agent };
+}
+
+export function shouldBypassProxy(host: string, noProxy: string): boolean {
+  const normalizedHost = stripPort(host.trim().toLowerCase());
+  if (!normalizedHost) return false;
+  const entries = noProxy
+    .split(',')
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean);
+
+  return entries.some((entry) => {
+    if (entry === '*') return true;
+    const token = stripPort(entry);
+    if (!token) return false;
+    if (token.startsWith('.')) {
+      const suffix = token.slice(1);
+      return normalizedHost === suffix || normalizedHost.endsWith(token);
+    }
+    return normalizedHost === token || normalizedHost.endsWith(`.${token}`);
+  });
+}
+
+function normalizeHost(input: string | undefined): string | undefined {
+  if (!input) return undefined;
+  try {
+    return stripPort(new URL(input).host.toLowerCase());
+  } catch {
+    return stripPort(input.toLowerCase());
+  }
+}
+
+function stripPort(host: string): string {
+  if (host.startsWith('[')) {
+    const end = host.indexOf(']');
+    return end === -1 ? host : host.slice(1, end);
+  }
+  return host.split(':')[0] ?? '';
 }
 
 function redact(url: string): string {

--- a/src/card/config-card.ts
+++ b/src/card/config-card.ts
@@ -1,4 +1,4 @@
-import type { MessageReplyMode } from '../config/schema';
+import type { AgentEffort, MessageReplyMode } from '../config/schema';
 
 export interface ConfigFormOpts {
   messageReply: MessageReplyMode;
@@ -6,6 +6,8 @@ export interface ConfigFormOpts {
   maxConcurrentRuns: number;
   /** 0 means "disabled". */
   runIdleTimeoutMinutes: number;
+  /** Global default reasoning effort. */
+  effort: AgentEffort;
   requireMentionInGroup: boolean;
   /** Comma-separated open_id allowlist; empty string = unrestricted. */
   allowedUsers: string;
@@ -96,6 +98,24 @@ export function configFormCard(opts: ConfigFormOpts): object {
               default_value: String(opts.runIdleTimeoutMinutes),
               placeholder: { tag: 'plain_text', content: '0' },
               input_type: 'text',
+            },
+            {
+              tag: 'markdown',
+              content:
+                '\n**reasoning effort 默认值**\n' +
+                '_控制 Claude Code 每轮思考预算。低 effort 更快更省,高 effort 更适合复杂代码/研究。可被 `/effort` 在单个 session 覆盖_',
+            },
+            {
+              tag: 'select_static',
+              name: 'effort',
+              initial_option: opts.effort,
+              options: [
+                { text: { tag: 'plain_text', content: 'low - 快速/低 reasoning' }, value: 'low' },
+                { text: { tag: 'plain_text', content: 'medium' }, value: 'medium' },
+                { text: { tag: 'plain_text', content: 'high' }, value: 'high' },
+                { text: { tag: 'plain_text', content: 'xhigh - extra high(默认)' }, value: 'xhigh' },
+                { text: { tag: 'plain_text', content: 'max - 最高档' }, value: 'max' },
+              ],
             },
             {
               tag: 'markdown',
@@ -227,6 +247,7 @@ export function configSavedCard(opts: ConfigFormOpts): object {
             `**工具调用显示**:\`${opts.showToolCalls ? 'show' : 'hide'}\`\n` +
             `**并发上限**:\`${opts.maxConcurrentRuns}\`\n` +
             `**run 探活**:\`${opts.runIdleTimeoutMinutes > 0 ? `${opts.runIdleTimeoutMinutes} 分钟` : '关闭'}\`\n` +
+            `**reasoning effort 默认值**:\`${opts.effort}\`\n` +
             `**群里需要 @ bot**:\`${opts.requireMentionInGroup ? '是' : '否'}\`\n\n` +
             '🔒 **访问控制**\n' +
             `**用户白名单**:${summarizeList(opts.allowedUsers)}\n` +

--- a/src/card/run-renderer.ts
+++ b/src/card/run-renderer.ts
@@ -1,4 +1,5 @@
 import type { Block, FooterStatus, RunState, ToolEntry } from './run-state';
+import { EMPTY_AGENT_OUTPUT_TEXT } from './text-renderer';
 import { toolBodyMd, toolHeaderText } from './tool-render';
 
 const REASONING_MAX = 1500;
@@ -39,7 +40,7 @@ export function renderCard(state: RunState): object {
   } else if (state.terminal === 'error' && state.errorMsg) {
     elements.push(noteMd(`⚠️ agent 失败：${state.errorMsg}`));
   } else if (state.terminal === 'done' && elements.length === 0) {
-    elements.push(noteMd('_（未返回内容）_'));
+    elements.push(noteMd(EMPTY_AGENT_OUTPUT_TEXT));
   }
 
   if (state.terminal === 'running') {

--- a/src/card/templates.ts
+++ b/src/card/templates.ts
@@ -100,6 +100,7 @@ export function statusCard(info: StatusInfo): object {
     HR,
     actions([
       { text: '🆕 新会话', value: { cmd: 'new' }, style: 'primary' },
+      { text: '🧹 压缩上下文', value: { cmd: 'compact' } },
       { text: '🔁 恢复会话', value: { cmd: 'resume' } },
       { text: '📂 工作空间', value: { cmd: 'ws.list' } },
       { text: '💡 帮助', value: { cmd: 'help' } },
@@ -155,6 +156,7 @@ export function helpCard(): object {
         '**命令列表**',
         '',
         '- `/new` `/reset` — 清空当前 chat 的会话',
+        '- `/compact [说明]` — 压缩当前 Claude session 的上下文，继续使用同一个 session',
         '- `/new chat [name]` — 新建群+新会话，自动拉你进群',
         '- `/resume [N]` — 列出并恢复历史会话（最多 N 条）',
         '- `/cd <path>` — 切换工作目录（会重置 session）',
@@ -177,6 +179,7 @@ export function helpCard(): object {
     HR,
     actions([
       { text: '📊 状态', value: { cmd: 'status' }, style: 'primary' },
+      { text: '🧹 压缩上下文', value: { cmd: 'compact' } },
       { text: '🔁 恢复会话', value: { cmd: 'resume' } },
       { text: '📂 工作空间', value: { cmd: 'ws.list' } },
       { text: '🆕 新会话', value: { cmd: 'new' } },

--- a/src/card/templates.ts
+++ b/src/card/templates.ts
@@ -1,3 +1,5 @@
+import type { AgentEffort } from '../config/schema';
+
 interface ButtonSpec {
   text: string;
   value: Record<string, unknown>;
@@ -70,6 +72,8 @@ export interface StatusInfo {
   scope: string;
   /** Chat mode — used to label scope. */
   chatMode: 'p2p' | 'group' | 'topic';
+  effort: AgentEffort;
+  effortSource: 'session' | 'global';
 }
 
 export function statusCard(info: StatusInfo): object {
@@ -82,10 +86,13 @@ export function statusCard(info: StatusInfo): object {
     info.chatMode === 'topic'
       ? `\`${escapeCode(info.scope)}\` _（话题独立 session）_`
       : `\`${escapeCode(info.scope)}\``;
+  const effortSource =
+    info.effortSource === 'session' ? '_（session 覆盖）_' : '_（全局默认）_';
   const lines = [
     `🧭 **scope**: ${scopeLine}`,
     `📁 **cwd**: \`${escapeCode(info.cwd)}\``,
     `🔗 **session**: ${sessionLine}`,
+    `🧠 **effort**: \`${info.effort}\` ${effortSource}`,
     `🤖 **agent**: ${escapeMd(info.agentName)}`,
   ];
   return shell('📊 当前状态', [
@@ -156,6 +163,7 @@ export function helpCard(): object {
         '- `/config` — 调整偏好（消息回复方式、工具调用显示）',
         '- `/status` — 当前状态',
         '- `/stop` — 结束当前正在跑的任务（也可点卡片底部 ⏹ 终止 按钮）',
+        '- `/effort [low|medium|high|xhigh|max|default]` — 当前 session 的 reasoning effort；`/new low` 可新会话同时设低 effort',
         '- `/timeout [N|off|default]` — 当前 session 的探活分钟数,`/config` 改全局默认',
         '- `/ps` — 列出本机所有 bot,标识当前正在回复的那个',
         '- `/exit <id|#>` — 关掉指定 bot(用 `/ps` 看 id/序号)',

--- a/src/card/text-renderer.ts
+++ b/src/card/text-renderer.ts
@@ -1,6 +1,9 @@
 import type { Block, RunState, ToolEntry } from './run-state';
 import { toolHeaderText } from './tool-render';
 
+export const EMPTY_AGENT_OUTPUT_TEXT =
+  '⚠️ Claude 本轮没有返回可见文本。bridge 已收到你的消息,可以直接重发或发 `/reset` 开新会话后重试。';
+
 /**
  * Render `RunState` as plain markdown text — used in `messageReply: 'text'`
  * mode where we stream a markdown message instead of a card.
@@ -26,6 +29,8 @@ export function renderText(state: RunState): string {
     parts.push(`_⏱ ${mins} 分钟无响应,已自动终止_`);
   } else if (state.terminal === 'error' && state.errorMsg) {
     parts.push(`⚠️ agent 失败:${state.errorMsg}`);
+  } else if (state.terminal === 'done' && parts.length === 0) {
+    parts.push(EMPTY_AGENT_OUTPUT_TEXT);
   } else if (state.terminal === 'running' && state.footer) {
     parts.push(footerLine(state.footer));
   }

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -8,7 +8,7 @@ import type { Controls } from '../../commands';
 import { setSecret } from '../../config/keystore';
 import { paths } from '../../config/paths';
 import type { AppConfig } from '../../config/schema';
-import { isComplete, secretKeyForApp } from '../../config/schema';
+import { getAgentModel, getPermissionMode, isComplete, secretKeyForApp } from '../../config/schema';
 import {
   buildEncryptedAccountConfig,
   ensureSecretsGetterWrapper,
@@ -76,7 +76,10 @@ export async function runStart(opts: StartOptions): Promise<void> {
 
   await preFlightChecks({ skipCheckLarkCli: opts.skipCheckLarkCli });
 
-  const agent = new ClaudeAdapter();
+  const agent = new ClaudeAdapter({
+    defaultPermissionMode: getPermissionMode(cfg),
+    defaultModel: getAgentModel(cfg),
+  });
   if (!(await agent.isAvailable())) {
     console.error('✗ 未找到 claude CLI。请先安装 Claude Code：');
     console.error('  https://docs.anthropic.com/en/docs/claude-code/quickstart');

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -8,7 +8,7 @@ import type { Controls } from '../../commands';
 import { setSecret } from '../../config/keystore';
 import { paths } from '../../config/paths';
 import type { AppConfig } from '../../config/schema';
-import { getAgentModel, getPermissionMode, isComplete, secretKeyForApp } from '../../config/schema';
+import { getAgentEffort, getAgentModel, getPermissionMode, isComplete, secretKeyForApp } from '../../config/schema';
 import {
   buildEncryptedAccountConfig,
   ensureSecretsGetterWrapper,
@@ -79,6 +79,7 @@ export async function runStart(opts: StartOptions): Promise<void> {
   const agent = new ClaudeAdapter({
     defaultPermissionMode: getPermissionMode(cfg),
     defaultModel: getAgentModel(cfg),
+    defaultEffort: getAgentEffort(cfg),
   });
   if (!(await agent.isAvailable())) {
     console.error('✗ 未找到 claude CLI。请先安装 Claude Code：');

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -12,8 +12,9 @@ import {
 import { configCancelledCard, configFormCard, configSavedCard } from '../card/config-card';
 import { forgetManagedCard, sendManagedCard, updateManagedCard } from '../card/managed';
 import { helpCard, resumeCard, statusCard, workspacesCard } from '../card/templates';
-import type { AppConfig, MessageReplyMode, TenantBrand } from '../config/schema';
+import type { AgentEffort, AppConfig, MessageReplyMode, TenantBrand } from '../config/schema';
 import {
+  getAgentEffort,
   getAgentStopGraceMs,
   getMaxConcurrentRuns,
   getMessageReplyMode,
@@ -21,6 +22,7 @@ import {
   getRunIdleTimeoutMs,
   getShowToolCalls,
   isAdmin,
+  normalizeAgentEffort,
   secretKeyForApp,
 } from '../config/schema';
 import { setSecret } from '../config/keystore';
@@ -97,6 +99,7 @@ const handlers: Record<string, Handler> = {
   '/account': handleAccount,
   '/config': handleConfig,
   '/stop': handleStop,
+  '/effort': handleEffort,
   '/timeout': handleTimeout,
   '/ps': handlePs,
   '/exit': handleExit,
@@ -194,22 +197,85 @@ function expandTilde(p: string): string {
   return p;
 }
 
+const EFFORT_USAGE =
+  '用法:`/effort [low|medium|high|xhigh|max|default]` 或 `/new [low|medium|high|xhigh|max]`';
+
+function formatEffort(effort: AgentEffort): string {
+  switch (effort) {
+    case 'low':
+      return '`low`（最快/最低 reasoning）';
+    case 'medium':
+      return '`medium`';
+    case 'high':
+      return '`high`';
+    case 'xhigh':
+      return '`xhigh`（extra high）';
+    case 'max':
+      return '`max`（本机 Claude Code 最高档）';
+  }
+}
+
+function effortAliasNote(raw: string, effort: AgentEffort): string {
+  const normalized = raw.trim().toLowerCase().replace(/[\s_]+/g, '-');
+  return normalized && normalized !== effort ? `（已将 \`${raw.trim()}\` 映射为 \`${effort}\`）` : '';
+}
+
+function parseNewEffortArg(trimmed: string): {
+  effort?: AgentEffort;
+  explicitDefault?: boolean;
+  invalid?: boolean;
+  raw?: string;
+} {
+  if (!trimmed) return {};
+  const lower = trimmed.toLowerCase();
+  const raw = lower === 'effort' || lower.startsWith('effort ')
+    ? trimmed.slice('effort'.length).trim()
+    : trimmed;
+  if (!raw) return { invalid: true, raw };
+  if (raw.toLowerCase() === 'default') return { explicitDefault: true, raw };
+  const effort = normalizeAgentEffort(raw);
+  return effort ? { effort, raw } : { invalid: true, raw };
+}
+
 async function handleNew(args: string, ctx: CommandContext): Promise<void> {
   const trimmed = args.trim();
+  const lower = trimmed.toLowerCase();
 
   // /new chat [name]  — spin up a fresh group chat bound to a fresh session
-  if (trimmed === 'chat' || trimmed.startsWith('chat ')) {
+  if (lower === 'chat' || lower.startsWith('chat ')) {
     const rawName = trimmed === 'chat' ? '' : trimmed.slice(5).trim();
     return handleNewChat(rawName, ctx);
   }
 
+  const requestedEffort = parseNewEffortArg(trimmed);
+  if (requestedEffort.invalid) {
+    await reply(ctx, `❌ ${EFFORT_USAGE}\n\n示例:\`/new low\`、\`/new effort max\`、\`/new\``);
+    return;
+  }
+
   const wasRunning = ctx.activeRuns.interrupt(ctx.scope);
   ctx.sessions.clear(ctx.scope);
-  await reply(ctx, wasRunning ? '已中断当前任务并开始新会话。' : '已开始新会话。');
+  if (requestedEffort.effort) {
+    ctx.sessions.setEffort(ctx.scope, requestedEffort.effort);
+    log.info('command', 'new-effort-set', {
+      scope: ctx.scope,
+      effort: requestedEffort.effort,
+    });
+  }
+  const effortLine = requestedEffort.effort
+    ? `\neffort: ${formatEffort(requestedEffort.effort)}${effortAliasNote(requestedEffort.raw ?? '', requestedEffort.effort)}`
+    : requestedEffort.explicitDefault
+      ? `\neffort: 跟随全局(${formatEffort(getAgentEffort(ctx.controls.cfg))})`
+      : '';
+  await reply(
+    ctx,
+    `${wasRunning ? '已中断当前任务并开始新会话。' : '已开始新会话。'}${effortLine}`,
+  );
 }
 
 async function handleNewChat(rawName: string, ctx: CommandContext): Promise<void> {
   const sourceCwd = ctx.workspaces.cwdFor(ctx.scope);
+  const sourceEffort = ctx.sessions.getEffort(ctx.scope);
   const name = rawName || defaultChatName();
 
   let created;
@@ -230,13 +296,17 @@ async function handleNewChat(rawName: string, ctx: CommandContext): Promise<void
   if (sourceCwd) {
     ctx.workspaces.setCwd(created.chatId, sourceCwd);
   }
+  if (sourceEffort) {
+    ctx.sessions.setEffort(created.chatId, sourceEffort);
+  }
 
   // Welcome the user inside the new group with a hint about how to start.
+  const effortLine = sourceEffort ? `\neffort 继承为 ${formatEffort(sourceEffort)}` : '';
   const welcome = sourceCwd
     ? `🎉 群已建好，cwd 继承自原群：\`${sourceCwd}\`\n\n@我 + 任意消息开始对话。`
     : '🎉 群已建好。\n\n@我 + 任意消息开始对话。';
   try {
-    await ctx.channel.send(created.chatId, { markdown: welcome });
+    await ctx.channel.send(created.chatId, { markdown: `${welcome}${effortLine}` });
   } catch (err) {
     console.warn('[new-chat] welcome message failed:', err);
   }
@@ -383,6 +453,7 @@ async function applyResume(sessionId: string, ctx: CommandContext): Promise<void
 async function handleStatus(_args: string, ctx: CommandContext): Promise<void> {
   const cwd = ctx.workspaces.cwdFor(ctx.scope) ?? homedir();
   const sess = ctx.sessions.getRaw(ctx.scope);
+  const sessionEffort = ctx.sessions.getEffort(ctx.scope);
   const card = statusCard({
     cwd,
     sessionId: sess?.sessionId,
@@ -390,6 +461,8 @@ async function handleStatus(_args: string, ctx: CommandContext): Promise<void> {
     agentName: ctx.agent.displayName,
     scope: ctx.scope,
     chatMode: ctx.chatMode,
+    effort: sessionEffort ?? getAgentEffort(ctx.controls.cfg),
+    effortSource: sessionEffort ? 'session' : 'global',
   });
   await ctx.channel.send(ctx.msg.chatId, { card }, { replyTo: ctx.msg.messageId });
 }
@@ -399,6 +472,61 @@ async function handleStop(_args: string, ctx: CommandContext): Promise<void> {
   log.info('command', 'stop', { interrupted: ok });
   // No reply: if there was a run, its in-flight render loop will mark the
   // card as 'interrupted' and re-render (`_⏹ 已被中断_`).
+}
+
+async function handleEffort(args: string, ctx: CommandContext): Promise<void> {
+  const raw = args.trim();
+  const trimmed = raw.toLowerCase();
+  const globalEffort = getAgentEffort(ctx.controls.cfg);
+
+  if (!trimmed) {
+    const sessionEffort = ctx.sessions.getEffort(ctx.scope);
+    const usage = [
+      '',
+      '用法:',
+      '- `/effort low` 当前 session 设低 reasoning,适合快速聊天/健身记录',
+      '- `/effort high` 或 `/effort xhigh` 当前 session 提高 reasoning',
+      '- `/effort max` 当前 session 使用本机最高档',
+      '- `/effort default` 清除 session 覆盖,回退全局',
+      '- `/new low` 新会话并同时设低 effort',
+      '',
+      '_别名:`extra high` → `xhigh`;`ultra` → `max`_',
+    ].join('\n');
+    if (sessionEffort) {
+      await reply(
+        ctx,
+        `🧠 当前 session effort:${formatEffort(sessionEffort)}\n全局默认:${formatEffort(globalEffort)}${usage}`,
+      );
+      return;
+    }
+    await reply(ctx, `🧠 当前 session effort:跟随全局(${formatEffort(globalEffort)})${usage}`);
+    return;
+  }
+
+  if (trimmed === 'default') {
+    const cleared = ctx.sessions.clearEffortOverride(ctx.scope);
+    log.info('command', 'effort-clear', { scope: ctx.scope, cleared });
+    await reply(
+      ctx,
+      cleared
+        ? `✅ 已清除 session effort 覆盖,回退到全局(${formatEffort(globalEffort)})。`
+        : `当前 session 本来就没设过 effort 覆盖,跟随全局(${formatEffort(globalEffort)})。`,
+    );
+    return;
+  }
+
+  const effort = normalizeAgentEffort(raw);
+  if (!effort) {
+    await reply(ctx, `❌ ${EFFORT_USAGE}\n\n别名:\`extra high\` = \`xhigh\`,\`ultra\` = \`max\``);
+    return;
+  }
+
+  ctx.sessions.setEffort(ctx.scope, effort);
+  log.info('command', 'effort-set', { scope: ctx.scope, effort });
+  await reply(
+    ctx,
+    `✅ 当前 session effort 已设为 ${formatEffort(effort)}${effortAliasNote(raw, effort)}。\n下条消息开始生效。`,
+  );
 }
 
 async function handleTimeout(args: string, ctx: CommandContext): Promise<void> {
@@ -625,6 +753,7 @@ async function handleDoctor(args: string, ctx: CommandContext): Promise<void> {
   const run = ctx.agent.run({
     prompt,
     cwd: homedir(),
+    effort: getAgentEffort(ctx.controls.cfg),
     stopGraceMs: getAgentStopGraceMs(ctx.controls.cfg),
   });
   const handle = ctx.activeRuns.register(ctx.scope, run);
@@ -896,6 +1025,7 @@ async function showConfigForm(ctx: CommandContext): Promise<void> {
     showToolCalls: getShowToolCalls(ctx.controls.cfg),
     maxConcurrentRuns: getMaxConcurrentRuns(ctx.controls.cfg),
     runIdleTimeoutMinutes: ms ? Math.round(ms / 60_000) : 0,
+    effort: getAgentEffort(ctx.controls.cfg),
     requireMentionInGroup: getRequireMentionInGroup(ctx.controls.cfg),
     allowedUsers: (access.allowedUsers ?? []).join(', '),
     allowedChats: (access.allowedChats ?? []).join(', '),
@@ -958,6 +1088,10 @@ async function submitConfig(ctx: CommandContext): Promise<void> {
   if (rawRequireMention === 'yes') requireMentionInGroup = true;
   else if (rawRequireMention === 'no') requireMentionInGroup = false;
   else requireMentionInGroup = getRequireMentionInGroup(ctx.controls.cfg);
+  // Parse global default effort. Empty / unexpected keeps current.
+  const rawEffort = String(fv.effort ?? '').trim();
+  const currentEffort = getAgentEffort(ctx.controls.cfg);
+  const effort = rawEffort ? normalizeAgentEffort(rawEffort) ?? currentEffort : currentEffort;
 
   // Parse access lists. Comma-separated; trim each, drop empties, dedupe.
   // Empty list = unrestricted (back-compat).
@@ -1044,6 +1178,7 @@ async function submitConfig(ctx: CommandContext): Promise<void> {
       showToolCalls,
       maxConcurrentRuns,
       runIdleTimeoutMinutes,
+      effort,
       requireMentionInGroup,
       // Empty arrays serialize fine but read identically to omitted ones
       // (isUserAllowed / isAdmin both treat length===0 as unrestricted).
@@ -1065,6 +1200,7 @@ async function submitConfig(ctx: CommandContext): Promise<void> {
       showToolCalls,
       maxConcurrentRuns,
       runIdleTimeoutMinutes,
+      effort,
       requireMentionInGroup,
       allowedUsersCount: allowedUsers.length,
       allowedChatsCount: allowedChats.length,
@@ -1079,6 +1215,7 @@ async function submitConfig(ctx: CommandContext): Promise<void> {
         showToolCalls,
         maxConcurrentRuns,
         runIdleTimeoutMinutes,
+        effort,
         requireMentionInGroup,
         allowedUsers: allowedUsers.join(', '),
         allowedChats: allowedChats.join(', '),

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -100,6 +100,7 @@ const handlers: Record<string, Handler> = {
   '/config': handleConfig,
   '/stop': handleStop,
   '/effort': handleEffort,
+  '/compact': handleCompact,
   '/timeout': handleTimeout,
   '/ps': handlePs,
   '/exit': handleExit,
@@ -199,6 +200,8 @@ function expandTilde(p: string): string {
 
 const EFFORT_USAGE =
   '用法:`/effort [low|medium|high|xhigh|max|default]` 或 `/new [low|medium|high|xhigh|max]`';
+
+const COMMAND_POST_DONE_EXIT_GRACE_MS = 2000;
 
 function formatEffort(effort: AgentEffort): string {
   switch (effort) {
@@ -448,6 +451,111 @@ async function applyResume(sessionId: string, ctx: CommandContext): Promise<void
     ctx,
     `✓ 已恢复会话 \`${sessionId.slice(0, 8)}…\`。接着发消息就行。`,
   );
+}
+
+async function handleCompact(args: string, ctx: CommandContext): Promise<void> {
+  const cwd = ctx.workspaces.cwdFor(ctx.scope) ?? homedir();
+  const sessionId = ctx.sessions.resumeFor(ctx.scope, cwd);
+  const rawSession = ctx.sessions.getRaw(ctx.scope);
+
+  if (!sessionId) {
+    if (rawSession?.sessionId && rawSession.cwd !== cwd) {
+      await reply(
+        ctx,
+        `当前 session 绑定在旧 cwd：\`${rawSession.cwd ?? '(unknown)'}\`。\n当前 cwd 是：\`${cwd}\`。\n先用 \`/status\` 检查，或 \`/resume\` 选择要恢复的 session。`,
+      );
+      return;
+    }
+    await reply(ctx, '当前 chat 还没有可压缩的 Claude session。先正常发一条消息，或用 `/resume` 恢复历史 session。');
+    return;
+  }
+
+  const wasRunning = ctx.activeRuns.interrupt(ctx.scope);
+  if (wasRunning) {
+    await new Promise((resolve) => setTimeout(resolve, 300));
+  }
+
+  const prompt = args.trim() ? `/compact ${args.trim()}` : '/compact';
+  const effort = ctx.sessions.getEffort(ctx.scope) ?? getAgentEffort(ctx.controls.cfg);
+  log.info('command', 'compact-start', {
+    scope: ctx.scope,
+    sessionId,
+    hasInstructions: args.trim().length > 0,
+    interrupted: wasRunning,
+    effort,
+  });
+
+  const run = ctx.agent.run({
+    prompt,
+    sessionId,
+    cwd,
+    effort,
+    stopGraceMs: getAgentStopGraceMs(ctx.controls.cfg),
+  });
+  const handle = ctx.activeRuns.register(ctx.scope, run);
+
+  try {
+    await ctx.channel.stream(
+      ctx.msg.chatId,
+      {
+        card: {
+          initial: renderCard(initialState),
+          producer: async (ctrl) => {
+            let state: RunState = initialState;
+            const flush = (): Promise<void> => ctrl.update(renderCard(state));
+
+            for await (const evt of handle.run.events) {
+              if (handle.interrupted) break;
+              if (evt.type === 'system') {
+                if (evt.sessionId) {
+                  const effectiveCwd = evt.cwd ?? cwd;
+                  ctx.sessions.set(ctx.scope, evt.sessionId, effectiveCwd);
+                  log.info('session', 'set', {
+                    step: 'compact',
+                    sessionId: evt.sessionId,
+                  });
+                }
+                continue;
+              }
+              if (evt.type === 'usage') {
+                if (evt.costUsd !== undefined) {
+                  log.info('agent', 'usage', {
+                    step: 'compact',
+                    costUsd: Number(evt.costUsd.toFixed(4)),
+                  });
+                }
+                continue;
+              }
+              state = reduce(state, evt);
+              await flush();
+              if (state.terminal !== 'running') break;
+            }
+
+            state = handle.interrupted ? markInterrupted(state) : finalizeIfRunning(state);
+            await flush();
+
+            if (handle.interrupted) {
+              await handle.run.stop();
+            } else {
+              const exited = await handle.run.waitForExit(COMMAND_POST_DONE_EXIT_GRACE_MS);
+              if (!exited) {
+                log.warn('agent', 'post-done-timeout', {
+                  step: 'compact',
+                  graceMs: COMMAND_POST_DONE_EXIT_GRACE_MS,
+                });
+                await handle.run.stop();
+              }
+            }
+          },
+        },
+      },
+      { replyTo: ctx.msg.messageId },
+    );
+  } catch (err) {
+    log.fail('command', err, { step: 'compact' });
+  } finally {
+    ctx.activeRuns.unregister(ctx.scope, run);
+  }
 }
 
 async function handleStatus(_args: string, ctx: CommandContext): Promise<void> {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -69,6 +69,28 @@ export interface SecretsConfig {
 export type MessageReplyMode = 'card' | 'markdown' | 'text';
 
 /**
+ * Permission mode passed to the spawned `claude` CLI via `--permission-mode`.
+ *
+ *   - `auto` (the bridge default): Claude Code's safety classifier reviews
+ *     each tool call. Safe ops auto-run; risky ops (curl|bash, mass
+ *     delete, exfil, force-push main, etc.) are blocked and Claude is
+ *     asked to try something else. Requires Sonnet 4.6 / Opus 4.6 / Opus
+ *     4.7 and direct Anthropic API. In headless mode (which is what the
+ *     bridge runs) the session aborts after 3 consecutive or 20
+ *     cumulative blocks — a useful safety net for a remote-driven bot.
+ *   - `bypassPermissions`: pre-auto behavior; skips all permission checks.
+ *   - `acceptEdits`: edits auto-approved, Bash still prompts (and in
+ *     headless mode, gets denied).
+ *   - `default` / `plan`: prompt-based — not useful for a headless bot.
+ */
+export type PermissionMode =
+  | 'default'
+  | 'acceptEdits'
+  | 'bypassPermissions'
+  | 'plan'
+  | 'auto';
+
+/**
  * Access control settings. All three lists default to "no restriction" when
  * empty / undefined, so existing deployments are not broken on upgrade.
  * Operators that want a hardened deployment fill these in via
@@ -141,6 +163,18 @@ export interface AppPreferences {
    * Range 100-30000; out-of-range values fall back to default.
    */
   agentStopGraceMs?: number;
+  /**
+   * Permission mode passed to spawned `claude`. Default `'auto'` (safety
+   * classifier reviews each tool call). See `PermissionMode` for tradeoffs.
+   */
+  permissionMode?: PermissionMode;
+  /**
+   * Model passed to `claude --model`. Default `'claude-opus-4-7'`. Must be
+   * Sonnet 4.6 / Opus 4.6 / Opus 4.7 if `permissionMode` is `'auto'` (older
+   * models reject the auto classifier). Set to a cheaper model (e.g.
+   * `'claude-sonnet-4-6'`) to reduce token spend on a long-running bot.
+   */
+  model?: string;
 }
 
 /**
@@ -239,6 +273,40 @@ export function getAgentStopGraceMs(cfg: AppConfig): number {
   const raw = cfg.preferences?.agentStopGraceMs;
   if (typeof raw !== 'number' || !Number.isFinite(raw)) return 5000;
   return Math.min(30_000, Math.max(100, Math.floor(raw)));
+}
+
+const VALID_PERMISSION_MODES: ReadonlySet<PermissionMode> = new Set([
+  'default',
+  'acceptEdits',
+  'bypassPermissions',
+  'plan',
+  'auto',
+]);
+
+/**
+ * Resolve the permission mode passed to `claude --permission-mode`.
+ * Defaults to `'auto'` so the bridge runs with the safety classifier on
+ * out of the box. Unknown values fall back to the default rather than
+ * silently letting a typo turn into `bypassPermissions`.
+ */
+export function getPermissionMode(cfg: AppConfig): PermissionMode {
+  const raw = cfg.preferences?.permissionMode;
+  if (typeof raw === 'string' && VALID_PERMISSION_MODES.has(raw as PermissionMode)) {
+    return raw as PermissionMode;
+  }
+  return 'auto';
+}
+
+/**
+ * Resolve the model passed to `claude --model`. Defaults to
+ * `'claude-opus-4-7'` — auto mode requires Sonnet 4.6+, and Opus 4.7
+ * matches what most users run locally. Empty/whitespace falls back to
+ * default.
+ */
+export function getAgentModel(cfg: AppConfig): string {
+  const raw = cfg.preferences?.model;
+  if (typeof raw === 'string' && raw.trim().length > 0) return raw.trim();
+  return 'claude-opus-4-7';
 }
 
 /** True when `senderId` may interact with the bot. Empty list = allow all. */

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -90,6 +90,8 @@ export type PermissionMode =
   | 'plan'
   | 'auto';
 
+export type AgentEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
 /**
  * Access control settings. All three lists default to "no restriction" when
  * empty / undefined, so existing deployments are not broken on upgrade.
@@ -175,6 +177,12 @@ export interface AppPreferences {
    * `'claude-sonnet-4-6'`) to reduce token spend on a long-running bot.
    */
   model?: string;
+  /**
+   * Reasoning effort passed to `claude --effort`. One of
+   * `low` / `medium` / `high` / `xhigh` / `max`. Default `'xhigh'`.
+   * Higher = more thinking budget per turn (stronger reasoning, more tokens).
+   */
+  effort?: string;
 }
 
 /**
@@ -307,6 +315,47 @@ export function getAgentModel(cfg: AppConfig): string {
   const raw = cfg.preferences?.model;
   if (typeof raw === 'string' && raw.trim().length > 0) return raw.trim();
   return 'claude-opus-4-7';
+}
+
+const VALID_EFFORT_LEVELS: ReadonlySet<AgentEffort> = new Set([
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+]);
+
+const EFFORT_ALIASES: Record<string, AgentEffort> = {
+  xh: 'xhigh',
+  'x-high': 'xhigh',
+  xhigh: 'xhigh',
+  extra: 'xhigh',
+  extrahigh: 'xhigh',
+  'extra-high': 'xhigh',
+  ultrahigh: 'max',
+  'ultra-high': 'max',
+  ultra: 'max',
+};
+
+export function normalizeAgentEffort(raw: string): AgentEffort | undefined {
+  const normalized = raw.trim().toLowerCase().replace(/[\s_]+/g, '-');
+  if (!normalized) return undefined;
+  if (VALID_EFFORT_LEVELS.has(normalized as AgentEffort)) {
+    return normalized as AgentEffort;
+  }
+  return EFFORT_ALIASES[normalized] ?? EFFORT_ALIASES[normalized.replace(/-/g, '')];
+}
+
+/**
+ * Resolve the reasoning effort passed to `claude --effort`. Defaults to
+ * `'xhigh'` (extra-high — one notch below `max`) so the bridge reasons hard
+ * out of the box. Unknown values fall back to the default rather than letting
+ * a typo silently weaken reasoning.
+ */
+export function getAgentEffort(cfg: AppConfig): AgentEffort {
+  const raw = cfg.preferences?.effort;
+  if (typeof raw === 'string') return normalizeAgentEffort(raw) ?? 'xhigh';
+  return 'xhigh';
 }
 
 /** True when `senderId` may interact with the bot. Empty list = allow all. */

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { paths } from '../config/paths';
+import { normalizeAgentEffort, type AgentEffort } from '../config/schema';
 import { log } from '../core/logger';
 
 export interface SessionEntry {
@@ -14,6 +15,8 @@ export interface SessionEntry {
    * scope, undefined = follow global default. /new clears the whole entry,
    * so this resets to "follow global" when the user starts a new session. */
   idleTimeoutMinutes?: number;
+  /** Per-scope reasoning effort override. Undefined = follow global default. */
+  effort?: AgentEffort;
 }
 
 type SessionMap = Record<string, SessionEntry>;
@@ -43,13 +46,16 @@ export class SessionStore {
         const cwd = typeof entry.cwd === 'string' ? entry.cwd : undefined;
         const idleTimeoutMinutes =
           typeof entry.idleTimeoutMinutes === 'number' ? entry.idleTimeoutMinutes : undefined;
+        const effort =
+          typeof entry.effort === 'string' ? normalizeAgentEffort(entry.effort) : undefined;
         const hasSession = sessionId !== undefined && cwd !== undefined;
-        if (!hasSession && idleTimeoutMinutes === undefined) continue;
+        if (!hasSession && idleTimeoutMinutes === undefined && effort === undefined) continue;
         this.data[chatId] = {
           ...(sessionId !== undefined ? { sessionId } : {}),
           ...(cwd !== undefined ? { cwd } : {}),
           updatedAt: entry.updatedAt,
           ...(idleTimeoutMinutes !== undefined ? { idleTimeoutMinutes } : {}),
+          ...(effort !== undefined ? { effort } : {}),
         };
       }
     } catch (err) {
@@ -75,8 +81,8 @@ export class SessionStore {
   }
 
   set(chatId: string, sessionId: string, cwd: string): void {
-    // Preserve idleTimeoutMinutes across run starts — it's a per-scope
-    // preference, not per-run-instance state. /new (clear) wipes it.
+    // Preserve per-scope preferences across run starts — they are not
+    // per-run-instance state. /new (clear) wipes them.
     const prev = this.data[chatId];
     this.data[chatId] = {
       sessionId,
@@ -85,6 +91,7 @@ export class SessionStore {
       ...(prev?.idleTimeoutMinutes !== undefined
         ? { idleTimeoutMinutes: prev.idleTimeoutMinutes }
         : {}),
+      ...(prev?.effort !== undefined ? { effort: prev.effort } : {}),
     };
     this.schedulePersist();
   }
@@ -117,6 +124,32 @@ export class SessionStore {
     const prev = this.data[chatId];
     if (!prev || prev.idleTimeoutMinutes === undefined) return false;
     const { idleTimeoutMinutes: _, ...rest } = prev;
+    this.data[chatId] = { ...rest, updatedAt: Date.now() };
+    this.schedulePersist();
+    return true;
+  }
+
+  /** Per-scope effort override. `undefined` means no override set. */
+  getEffort(chatId: string): AgentEffort | undefined {
+    return this.data[chatId]?.effort;
+  }
+
+  setEffort(chatId: string, effort: AgentEffort): void {
+    const prev = this.data[chatId];
+    this.data[chatId] = {
+      ...(prev ?? { updatedAt: Date.now() }),
+      effort,
+      updatedAt: Date.now(),
+    };
+    this.schedulePersist();
+  }
+
+  /** Remove the effort override so this scope falls back to the global default.
+   * Returns true if something was actually removed. */
+  clearEffortOverride(chatId: string): boolean {
+    const prev = this.data[chatId];
+    if (!prev || prev.effort === undefined) return false;
+    const { effort: _, ...rest } = prev;
     this.data[chatId] = { ...rest, updatedAt: Date.now() };
     this.schedulePersist();
     return true;

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -102,6 +102,22 @@ export class SessionStore {
     this.schedulePersist();
   }
 
+  /** Clear only the resumable Claude session identity, preserving per-scope
+   * preferences such as effort and timeout overrides. */
+  clearSession(chatId: string): boolean {
+    const prev = this.data[chatId];
+    if (!prev || (prev.sessionId === undefined && prev.cwd === undefined)) return false;
+
+    const { sessionId: _sessionId, cwd: _cwd, ...rest } = prev;
+    if (rest.idleTimeoutMinutes === undefined && rest.effort === undefined) {
+      delete this.data[chatId];
+    } else {
+      this.data[chatId] = { ...rest, updatedAt: Date.now() };
+    }
+    this.schedulePersist();
+    return true;
+  }
+
   /** Per-scope idle-timeout override. `undefined` means no override set. */
   getIdleTimeoutMinutes(chatId: string): number | undefined {
     return this.data[chatId]?.idleTimeoutMinutes;

--- a/test/effort.test.ts
+++ b/test/effort.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  getAgentEffort,
+  normalizeAgentEffort,
+  type AppConfig,
+} from '../src/config/schema';
+import { SessionStore } from '../src/session/store';
+
+const tempDirs: string[] = [];
+
+async function tempSessionFile(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'bridge-effort-test-'));
+  tempDirs.push(dir);
+  return join(dir, 'sessions.json');
+}
+
+function minimalConfig(effort?: string): AppConfig {
+  return {
+    accounts: {
+      app: {
+        id: 'cli_test',
+        secret: 'secret',
+        tenant: 'feishu',
+      },
+    },
+    preferences: effort ? { effort } : {},
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+describe('agent effort normalization', () => {
+  it('accepts Claude Code supported effort levels', () => {
+    expect(normalizeAgentEffort('low')).toBe('low');
+    expect(normalizeAgentEffort('medium')).toBe('medium');
+    expect(normalizeAgentEffort('high')).toBe('high');
+    expect(normalizeAgentEffort('xhigh')).toBe('xhigh');
+    expect(normalizeAgentEffort('max')).toBe('max');
+  });
+
+  it('maps user-friendly aliases to supported Claude Code levels', () => {
+    expect(normalizeAgentEffort('extra high')).toBe('xhigh');
+    expect(normalizeAgentEffort('extra-high')).toBe('xhigh');
+    expect(normalizeAgentEffort('x_high')).toBe('xhigh');
+    expect(normalizeAgentEffort('ultra')).toBe('max');
+    expect(normalizeAgentEffort('ultra high')).toBe('max');
+  });
+
+  it('falls back to xhigh for invalid global config values', () => {
+    expect(getAgentEffort(minimalConfig('low'))).toBe('low');
+    expect(getAgentEffort(minimalConfig('not-a-level'))).toBe('xhigh');
+    expect(getAgentEffort(minimalConfig())).toBe('xhigh');
+  });
+});
+
+describe('SessionStore effort override', () => {
+  it('persists effort-only entries and reloads them', async () => {
+    const file = await tempSessionFile();
+    const store = new SessionStore(file);
+
+    store.setEffort('chat-a', 'low');
+    await store.flush();
+
+    const reloaded = new SessionStore(file);
+    await reloaded.load();
+
+    expect(reloaded.getEffort('chat-a')).toBe('low');
+    expect(reloaded.getRaw('chat-a')?.sessionId).toBeUndefined();
+  });
+
+  it('preserves effort when a Claude session id is recorded', async () => {
+    const file = await tempSessionFile();
+    const store = new SessionStore(file);
+
+    store.setEffort('chat-a', 'max');
+    store.set('chat-a', 'session-1', '/tmp/project');
+    await store.flush();
+
+    const reloaded = new SessionStore(file);
+    await reloaded.load();
+
+    expect(reloaded.getEffort('chat-a')).toBe('max');
+    expect(reloaded.resumeFor('chat-a', '/tmp/project')).toBe('session-1');
+  });
+
+  it('clears effort override without dropping resumable session state', async () => {
+    const file = await tempSessionFile();
+    const store = new SessionStore(file);
+
+    store.set('chat-a', 'session-1', '/tmp/project');
+    store.setEffort('chat-a', 'high');
+    expect(store.clearEffortOverride('chat-a')).toBe(true);
+    await store.flush();
+
+    const reloaded = new SessionStore(file);
+    await reloaded.load();
+
+    expect(reloaded.getEffort('chat-a')).toBeUndefined();
+    expect(reloaded.resumeFor('chat-a', '/tmp/project')).toBe('session-1');
+  });
+});

--- a/test/effort.test.ts
+++ b/test/effort.test.ts
@@ -103,4 +103,36 @@ describe('SessionStore effort override', () => {
     expect(reloaded.getEffort('chat-a')).toBeUndefined();
     expect(reloaded.resumeFor('chat-a', '/tmp/project')).toBe('session-1');
   });
+
+  it('clears session identity without dropping effort override', async () => {
+    const file = await tempSessionFile();
+    const store = new SessionStore(file);
+
+    store.set('chat-a', 'session-1', '/tmp/project');
+    store.setEffort('chat-a', 'medium');
+    expect(store.clearSession('chat-a')).toBe(true);
+    await store.flush();
+
+    const reloaded = new SessionStore(file);
+    await reloaded.load();
+
+    expect(reloaded.resumeFor('chat-a', '/tmp/project')).toBeUndefined();
+    expect(reloaded.getRaw('chat-a')?.sessionId).toBeUndefined();
+    expect(reloaded.getRaw('chat-a')?.cwd).toBeUndefined();
+    expect(reloaded.getEffort('chat-a')).toBe('medium');
+  });
+
+  it('drops the entry when clearing a session without scope preferences', async () => {
+    const file = await tempSessionFile();
+    const store = new SessionStore(file);
+
+    store.set('chat-a', 'session-1', '/tmp/project');
+    expect(store.clearSession('chat-a')).toBe(true);
+    await store.flush();
+
+    const reloaded = new SessionStore(file);
+    await reloaded.load();
+
+    expect(reloaded.getRaw('chat-a')).toBeUndefined();
+  });
 });

--- a/test/network-config.test.ts
+++ b/test/network-config.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { shouldBypassProxy } from '../src/bot/network-config';
+
+describe('NO_PROXY matching', () => {
+  it('matches suffix entries with a leading dot', () => {
+    expect(shouldBypassProxy('open.feishu.cn', '.feishu.cn')).toBe(true);
+    expect(shouldBypassProxy('feishu.cn', '.feishu.cn')).toBe(true);
+    expect(shouldBypassProxy('open.larksuite.com', '.feishu.cn')).toBe(false);
+  });
+
+  it('matches plain domains and subdomains', () => {
+    expect(shouldBypassProxy('open.feishu.cn', 'feishu.cn')).toBe(true);
+    expect(shouldBypassProxy('open.feishu.cn', 'open.feishu.cn')).toBe(true);
+    expect(shouldBypassProxy('notfeishu.cn', 'feishu.cn')).toBe(false);
+  });
+
+  it('ignores ports and accepts wildcard', () => {
+    expect(shouldBypassProxy('open.feishu.cn:443', 'open.feishu.cn:443')).toBe(true);
+    expect(shouldBypassProxy('open.feishu.cn:443', '*')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Motivation

The bridge spawns `claude` with `--permission-mode bypassPermissions` today. That's a sensible default while the upstream Claude Code didn't have anything between "ask every time" and "skip all checks", but since Claude Code v2.1.83 (2026-03-27) there's a new `auto` mode that runs a safety classifier on every tool call.

For a remote-driven bot — where the operator isn't at the prompt to confirm anything — `auto` is a much better fit:

- Read-only and working-directory edits auto-approve (no friction)
- Risky actions (`curl | bash`, mass delete, sensitive exfil, force-push to `main`, IAM changes, etc.) get blocked and Claude is asked to try something else
- **In headless mode (which the bridge runs in), the session aborts after 3 consecutive or 20 cumulative blocks** — a useful safety net, since there's no human to fall back to a permission prompt

Boundaries stated in conversation also act as block signals, so a user can say "don't push" and the classifier enforces it for the rest of the session.

## Tradeoff

Auto mode requires Sonnet 4.6 / Opus 4.6 / Opus 4.7 and direct Anthropic API (not Bedrock/Vertex). This PR therefore always passes an explicit `--model` (default `claude-opus-4-7`) so the bridge doesn't rely on the CLI's default model, which may be older and would silently reject auto.

Users who want to opt out (or stay on the old behavior) can set `preferences.permissionMode = "bypassPermissions"` in `~/.lark-channel/config.json` — no code change needed.

## Changes

- `src/agent/claude/adapter.ts` — `ClaudeAdapterOptions` gains `defaultPermissionMode` and `defaultModel`; the per-call `run()` opts still win, so existing callers don't need to change.
- `src/config/schema.ts` — add `PermissionMode` type, expose `preferences.permissionMode` and `preferences.model`, plus `getPermissionMode(cfg)` / `getAgentModel(cfg)` resolvers. Unknown values for `permissionMode` fall back to `'auto'` rather than silently becoming `bypassPermissions` — defensive against typos.
- `src/cli/commands/start.ts` — wire the resolved config into the `ClaudeAdapter` constructor.
- The `agent.spawn` log line now includes `permissionMode` so operators can verify what mode each run actually used.

## Notes

- 4 files changed, +101/-6
- Backwards compatible: configs that don't set `permissionMode` / `model` get the new defaults; configs that do are respected.
- `pnpm typecheck` + `pnpm build` both clean.
- Tested end-to-end with a self-hosted bot — `agent.spawn` log shows `"permissionMode":"auto","model":"claude-opus-4-7"` and the session behaves as expected (read-only and edit auto-approve, Bash routed through classifier).

Happy to split into smaller commits or rework the config field naming if you prefer.