### PR TITLE
Add multi-window-bridge: local Claude Code windows → Feishu (companion to lark-channel-bridge)

### DIFF
--- a/contrib/multi-window-bridge/.gitignore
+++ b/contrib/multi-window-bridge/.gitignore
@@ -1,0 +1,14 @@
+# Runtime state & secrets — never commit these.
+.tenant_token.json
+registry.json
+registry.json.lock
+session_chats.json
+.receiver_state.json
+pending.json
+pending.json.lock
+logs/
+__pycache__/
+*.pyc
+
+# Local config holds your real chatId / userOpenId — edit config/config.json
+# in place, but do not commit your real IDs back upstream.

--- a/contrib/multi-window-bridge/ARCHITECTURE.md
+++ b/contrib/multi-window-bridge/ARCHITECTURE.md
@@ -1,0 +1,226 @@
+# Multi-Window Bridge — 架构
+
+## 1. 总览
+
+```
+ ┌────────────────────────── 一个 Warp 窗口 = 一个 Claude Code 会话 ──────────────────────────┐
+ │                                                                                              │
+ │   $ cc-register --alias=kb-debug   (zsh function, 可选别名)                                  │
+ │           │                                                                                  │
+ │           ▼  设置 MWB_WINDOW_ALIAS env → exec claude                                          │
+ │   ┌──────────────────────────────┐                                                           │
+ │   │   claude (Code TUI)          │  ◀────── 用户在这里干活                                    │
+ │   │                              │                                                           │
+ │   │  triggers:                   │                                                           │
+ │   │   • SessionStart  ──►  registry.py  注册 {window-id, pid, cwd, session_id}              │
+ │   │   • Notification  ──►  feishu.py    "[kb-debug] 需要回复…"                              │
+ │   │   • PreToolUse    ──►  feishu.py    "[kb-debug] 申请执行 Bash: rm -rf …"                │
+ │   │   • Stop          ──►  feishu.py    "[kb-debug] 已完成"  (可关)                          │
+ │   │   • SessionEnd    ──►  registry.py  注销                                                 │
+ │   └──────────────────────────────┘                                                           │
+ └──────────────────────────────────────────────────────────────────────────────────────────────┘
+                                              │
+                                              │ JSON 文件 + flock
+                                              ▼
+                                   ┌────────────────────────┐
+                                   │  registry.json         │  ◀── 全局唯一事实
+                                   │  ~/.claude/MWB/        │      window-id ↔ {pid, sid, cwd, lastHookAt, lastHookKind}
+                                   └────────────────────────┘
+                                              │
+                                              │ 读取 (60s 一次)
+                                              ▼
+                                   ┌────────────────────────┐
+                                   │  watchdog.py (launchd) │  超过阈值无 hook 心跳 + 进程仍活 → 发"疑似卡死"
+                                   └────────────────────────┘
+                                              │
+                                              ▼
+                                       feishu.py (sender)
+                                              │
+                                              ▼
+                       ┌──────────────────────────────────────────────────┐
+                       │  飞书 bot (cli_xxxxxxxxxxxxxxxx / "你的飞书 bot") │
+                       │  凭据复用 ~/.lark-channel/config.json              │
+                       │  目标 chat = oc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx  │
+                       └──────────────────────────────────────────────────┘
+                                              │
+                                              ▼ 用户回复  "[kb-debug] 继续干"
+                                              │
+                                   ┌────────────────────────┐
+                                   │  receiver.py (Stage 2) │  每 30s 拉新消息
+                                   │  (launchd)             │  解析 [window-id] 前缀 OR 引用回复
+                                   └────────────────────────┘
+                                              │
+                                              ▼
+                                   ┌────────────────────────┐
+                                   │  router.py (resume)    │  ① kill old pid (若仍活)
+                                   │                        │  ② AppleScript 开新 Warp tab
+                                   │                        │  ③ 跑  claude --resume <sid>
+                                   │                        │  ④ 用 pbcopy + Cmd+V 把回复粘进去 + Enter
+                                   └────────────────────────┘
+```
+
+## 2. 五个模块
+
+| 模块 | 文件 | 触发方式 | 核心职责 |
+|---|---|---|---|
+| **registry** | `lib/registry.py` | 函数库 (被 hook 调用) | `~/.claude/multi-window-bridge/registry.json` 的原子读写，flock 防并发 |
+| **hooks** | `hooks/*.py` | Claude Code 在事件点 spawn | 写心跳到 registry + 调 feishu.py 发通知 |
+| **watchdog** | `daemon/watchdog.py` | launchd KeepAlive | 每 60s 扫 registry，发"疑似卡死"，回收死进程残留 |
+| **feishu sender** | `lib/feishu.py` | 被 hooks + watchdog 调用 | 读 lark-channel-bridge 的 config.json → tenant_access_token → `POST /im/v1/messages` |
+| **receiver + router** | `daemon/receiver.py` + `daemon/router.py` | launchd (Stage 2) | 轮询飞书 chat 新消息，解析 window-id，开新 Warp tab `claude --resume` 并粘入回复 |
+
+## 3. 与现有 `lark-channel-bridge` 的边界
+
+| 维度 | lark-channel-bridge | multi-window-bridge (本项目) |
+|---|---|---|
+| **触发方向** | 飞书 → spawn 新 claude (无状态) | claude → 飞书 (主动), 飞书 → 已有 claude session (Stage 2) |
+| **进程生命周期** | 收到飞书消息时短 spawn / 跑完即退 | 跟随用户在 Warp 里手开的 claude 进程 |
+| **会话识别** | 按飞书 chat_id 维护 sessionId 映射 | 按 window-id (`{cwd-basename}-{N}`) 映射 sessionId + claude PID |
+| **凭据来源** | `~/.lark-channel/config.json` (自有) | 读同一份 config.json (不复制) |
+| **bot App ID** | cli_xxxxxxxxxxxxxxxx | 同上 (复用) |
+| **launchd 服务** | `com.local.lark-channel-bridge.plist` | `com.local.mwb-watchdog.plist` + `com.local.mwb-receiver.plist` |
+| **冲突点** | 飞书事件订阅 URL: 同一 App 只能一个 webhook | **本项目不订 webhook，只拉 REST API**，所以不抢 |
+| **消息互看** | 都进同一个 chat | receiver 用 `last_seen_msg_id` 过滤，只处理 `[window-id]` 前缀消息，剩下的留给 lark-channel-bridge |
+
+**关键设计**：本项目**不订阅飞书 event webhook**，避免和 lark-channel-bridge 抢消息路由。Stage 2 用 `im/v1/messages` REST 拉取，间隔 30s。代价：回复延迟 15-30s（用户能接受，飞书发完就放下手机）。
+
+## 4. 数据结构
+
+### registry.json
+
+```json
+{
+  "version": 1,
+  "windows": {
+    "kb-1": {
+      "alias": "kb-1",
+      "cwd": "/Users/you/kb",
+      "claudePid": 12345,
+      "sessionId": "7b2838bc-...",
+      "transcriptPath": "/Users/you/.claude/projects/-Users-you-kb/7b2838bc-....jsonl",
+      "startedAt": 1779030000,
+      "lastHookAt": 1779031200,
+      "lastHookKind": "Notification",
+      "lastHookSummary": "Claude is waiting for your input",
+      "registeredManually": true
+    },
+    "kb-2": { "...": "..." }
+  },
+  "notifications": {
+    "om_xxx_msg_id": { "windowId": "kb-1", "kind": "Notification", "sentAt": 1779031200 }
+  }
+}
+```
+
+- `windows` — 活会话
+- `notifications` — 出账消息 ID 反查表（最多保留 200 条，给 Stage 2 的"引用回复"路由用）
+
+### config/config.json
+
+```json
+{
+  "feishu": {
+    "chatId": "oc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "credentialFile": "~/.lark-channel/config.json"
+  },
+  "notifications": {
+    "onInput": true,
+    "onToolAuth": true,
+    "onStop": true,
+    "onWatchdog": true,
+    "toolAuthBashOnly": false,
+    "toolAuthIncludes": ["Bash", "Edit", "Write", "NotebookEdit"]
+  },
+  "watchdog": {
+    "intervalSeconds": 60,
+    "staleThresholdSeconds": 600,
+    "rearmAfterAlertSeconds": 1800
+  },
+  "stage2": {
+    "enabled": false,
+    "pollIntervalSeconds": 30,
+    "allowAppleScriptPaste": false,
+    "warpAppPath": "/Applications/Warp.app"
+  }
+}
+```
+
+设计原则：**默认保守** — Stage 2 关闭、AppleScript 自动粘贴关闭、watchdog 阈值 10 分钟。
+
+## 5. Stage 2 决策（回复路由）
+
+**方案 A 胜出**（spawn 新 Warp tab + `claude --resume <sid>`），不走方案 B (注入到原窗口)。
+
+**为什么否决 B**：Warp 没有公开 Accessibility API 给 Claude Code 的 TUI 输入框，AppleScript 只能做"焦点到 Warp + keystroke"。这要求：
+1. Warp 当前可见且没被遮 (失败：用户切到了别的 app)
+2. 目标 tab 当前 active (失败：用户切到了别的 tab)
+3. Claude TUI 输入框聚焦 (失败：用户在用 `/` slash command 弹窗)
+4. 系统辅助功能权限给到 Terminal/launchd
+
+任何一项不对 → 字符跑去别处了。这不是"v1 凑合用"级别的脆弱，是"用户会失去信任"级别的脆弱。
+
+**方案 A 的"分身窗口"问题如何解决**：
+- receiver 收到回复后，先 `kill -TERM <oldPid>` 把原窗口里的 claude 结束（registry 里有 PID）
+- 然后开新 Warp tab 跑 `claude --resume <sid>`
+- Claude 的 session.jsonl 是事实来源，新 tab 直接接上原会话完整上下文
+- 用户体验：原窗口里 claude 进程退出后剩个空 shell prompt（用户可手动关或留着），新窗口里 claude 已经接住飞书的回复继续干
+
+**为什么不用 `claude -p "<msg>" --resume <sid>`**（一次性 print 模式）：
+- Print 模式跑完即退，用户回到电脑想跟进时还得再 `claude --resume <sid>`
+- 把回复变成"一锤子买卖"，违背"双向交互"的目标
+
+**AppleScript 自动粘贴默认关**（`stage2.allowAppleScriptPaste: false`）：
+- 默认行为：开新 Warp tab + 跑 `claude --resume <sid>`，**用户的回复文本被 pbcopy 复制到剪贴板**，Claude TUI 起来后用户 Cmd+V 粘进去回车
+- 进阶（用户自己打开开关 + 授辅助功能权限）：AppleScript 自动 Cmd+V + Enter，全自动
+- 这个降级是有意的：让"基础能跑"和"全自动"分两步交付信任
+
+## 6. 启动 / 关闭顺序
+
+```
+启动:
+  1. mwb-install   写入所有文件 / 装 launchd plist / 在 ~/.zshrc 加 cc-register source
+  2. source ~/.zshrc 或重开终端
+  3. cc-register --alias=foo   开第一个会话 (alias 可选)
+  4. (Stage 2 可选)  在 config.json 把 stage2.enabled 设 true → launchctl load receiver plist
+
+关闭:
+  1. mwb-uninstall  卸 launchd / 删 ~/.claude/multi-window-bridge/ / 移除 cc-register source / 还原 settings.json hooks
+  2. (lark-channel-bridge 不受影响)
+```
+
+## 7. 文件清单
+
+```
+~/.claude/multi-window-bridge/
+├── ARCHITECTURE.md              # 本文档
+├── README.md                    # PM 友好的中文说明
+├── FAILURE-MODES.md             # 模块挂掉时观察 + 自愈
+├── config/
+│   └── config.json              # 默认配置
+├── lib/
+│   ├── common.py                # 配置加载 / 日志 / flock
+│   ├── registry.py              # registry 读写
+│   └── feishu.py                # 飞书 API 客户端
+├── hooks/
+│   ├── session_start.py
+│   ├── notification.py
+│   ├── pre_tool_use.py
+│   ├── stop.py
+│   └── session_end.py
+├── daemon/
+│   ├── watchdog.py
+│   ├── receiver.py              # Stage 2
+│   └── router.py                # Stage 2
+├── bin/
+│   ├── cc-register              # zsh function (source)
+│   ├── mwb-install
+│   ├── mwb-uninstall
+│   └── mwb-test                 # 冒烟测试
+├── launchd/
+│   ├── com.local.mwb-watchdog.plist
+│   └── com.local.mwb-receiver.plist  # Stage 2
+├── settings.patch.json          # 给 ~/.claude/settings.json 的 hooks 段补丁参考
+├── registry.json                # 运行时 (不进 git)
+└── logs/
+    └── YYYY-MM-DD.log
+```

--- a/contrib/multi-window-bridge/FAILURE-MODES.md
+++ b/contrib/multi-window-bridge/FAILURE-MODES.md
@@ -1,0 +1,66 @@
+# Failure modes & self-healing
+
+每一行 = 一个模块挂掉时，你会观察到什么、怎么自愈。
+
+## 1. 模块 × 现象 × 排查
+
+| 模块 | 挂掉时你会看到 | 自动自愈 | 手动恢复 |
+|---|---|---|---|
+| **registry.json** 文件损坏 (异常断电 / 磁盘满) | hooks 跑出来日志 `registry.corrupt`；飞书还在发但 window-id 全 reset 为 `<basename>-1` | hooks 检测到非法 JSON 时把 registry 当空的重建 | 没事可做。如果你想要原始数据，看 `~/.claude/multi-window-bridge/logs/<日期>.log`，每个 SessionStart 都记了 sessionId |
+| **lark-channel/config.json 没了 / 改密** | 所有 hook 日志里 `feishu.token.fail`；飞书不发任何东西 | 不会自愈 | 重跑 `lark-channel-bridge start` 走扫码流程；或手动改 `~/.lark-channel/config.json`。MWB 会自动重读 |
+| **token 缓存过期** (cached token 失效但磁盘上还在) | 偶尔某条消息发不出去，下次就好了 | 是 — `feishu.py` 失败后下次调用会重新走 `/auth/v3/tenant_access_token/internal` | 手动: `rm ~/.claude/multi-window-bridge/.tenant_token.json` |
+| **watchdog 进程崩了** | 不再收到"疑似卡死"通知；hook 通知正常 | 是 — launchd `KeepAlive.Crashed=true` 10 秒内重启；`ThrottleInterval=10` 防疯狂重启循环 | `launchctl list \| grep mwb-watchdog` 看 PID + exit code；看 `logs/watchdog.err.log` |
+| **watchdog 死循环不退出** | watchdog 进程占 CPU；通知卡 | 不会自愈 | `launchctl unload ~/Library/LaunchAgents/com.local.mwb-watchdog.plist && launchctl load ...` |
+| **某个 Claude 进程 SIGKILL 突然死** (没触发 SessionEnd) | registry 里残留该 window；watchdog 下次巡逻发现 PID 已死，evict + 不通知 | 是 — `watchdog._tick` 先做 `_prune_dead`，evict 不发飞书（用户已经关窗口了，没必要再喊） | 没事可做 |
+| **hook 超时** (>= 5-8s 没返回) | Claude 主流程不卡 (Claude 强制超时)；某条通知没发出去 | hook 是 fire-and-forget，下次事件还会发 | 看 `logs/<日期>.log` 里 `hook.*.fail`；常见是 feishu 那边网络慢 |
+| **receiver 拉到 0 条消息** (Stage 2) | 飞书回复"[kb-1] xxx" 30s 内本机没反应；超过 1 分钟还没反应说明真挂了 | 是 — launchd 重启 receiver | 看 `logs/receiver.err.log`；最常见: token 过期 / 网络问题 |
+| **receiver 把消息派给错的 window** | 新 Warp tab 跑了 `claude --resume <错的 sid>`，回复落到错的会话上 | 不会自愈 | 这种"误派"意味着 alias 撞了 — 自查 registry.json 里有没有重名 window-id；用 `cc-register --alias=明确点的名字` 避免 |
+| **AppleScript 自动粘贴失败** (Stage 2 + allowAppleScriptPaste=true) | 新 Warp tab 起来了，TUI 在那，但回复文本没出现 | 不会自愈；剪贴板里还在 | 用户直接在 Warp 里 Cmd+V + Enter 即可；考虑把 `allowAppleScriptPaste` 关回 false |
+| **Warp 没装 / 改名** | router 报 `osascript phase1 rc=...`；飞书回复说"resume failed" | 不会自愈 | 修 `config.json.stage2.warpAppPath`，或先关 Stage 2 临时回退 |
+| **ClashX fake-ip 干掉 feishu API** (参考 你的代理配置) | 全部 feishu 调用 `network: ECONNRESET` 或 super slow | 不会自愈 | 检查 ClashX yaml 的 `fake-ip-filter`，确保 `*.feishu.cn` 在过滤名单里 |
+
+## 2. 通用排查动作（按顺序试）
+
+```bash
+# 1. 看今天的日志（hooks + watchdog + receiver 都写在这）
+tail -50 ~/.claude/multi-window-bridge/logs/$(date +%F).log
+
+# 2. 看 launchd 服务状态
+launchctl list | grep mwb
+
+# 3. 看 launchd stderr (启动失败 / 路径错的话会在这)
+cat ~/.claude/multi-window-bridge/logs/watchdog.err.log
+cat ~/.claude/multi-window-bridge/logs/receiver.err.log  # Stage 2 才有
+
+# 4. 看 registry 状态
+cat ~/.claude/multi-window-bridge/registry.json | python3 -m json.tool
+
+# 5. 看飞书 token 缓存
+ls -la ~/.claude/multi-window-bridge/.tenant_token.json
+
+# 6. 重启 watchdog (大多数"为什么不发了"问题的速效药)
+launchctl unload ~/Library/LaunchAgents/com.local.mwb-watchdog.plist
+launchctl load ~/Library/LaunchAgents/com.local.mwb-watchdog.plist
+
+# 7. 重启 receiver (Stage 2)
+launchctl unload ~/Library/LaunchAgents/com.local.mwb-receiver.plist
+launchctl load ~/Library/LaunchAgents/com.local.mwb-receiver.plist
+
+# 8. 端到端 smoke (跳过 hooks 直接试 feishu send)
+~/.claude/multi-window-bridge/bin/mwb-test
+```
+
+## 3. 哪些 corner case **不**自动处理（已知，故意的）
+
+- **同 alias 撞名**：`cc-register --alias=foo` 开两次 → 第二次会变成 `foo-2`。**不会**报错或弹警告。背后原因：宁可静默续号，也别打断用户工作流。
+- **PID 复用**：极少数情况下，一个 Claude 进程退出后，几小时内系统把同一个 PID 分配给别的进程。watchdog 巡逻时会把这个"非 Claude 的进程"当成"我们的 Claude"。后果：永远不会触发 evict（除非那个进程也死），偶尔误发"疑似卡死"。**接受**这个边界 case，30 分钟 rearm 让噪音可控。
+- **AppleScript 焦点抢错** (Stage 2 + auto-paste)：上面表里列了，重申一次——这就是为啥默认关。**别在 `allowAppleScriptPaste=true` 时同时手敲键盘**。
+- **Claude session.jsonl 锁冲突**：理论上 `--resume` 时如果旧 PID 没杀干净，新旧两个 claude 进程会同时写一个文件。router 主动 `SIGTERM` + sleep 0.5s 后才 resume，**绝大多数情况够用**。极少数老 PID 在 GC 大对象时 SIGTERM 没立即响应，看到 session 写入冲突的话，等 5s 重试。
+- **飞书 API 限流**：飞书私聊单 bot 大概每秒 5 条够用。**watchdog 同一窗口 30 分钟才再 alert 一次**就是为了不撞限流。极端情况（10 个窗口同时卡死）也只会触发 10 条通知，远低于限流。
+
+## 4. 卸载后还需要清理的（mwb-uninstall 不会动的东西）
+
+- `~/.lark-channel/` —— lark-channel-bridge 的东西，不该动
+- 已发出去的飞书消息 —— 历史记录，飞书侧
+- `~/.claude/settings.json.bak.<时间戳>` —— 故意留着，万一你要回滚
+- (Stage 2) Accessibility 权限 —— 如果你给过 osascript，系统设置里还在，可以手动撤

--- a/contrib/multi-window-bridge/README.md
+++ b/contrib/multi-window-bridge/README.md
@@ -1,0 +1,209 @@
+# multi-window-bridge — 多窗口 Claude ↔ 飞书 通知桥
+
+把多个 Warp 窗口里跑着的 Claude Code 会话「**主动喊飞书**」+「**飞书喊回来**」串成一张通知网。出门 / 在另一个房间 / 在另一个屏幕，照样知道哪个窗口需要你管它。
+
+---
+
+## 它解决什么问题
+
+你现在：
+- 同时开 4 个 Warp 窗口，每个跑一个 Claude Code，做不同任务
+- 离开电脑去开会
+- 回来发现：1 号窗口在 20 分钟前就在等你回复某个问题，3 号窗口在 5 分钟前完成了一个大任务，4 号窗口卡在某个错误上
+
+你想要的：
+- 1 号窗口等输入 → 手机收到飞书消息「**[kb-debug] 需要你回复**」
+- 3 号完成 → 「**[yitang-fix] 已完成**」
+- 4 号卡 10 分钟没动 → 「**[code-review] 疑似卡死**」
+- 看到消息后，**直接在飞书里回复**，本机会自动开新 Warp tab 把回复接上原会话继续干
+
+这套就是干这个的。
+
+---
+
+## 跟现有 `lark-channel-bridge` 是啥关系
+
+**完全不冲突，两套独立跑。**
+
+| | lark-channel-bridge（已经在跑的） | multi-window-bridge（本套） |
+|---|---|---|
+| 触发方向 | 飞书发消息 → 本机新开一个 Claude 跑完即退 | 本机已开的 Claude → 飞书；飞书回复 → 接回本机已开的 Claude |
+| 生命周期 | 短命子进程，每条消息独立 | 跟随你手开的 Warp 窗口，跨多轮对话 |
+| 飞书 bot | 同一个 bot（你的飞书 bot） | 同一个 bot |
+| 区分方式 | 任意飞书消息都触发 | **只处理带 `[window-id]` 标记的回复**，其余留给 lark-channel-bridge |
+
+凭据共享：本套读 `~/.lark-channel/config.json`，不另存一份。
+
+---
+
+## 怎么装
+
+本项目假定装在 `~/.claude/multi-window-bridge/`。从本仓库安装：先把 `contrib/multi-window-bridge/` 整个目录复制过去，再跑 installer：
+
+```bash
+cp -R contrib/multi-window-bridge ~/.claude/multi-window-bridge
+~/.claude/multi-window-bridge/bin/mwb-install
+source ~/.zshrc          # 让 cc-register 在当前终端生效
+~/.claude/multi-window-bridge/bin/mwb-test   # 应该收到一条飞书测试消息
+```
+
+> 装之前先把 `config/config.json` 里的 `feishu.chatId` / `feishu.userOpenId` 填成你自己的（占位符是 `oc_xxx…` / `ou_xxx…`），`credentialFile` 默认复用 lark-channel-bridge 的 `~/.lark-channel/config.json`。
+
+装完之后做了什么：
+1. 在 `~/.claude/settings.json` 的 `hooks` 段加了 5 条 MWB hook（**不影响你已有的 UserPromptSubmit + statusLine**，原文件备份在 `settings.json.bak.<时间戳>`）
+2. 在 `~/.zshrc` 加了一行 `source ~/.claude/multi-window-bridge/bin/cc-register`，引入 `cc-register` 命令
+3. 起了一个 launchd 守护进程 `com.local.mwb-watchdog`（每 60 秒巡逻一次，发"疑似卡死"通知）
+
+---
+
+## 怎么用（日常）
+
+### 开一个会话
+
+老办法：直接 `claude` —— **依然有效**，会自动起一个 `<目录名>-<序号>` 的 window-id（比如 `kb-1`）。
+
+新办法（推荐，想给会话起个有意义的名字）：
+
+```bash
+cc-register --alias=fix-onboarding-bug
+# 或者
+cc-register -a perf-review
+```
+
+然后正常用 Claude 就行，不需要做别的。
+
+### 打开多个窗口
+
+Warp 里 Cmd+T 开新 tab → `cd 到对应目录` → `cc-register --alias=xxx`。每个 tab 一个 alias，互不打扰。
+
+### 查看当前有哪些会话在跑
+
+```bash
+cat ~/.claude/multi-window-bridge/registry.json | python3 -m json.tool
+```
+
+或者看实时日志：
+
+```bash
+tail -f ~/.claude/multi-window-bridge/logs/$(date +%F).log
+```
+
+---
+
+## 飞书会收到哪些消息
+
+| 触发点 | 消息长什么样 | 频率 |
+|---|---|---|
+| Claude 等你输入 | 🟡 [kb-1] 需要你回复 / 💬 \<最后一段提示\> | 每次 Claude 弹问题（带 5 秒 per-window 节流） |
+| 即将跑敏感工具 | 🔧 [kb-1] 即将执行 Bash / $ rm -rf foo | 仅 Bash / Edit / Write / NotebookEdit |
+| 任务完成 | ✅ [kb-1] 已完成 / \<最后一段输出\> | 每个 Stop（可在 config 关掉） |
+| 疑似卡死 | ⚠️ [kb-1] 疑似卡死 / ⏱ 最后活动 12 分钟前 | watchdog 巡逻，阈值默认 10 分钟，30 分钟内不重复 |
+
+不想被某类消息打扰？编辑 `~/.claude/multi-window-bridge/config/config.json` 的 `notifications` 段把对应开关设 `false`，下一秒生效。
+
+---
+
+## Stage 2：飞书回复 → 接回本机（默认关，需要手动打开）
+
+### 怎么开
+
+```bash
+# 1. 把 config.json 里 stage2.enabled 改成 true
+python3 -c "
+import json, os
+p = os.path.expanduser('~/.claude/multi-window-bridge/config/config.json')
+c = json.load(open(p))
+c['stage2']['enabled'] = True
+json.dump(c, open(p,'w'), indent=2, ensure_ascii=False)
+print('stage2 enabled')
+"
+
+# 2. 起 receiver
+launchctl load ~/Library/LaunchAgents/com.local.mwb-receiver.plist
+```
+
+### 在飞书里怎么回复
+
+**3 种回复方式都认**：
+
+1. **方括号前缀**（推荐）：`[kb-1] 帮我把那个 bug 修了` ✅
+2. **冒号前缀**：`kb-1: 帮我把那个 bug 修了` ✅
+3. **引用回复**：直接对 bot 发的某条通知点引用回复，正文写你要说的，不带任何前缀 ✅
+
+⚠️ **不带 window-id 前缀也不引用回复的纯文本消息，本套不处理**，留给 `lark-channel-bridge` 兜底（它会按它原本的逻辑去 spawn 一个新 claude）。
+
+### 飞书回复后，本机发生什么
+
+**回答："会开一个新的 Warp tab，原来那个窗口会自己关掉。"**
+
+技术上发生这几步：
+1. receiver 30 秒一次拉飞书消息，发现一条 `[kb-1] xxx`
+2. 看 registry，找到 `kb-1` 对应的 sessionId 和 PID
+3. **把原 PID 杀掉**（不然两个 claude 同时写一个 session 文件会乱）
+4. 开一个新 Warp tab，跑 `claude --resume <sessionId>`
+5. 你的回复内容自动复制到剪贴板
+6. 等 Claude TUI 起来后，**你在 Warp 里按 Cmd+V 然后回车**就行
+
+### 为什么不直接在原 Warp tab 里"自动打字"？
+
+我们试过了，**太脆弱**。Warp 没给一个稳定的方式让外部程序往它的 TUI 里塞键盘输入。会出这些问题：
+- 你切到了别的 app，键盘事件跑到那边去
+- 你切到了别的 tab，回复打到了错的 Claude 上
+- Claude 在弹某个内部弹窗（/help、模型选择等），输入被弹窗吞掉
+
+所以**默认走"新开 tab + 你自己粘"**这条路。慢一秒，但 100% 可靠。原窗口里的 claude 会自己结束，剩个空 shell prompt 你随手 Cmd+W 关掉就行。
+
+### 我懒，能让它全自动粘吗？
+
+可以，但要先**给 osascript 系统辅助功能权限**：
+
+1. 系统设置 → 隐私与安全 → 辅助功能 → 加 `/usr/bin/osascript`（或勾上你的终端 app）
+2. `config.json` 把 `stage2.allowAppleScriptPaste` 改成 `true`
+3. 测一次：飞书发 `[kb-1] hello`，看新 tab 里自不自动粘进去 + 回车
+
+⚠️ **不保证 100% 可靠**——Warp 升级、系统升级都可能让 AppleScript 焦点抢错。出问题就关回 `false`。
+
+---
+
+## 关掉 / 卸载
+
+```bash
+~/.claude/multi-window-bridge/bin/mwb-uninstall          # 软卸（保留 logs/registry）
+~/.claude/multi-window-bridge/bin/mwb-uninstall --purge  # 彻底删
+```
+
+`mwb-uninstall` 只删本套的东西：
+- 移除 settings.json 里以 `/multi-window-bridge/hooks/` 开头的 hook（**其它 hook 不动**）
+- 从 ~/.zshrc 删掉 cc-register 那行
+- unload + 删 launchd plist
+
+`lark-channel-bridge` 完全不受影响。
+
+---
+
+## 常见问题
+
+**Q：装完没收到测试消息**
+A：`~/.claude/multi-window-bridge/bin/mwb-test` 跑一次。如果失败，看 `~/.claude/multi-window-bridge/logs/$(date +%F).log` 里 `feishu.send.fail` 那一行。最常见原因是网络代理（参考 你的代理配置 ClashX 配置）。
+
+**Q：cc-register 命令找不到**
+A：`source ~/.zshrc` 一次。或者重新开个 Warp tab。
+
+**Q：window-id 想改名**
+A：直接 `cc-register --alias=新名字` 重新开一个会话就行。旧 alias 在 SessionEnd 后自动注销。
+
+**Q：飞书消息太吵了**
+A：编辑 `config.json` 的 `notifications` 段：把 `onStop` 关掉是最大改善（任务完成不再喊你）。`onToolAuth` 关掉就只剩 `需要回复` 和 `疑似卡死`。
+
+**Q：watchdog 误报"疑似卡死"（任务确实在跑，只是很长）**
+A：把 `watchdog.staleThresholdSeconds` 从 600 调大到 1800。
+
+**Q：装完之后 Claude 启动变慢了**
+A：每个 hook 跑一次 Python import，第一次约 80ms。如果体感卡，看 logs/ 里有没有 `hook.*.fail`。所有 hook 的 timeout 在 settings.json 里限了 5-8 秒，超时不会卡住 Claude 主流程。
+
+**Q：能跟 lark-channel-bridge 同时收发同一个 chat 吗？**
+A：能。lark-channel-bridge 走飞书 webhook 事件订阅，本套走 REST API 拉取。两条路径互不抢。但**飞书 chat 里同一条消息，两边都会看见**——本套用 `[window-id]` 前缀过滤，没匹配上的留给 lark-channel-bridge。
+
+---
+
+详细架构图见 [`ARCHITECTURE.md`](ARCHITECTURE.md)，失败模式排查见 [`FAILURE-MODES.md`](FAILURE-MODES.md)。

--- a/contrib/multi-window-bridge/bin/cc-register
+++ b/contrib/multi-window-bridge/bin/cc-register
@@ -1,0 +1,84 @@
+# multi-window-bridge / cc-register
+# zsh function: launch `claude` with an optional window alias so MWB hooks can
+# attribute the session to a stable, human-readable window-id.
+#
+# Source this file from ~/.zshrc:
+#   [ -f ~/.claude/multi-window-bridge/bin/cc-register ] && source ~/.claude/multi-window-bridge/bin/cc-register
+#
+# Usage:
+#   cc-register                       # auto-name: <basename(cwd)>-<N>
+#   cc-register --alias=morning-debug # explicit alias
+#   cc-register -a morning-debug      # short form
+#   cc-register --alias=fix-bug -- --print "fix the bug"
+#                                     # everything after `--` is passed to claude
+#
+# After launch, hooks fire on Notification / PreToolUse / Stop / SessionEnd and
+# push to feishu. See ~/.claude/multi-window-bridge/README.md.
+
+cc-register() {
+    local alias=""
+    local -a claude_args=()
+    local in_passthrough=0
+
+    while [[ $# -gt 0 ]]; do
+        if (( in_passthrough )); then
+            claude_args+=("$1"); shift; continue
+        fi
+        case "$1" in
+            -a|--alias)
+                alias="$2"; shift 2;;
+            --alias=*)
+                alias="${1#--alias=}"; shift;;
+            --)
+                in_passthrough=1; shift;;
+            -h|--help)
+                cat <<'HELP'
+cc-register — launch claude with a multi-window-bridge alias
+
+  cc-register [--alias=NAME | -a NAME] [-- CLAUDE_ARGS...]
+
+NAME may contain letters, digits, `-`, `_`. Unsafe chars are sanitized.
+If omitted, hooks auto-assign <basename(cwd)>-<N> at SessionStart time.
+
+Examples
+  cc-register                          # auto-named (e.g. kb-1)
+  cc-register --alias=fix-401          # named "fix-401"
+  cc-register -a perf -- --print done  # name "perf", pass --print done to claude
+HELP
+                return 0;;
+            *)
+                # First positional or unknown flag — pass everything from here on
+                # to claude. This makes `cc-register --resume foo` Just Work.
+                claude_args+=("$1"); shift; in_passthrough=1;;
+        esac
+    done
+
+    if [[ -n "$alias" ]]; then
+        # Sanitize: kebab-case alnum/dash/underscore only
+        alias="${alias//[^a-zA-Z0-9_-]/-}"
+        export MWB_WINDOW_ALIAS="$alias"
+    else
+        unset MWB_WINDOW_ALIAS
+    fi
+
+    # Resolve claude binary from PATH.
+    local claude_bin
+    claude_bin="$(command -v claude)"
+    if [[ -z "$claude_bin" ]]; then
+        echo "cc-register: cannot find 'claude' on PATH" >&2
+        return 127
+    fi
+
+    # NOT using `exec` on purpose: when Claude exits we want the user to fall
+    # back to an interactive shell in the same Warp tab, not have the tab
+    # disappear. Hook PPID is the claude process regardless (claude spawns the
+    # hook directly), so PID tracking is unaffected.
+    if (( ${#claude_args} > 0 )); then
+        "$claude_bin" "${claude_args[@]}"
+    else
+        "$claude_bin"
+    fi
+    local rc=$?
+    unset MWB_WINDOW_ALIAS
+    return $rc
+}

--- a/contrib/multi-window-bridge/bin/mwb-backfill-groups
+++ b/contrib/multi-window-bridge/bin/mwb-backfill-groups
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""mwb-backfill-groups — 把 alive 但还没群的 window 补上群,顺手把名字过期的群改回当前模板。
+
+用法:
+  mwb-backfill-groups                  默认: 建缺的群 + 改名(让所有 mapped 群名 = 当前模板)
+  mwb-backfill-groups --dry-run        只看会做什么,不实际改
+  mwb-backfill-groups --no-rename      只补建,不改已有群的名
+  mwb-backfill-groups --rename-only    只改名,不补建
+  mwb-backfill-groups --include-dead   连历史死 window 都改名(默认跳过)
+
+设计:
+- 用 group_create_worker 的同一套模板逻辑,保证名字一致
+- 改名是 idempotent: 名字已经对的直接跳过
+- 死 window 默认跳过(他们不会发消息了,改名没意义,还占飞书 API 额度)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+MWB = Path.home() / ".claude" / "multi-window-bridge"
+sys.path.insert(0, str(MWB / "lib"))
+
+from common import load_config  # noqa: E402
+import feishu  # noqa: E402
+import session_chats  # noqa: E402
+from group_create_worker import _cwd_base  # noqa: E402
+
+
+def _alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+
+
+def _render_name(template: str, window_id: str, cwd: str) -> str:
+    return template.format(windowId=window_id, cwdBase=_cwd_base(cwd), cwd=cwd)
+
+
+def _read_registry() -> dict[str, dict]:
+    try:
+        return json.loads((MWB / "registry.json").read_text()).get("windows", {})
+    except Exception:
+        return {}
+
+
+def cmd(dry_run: bool, do_create: bool, do_rename: bool,
+        include_dead: bool) -> int:
+    cfg = load_config()
+    feishu_cfg = cfg.get("feishu", {})
+    pwg = feishu_cfg.get("perWindowGroups", {})
+    if not pwg.get("enabled"):
+        print("⚠️  perWindowGroups.enabled=false in config. Nothing to do.")
+        return 0
+    template = pwg.get("groupNameTemplate", "claude · {windowId} · {cwdBase}")
+
+    registry = _read_registry()
+    mapped = session_chats.list_all()
+
+    # --- pass 1: build to_create + to_rename ---
+    to_create: list[tuple[str, str]] = []   # (wid, cwd)
+    to_rename: list[tuple[str, str, str, str]] = []  # (wid, chat_id, old, new)
+
+    if do_create:
+        for wid, e in registry.items():
+            if wid in mapped:
+                continue
+            pid = e.get("claudePid", -1)
+            if not _alive(pid):
+                continue
+            cwd = e.get("cwd", "")
+            if not cwd:
+                continue
+            to_create.append((wid, cwd))
+
+    if do_rename:
+        for wid, info in mapped.items():
+            cwd = info.get("cwd", "")
+            chat_id = info.get("chatId")
+            if not chat_id or not cwd:
+                continue
+            # Skip dead windows unless --include-dead
+            if not include_dead:
+                reg_entry = registry.get(wid)
+                if reg_entry:
+                    pid = reg_entry.get("claudePid", -1)
+                    if not _alive(pid):
+                        continue
+                else:
+                    # window not in registry anymore = dead long ago
+                    continue
+            new_name = _render_name(template, wid, cwd)
+            old_name = info.get("groupName", "")
+            if new_name != old_name:
+                to_rename.append((wid, chat_id, old_name, new_name))
+
+    # --- report ---
+    print(f"=== plan ===")
+    print(f"待建群 ({len(to_create)}):")
+    for wid, cwd in to_create:
+        name = _render_name(template, wid, cwd)
+        print(f"  + {wid}  cwd={cwd}  →  {name!r}")
+    print(f"待改名 ({len(to_rename)}):")
+    for wid, chat_id, old, new in to_rename:
+        print(f"  ~ {wid}  {old!r}  →  {new!r}")
+
+    if dry_run:
+        print("\n(--dry-run, 没改任何东西)")
+        return 0
+
+    # --- pass 2: execute ---
+    if to_create:
+        print("\n=== 建群 ===")
+        worker = MWB / "lib" / "group_create_worker.py"
+        for wid, cwd in to_create:
+            subprocess.run(
+                ["/usr/bin/python3", str(worker), wid, cwd],
+                check=False,
+            )
+            print(f"  ✓ spawned for {wid}")
+        # Workers are async; wait a bit so logs land before next step.
+        time.sleep(3)
+
+    if to_rename:
+        print("\n=== 改名 ===")
+        for wid, chat_id, old, new in to_rename:
+            ok = feishu.update_group(chat_id, name=new)
+            if ok:
+                # Update local state
+                info = mapped[wid]
+                session_chats.set_chat_for_window(
+                    wid, chat_id, info.get("cwd", ""), new,
+                )
+                print(f"  ✓ {wid}  →  {new!r}")
+            else:
+                print(f"  ✗ {wid}  (API fail; check logs)")
+
+    print("\n=== done ===")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n")[0] if __doc__ else "")
+    p.add_argument("--dry-run", action="store_true", help="不实际改,只列出计划")
+    p.add_argument("--no-rename", action="store_true", help="只补建,不改已有群名")
+    p.add_argument("--rename-only", action="store_true", help="只改名,不补建")
+    p.add_argument("--include-dead", action="store_true",
+                   help="改名时也覆盖死 window 的群(默认跳过)")
+    args = p.parse_args()
+    if args.no_rename and args.rename_only:
+        print("❌ --no-rename 和 --rename-only 互斥")
+        return 2
+    do_create = not args.rename_only
+    do_rename = not args.no_rename
+    return cmd(args.dry_run, do_create, do_rename, args.include_dead)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/multi-window-bridge/bin/mwb-install
+++ b/contrib/multi-window-bridge/bin/mwb-install
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# multi-window-bridge installer.
+#
+# What it does:
+#   1. Backs up ~/.claude/settings.json → settings.json.bak.<ts>
+#   2. Merges MWB hooks (SessionStart/Notification/PreToolUse/Stop/SessionEnd)
+#      into the existing settings.json (does NOT touch other keys)
+#   3. Adds `source ~/.claude/multi-window-bridge/bin/cc-register` to ~/.zshrc
+#      (idempotent — skipped if already present)
+#   4. Installs + loads ~/Library/LaunchAgents/com.local.mwb-watchdog.plist
+#   5. Stage 2 (receiver) plist is COPIED but NOT loaded — enable via:
+#        edit config.json → stage2.enabled = true
+#        launchctl load ~/Library/LaunchAgents/com.local.mwb-receiver.plist
+#
+# Idempotent: rerunning is safe. Re-merges hooks. Re-creates launchd entries.
+
+set -euo pipefail
+
+MWB="$HOME/.claude/multi-window-bridge"
+SETTINGS="$HOME/.claude/settings.json"
+ZSHRC="$HOME/.zshrc"
+LAUNCH_DIR="$HOME/Library/LaunchAgents"
+WATCHDOG_PLIST="com.local.mwb-watchdog.plist"
+RECEIVER_PLIST="com.local.mwb-receiver.plist"
+
+ts="$(date +%s)"
+echo "→ multi-window-bridge install"
+echo "  MWB home:   $MWB"
+echo "  Settings:   $SETTINGS"
+
+# 1. Backup + merge settings.json
+if [[ ! -f "$SETTINGS" ]]; then
+    echo "{}" > "$SETTINGS"
+fi
+cp "$SETTINGS" "$SETTINGS.bak.$ts"
+echo "  backup → $SETTINGS.bak.$ts"
+
+/usr/bin/python3 - <<'PY'
+import json, os
+mwb = os.path.expanduser("~/.claude/multi-window-bridge")
+settings_path = os.path.expanduser("~/.claude/settings.json")
+patch_path = f"{mwb}/settings.patch.json"
+
+with open(settings_path) as fh:
+    cur = json.load(fh)
+with open(patch_path) as fh:
+    # Hook command paths are templated with __HOME__ — substitute real home.
+    patch = json.loads(fh.read().replace("__HOME__", os.path.expanduser("~")))
+
+cur_hooks = cur.get("hooks", {})
+for event, entries in patch["hooks"].items():
+    existing = cur_hooks.get(event, [])
+    # Strip any prior MWB entries (so we can re-run idempotently)
+    pruned = []
+    for grp in existing:
+        keep_hooks = []
+        for h in grp.get("hooks", []):
+            cmd = h.get("command", "")
+            if "/multi-window-bridge/hooks/" not in cmd:
+                keep_hooks.append(h)
+        if keep_hooks:
+            new_grp = dict(grp)
+            new_grp["hooks"] = keep_hooks
+            pruned.append(new_grp)
+    pruned.extend(entries)
+    cur_hooks[event] = pruned
+cur["hooks"] = cur_hooks
+
+with open(settings_path, "w") as fh:
+    json.dump(cur, fh, indent=2, ensure_ascii=False)
+print("  hooks merged into settings.json")
+PY
+
+# 2. zshrc source line (idempotent)
+SOURCE_LINE='[ -f ~/.claude/multi-window-bridge/bin/cc-register ] && source ~/.claude/multi-window-bridge/bin/cc-register'
+if grep -Fq "$SOURCE_LINE" "$ZSHRC" 2>/dev/null; then
+    echo "  ~/.zshrc already sources cc-register — skipping"
+else
+    {
+        printf "\n# multi-window-bridge\n"
+        printf "%s\n" "$SOURCE_LINE"
+    } >> "$ZSHRC"
+    echo "  added cc-register source to ~/.zshrc"
+fi
+
+# 3. launchd plists
+mkdir -p "$LAUNCH_DIR"
+for p in "$WATCHDOG_PLIST" "$RECEIVER_PLIST"; do
+    src="$MWB/launchd/$p"
+    dst="$LAUNCH_DIR/$p"
+    # plists are templated with __HOME__ — substitute real home on install.
+    sed "s#__HOME__#$HOME#g" "$src" > "$dst"
+    echo "  installed $dst"
+done
+
+# 4. Load watchdog only (receiver requires stage2.enabled flip first)
+launchctl unload "$LAUNCH_DIR/$WATCHDOG_PLIST" 2>/dev/null || true
+launchctl load "$LAUNCH_DIR/$WATCHDOG_PLIST"
+echo "  watchdog loaded under launchd"
+
+cat <<'NEXT'
+
+──────────────────────────────────────────────────
+✅ install complete
+
+Try it out:
+  source ~/.zshrc                  # pick up cc-register in current shell
+  cc-register --alias=demo         # start a Claude window named "demo"
+  # in Claude: type /help and Enter — wait for it to finish
+  # → you should get a feishu message "[demo] 已完成"
+
+Smoke test (sends one ping to feishu now):
+  ~/.claude/multi-window-bridge/bin/mwb-test
+
+Stage 2 (replies from feishu drive a new Warp tab):
+  1. edit ~/.claude/multi-window-bridge/config/config.json — set stage2.enabled = true
+  2. launchctl load ~/Library/LaunchAgents/com.local.mwb-receiver.plist
+  3. (optional) set stage2.allowAppleScriptPaste = true AFTER granting
+     Accessibility permission to osascript (System Settings → Privacy → Accessibility)
+
+Logs:
+  tail -f ~/.claude/multi-window-bridge/logs/$(date +%F).log
+
+Uninstall:
+  ~/.claude/multi-window-bridge/bin/mwb-uninstall
+──────────────────────────────────────────────────
+NEXT

--- a/contrib/multi-window-bridge/bin/mwb-list
+++ b/contrib/multi-window-bridge/bin/mwb-list
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""mwb-list — 列出 Claude Code 所有 session
+
+用法:
+  mwb-list                  最近 20 个 (默认),表格
+  mwb-list --markdown       markdown (飞书 / Claude Code 转发用)
+  mwb-list --json           原始 JSON
+  mwb-list --limit 50       多列点
+  mwb-list --alive-only     只看正在跑的 (mwb registry)
+
+设计:
+- 主数据源 = ~/.claude/projects/ 下所有 <sid>.jsonl (Claude Code 自己存的,所有历史 211 个全在)
+- 辅助 = ~/.claude/multi-window-bridge/registry.json (给活 session 加上 mwb alias + PID 信息)
+- 合并后按 mtime 倒序,默认前 20 个
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+MWB = Path.home() / ".claude" / "multi-window-bridge"
+
+
+def _alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError):
+        return False
+
+
+def _lark_session_ids() -> set[str]:
+    path = Path.home() / ".lark-channel" / "sessions.json"
+    try:
+        data = json.loads(path.read_text())
+        return {v.get("sessionId") for v in data.values()
+                if isinstance(v, dict) and v.get("sessionId")}
+    except Exception:  # noqa: BLE001
+        return set()
+
+
+def _rel_time(ts: int) -> str:
+    if not ts:
+        return "—"
+    delta = int(time.time()) - ts
+    if delta < 60:
+        return f"{delta}s 前"
+    if delta < 3600:
+        return f"{delta // 60}m 前"
+    if delta < 86400:
+        return f"{delta // 3600}h 前"
+    return f"{delta // 86400}d 前"
+
+
+def _short_cwd(cwd: str) -> str:
+    home = str(Path.home())
+    if cwd.startswith(home):
+        return "~" + cwd[len(home):]
+    return cwd
+
+
+def _read_cwd_from_jsonl(path: Path) -> str | None:
+    """Read first jsonl line and return its `cwd` field. None on any error.
+
+    The directory-name encoding (`-Users-you-kb-wiki`) is ambiguous when
+    the real cwd contains hyphens (e.g. `mwb-resume-test` vs `mwb/resume/test`).
+    Each transcript entry carries the true cwd in a field — use that.
+    """
+    try:
+        with path.open() as fh:
+            for line in fh:
+                try:
+                    e = json.loads(line)
+                except Exception:  # noqa: BLE001
+                    continue
+                cwd = e.get("cwd")
+                if cwd:
+                    return cwd
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+def _scan_session_files() -> dict[str, dict]:
+    """Scan ~/.claude/projects for all <sessionId>.jsonl. Returns {sid: meta}."""
+    base = Path.home() / ".claude" / "projects"
+    out: dict[str, dict] = {}
+    if not base.exists():
+        return out
+    for cwd_dir in base.iterdir():
+        if not cwd_dir.is_dir():
+            continue
+        encoded = cwd_dir.name
+        for f in cwd_dir.glob("*.jsonl"):
+            sid = f.stem
+            try:
+                mtime = int(f.stat().st_mtime)
+            except Exception:  # noqa: BLE001
+                continue
+            # Real cwd from jsonl (authoritative). Fallback to ambiguous decode.
+            real_cwd = _read_cwd_from_jsonl(f)
+            if not real_cwd:
+                real_cwd = ("/" + encoded[1:].replace("-", "/")
+                            if encoded.startswith("-") else encoded)
+            out[sid] = {"sessionId": sid, "cwd": real_cwd, "mtime": mtime}
+    return out
+
+
+def _load_window_chats() -> dict[str, dict]:
+    """Return {windowId: {chatId, groupName, cwd, createdAt}} from session_chats.json."""
+    path = MWB / "session_chats.json"
+    try:
+        data = json.loads(path.read_text())
+        return data.get("windowChats", {})
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def load(alive_only: bool = False) -> list[dict]:
+    # 1. Active windows from mwb registry (gives alias + PID + lastHookKind)
+    reg_path = MWB / "registry.json"
+    try:
+        reg_data = json.loads(reg_path.read_text())
+    except Exception:  # noqa: BLE001
+        reg_data = {"windows": {}}
+    try:
+        cfg = json.loads((MWB / "config" / "config.json").read_text())
+        mute_wids = set(cfg["notifications"].get("muteWindowIds", []))
+    except Exception:  # noqa: BLE001
+        mute_wids = set()
+    mute_lark = _lark_session_ids()
+    window_chats = _load_window_chats()
+
+    reg_by_sid: dict[str, dict] = {}
+    for wid, e in reg_data.get("windows", {}).items():
+        sid = e.get("sessionId", "")
+        if not sid:
+            continue
+        pid = e.get("claudePid", -1)
+        chat_meta = window_chats.get(wid) or {}
+        reg_by_sid[sid] = {
+            "wid": wid,
+            "alias": e.get("alias", wid),
+            "sessionId": sid,
+            "cwd": e.get("cwd", ""),
+            "pid": pid,
+            "alive": _alive(pid),
+            "lastHookAt": e.get("lastHookAt", 0),
+            "lastHookKind": e.get("lastHookKind", "?"),
+            "muted": wid in mute_wids or sid in mute_lark,
+            "registered": True,
+            "chatId": chat_meta.get("chatId"),
+            "groupName": chat_meta.get("groupName"),
+        }
+
+    if alive_only:
+        rows = list(reg_by_sid.values())
+        for r in rows:
+            r["activity"] = r["lastHookAt"]
+        return sorted(rows, key=lambda r: r["activity"], reverse=True)
+
+    # 2. All session files on disk
+    files = _scan_session_files()
+
+    # 3. Merge: every file is a row; registered ones get alias annotation
+    rows = []
+    for sid, meta in files.items():
+        if sid in reg_by_sid:
+            r = dict(reg_by_sid[sid])
+            r["activity"] = max(meta["mtime"], r["lastHookAt"])
+            rows.append(r)
+        else:
+            rows.append({
+                "wid": f"({sid[:8]})",
+                "alias": None,
+                "sessionId": sid,
+                "cwd": meta["cwd"],
+                "pid": None,
+                "alive": False,
+                "lastHookAt": 0,
+                "lastHookKind": "—",
+                "muted": False,
+                "registered": False,
+                "activity": meta["mtime"],
+                "chatId": None,
+                "groupName": None,
+            })
+    rows.sort(key=lambda r: r["activity"], reverse=True)
+    return rows
+
+
+def _truncate(s: str, n: int) -> str:
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def fmt_table(rows: list[dict]) -> str:
+    """终端友好版,等宽对齐"""
+    if not rows:
+        return "(没有 session)"
+    headers = ("WID/SID", "状态", "活动", "CWD", "SESSIONID", "群")
+    cols: list[tuple[str, list[str]]] = []
+    cols.append((headers[0], [(r["alias"] or r["wid"]) for r in rows]))
+    cols.append((headers[1], ["✅活" if r["alive"] else "—死" for r in rows]))
+    cols.append((headers[2], [_rel_time(r["activity"]) for r in rows]))
+    cols.append((headers[3], [_short_cwd(r["cwd"]) for r in rows]))
+    cols.append((headers[4], [(r["sessionId"][:8] + "…") if r["sessionId"] else "—"
+                              for r in rows]))
+    cols.append((headers[5], [_truncate(r.get("groupName") or "—", 32) for r in rows]))
+    widths = [max(len(h), max((len(v) for v in vs), default=0)) for h, vs in cols]
+    lines = ["  ".join(h.ljust(w) for (h, _), w in zip(cols, widths))]
+    lines.append("  ".join("-" * w for w in widths))
+    for i, r in enumerate(rows):
+        row_vals = [vs[i] for _, vs in cols]
+        muted = " 🔇" if r["muted"] else ""
+        lines.append("  ".join(v.ljust(w) for v, w in zip(row_vals, widths)) + muted)
+    return "\n".join(lines)
+
+
+def fmt_markdown(rows: list[dict], total: int) -> str:
+    """飞书 / Claude Code 卡片版"""
+    if not rows:
+        return "**(没有 session)**"
+    alive_n = sum(1 for r in rows if r["alive"])
+    out = []
+    out.append("## 🪟 Claude Code session")
+    out.append("")
+    out.append(f"显示 **{len(rows)} / {total}** 个 · 活 **{alive_n}** 个 · 按活动倒序")
+    out.append("")
+    out.append("| 标识 | 状态 | 活动 | CWD | 群 |")
+    out.append("|---|---|---|---|---|")
+    for r in rows:
+        if r["alias"]:
+            label = f"`{r['alias']}`"
+        else:
+            label = f"_(historical)_ `{r['sessionId'][:8]}…`"
+        status = "✅ 活" if r["alive"] else "—"
+        muted = " 🔇" if r["muted"] else ""
+        group_cell = f"`{_truncate(r.get('groupName') or '', 28)}`" if r.get("groupName") else "—"
+        out.append(f"| {label}{muted} | {status} | {_rel_time(r['activity'])} | `{_short_cwd(r['cwd'])}` | {group_cell} |")
+    out.append("")
+    out.append("---")
+    out.append("")
+    out.append("### 远程接管(飞书发,任何一行都能):")
+    out.append("")
+    for r in rows:
+        if not r["sessionId"]:
+            continue
+        label = r["alias"] or f"({r['sessionId'][:8]})"
+        out.append(f"- **`{label}`**: `/resume use {r['sessionId']}`")
+    out.append("")
+    out.append("> 提示: 接管活的 session 前最好先把那个 Warp 里的 Claude 退掉,避免双写 race。")
+    if len(rows) < total:
+        out.append("")
+        out.append(f"> 还有 {total - len(rows)} 个更早的 session 没显示。本地跑 `mwb-list --limit 50` 看更多。")
+    return "\n".join(out)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--markdown", action="store_true", help="markdown 表格 (飞书/卡片)")
+    p.add_argument("--json", action="store_true", help="原始 JSON")
+    p.add_argument("--limit", type=int, default=20, help="最多显示几行 (默认 20)")
+    p.add_argument("--alive-only", action="store_true",
+                   help="只看正在跑的 session (mwb registry,跳过历史 .jsonl)")
+    p.add_argument("--all", action="store_true", help="显示全部 (覆盖 --limit)")
+    args = p.parse_args()
+
+    rows = load(alive_only=args.alive_only)
+    total = len(rows)
+    if not args.all:
+        rows = rows[: args.limit]
+
+    if args.json:
+        print(json.dumps(rows, ensure_ascii=False, indent=2))
+    elif args.markdown:
+        print(fmt_markdown(rows, total))
+    else:
+        print(fmt_table(rows))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/multi-window-bridge/bin/mwb-mode
+++ b/contrib/multi-window-bridge/bin/mwb-mode
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# 切换 multi-window-bridge 飞书通知模式
+#
+#   mwb-mode               显示当前模式
+#   mwb-mode quiet         切到 quiet (默认): 只 ✅完成 / 🟡用户回复 / ⚠️卡死
+#   mwb-mode verbose       切到 verbose: 加 🔧 每个 Bash/Edit/Write 通知
+
+set -e
+CFG="$HOME/.claude/multi-window-bridge/config/config.json"
+
+case "${1:-show}" in
+    show|"")
+        /usr/bin/python3 -c "
+import json
+c = json.load(open('$CFG'))
+mode = c['notifications'].get('mode', 'quiet')
+on_tool = c['notifications'].get('onToolAuth', False)
+print(f'  当前模式: {mode}')
+print(f'  📢 飞书会收到:')
+print(f'     ✅ 已完成      ({\"on\" if c[\"notifications\"].get(\"onStop\", True) else \"OFF\"})')
+print(f'     🟡 真实需要回复 ({\"on\" if c[\"notifications\"].get(\"onInput\", True) else \"OFF\"})')
+print(f'     ⚠️ 疑似卡死    ({\"on\" if c[\"notifications\"].get(\"onWatchdog\", True) else \"OFF\"})')
+print(f'     🔧 即将执行    ({\"on\" if mode == \"verbose\" and on_tool else \"OFF (mode quiet 默认静音执行过程)\"})')
+"
+        ;;
+    quiet)
+        /usr/bin/python3 -c "
+import json
+p = '$CFG'
+c = json.load(open(p))
+c['notifications']['mode'] = 'quiet'
+c['notifications']['onToolAuth'] = False
+json.dump(c, open(p,'w'), indent=2, ensure_ascii=False)
+print('  ✅ 切到 quiet')
+print('     不再收到 🔧 PreToolUse 执行过程通知')
+"
+        launchctl kickstart -k gui/$(id -u)/com.local.mwb-watchdog 2>/dev/null || true
+        ;;
+    verbose)
+        /usr/bin/python3 -c "
+import json
+p = '$CFG'
+c = json.load(open(p))
+c['notifications']['mode'] = 'verbose'
+c['notifications']['onToolAuth'] = True
+json.dump(c, open(p,'w'), indent=2, ensure_ascii=False)
+print('  ✅ 切到 verbose')
+print('     🔧 Bash/Edit/Write/NotebookEdit 每次执行前都发飞书卡片')
+"
+        launchctl kickstart -k gui/$(id -u)/com.local.mwb-watchdog 2>/dev/null || true
+        ;;
+    *)
+        echo "Usage: mwb-mode [show|quiet|verbose]"
+        exit 2
+        ;;
+esac

--- a/contrib/multi-window-bridge/bin/mwb-test
+++ b/contrib/multi-window-bridge/bin/mwb-test
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Smoke test: send a ping via feishu.send_text using current config.
+
+exec /usr/bin/python3 - <<'PY'
+import sys, os, time
+sys.path.insert(0, os.path.expanduser("~/.claude/multi-window-bridge/lib"))
+import feishu, registry
+text = f"🧪 multi-window-bridge ping {time.strftime('%H:%M:%S')}\n本消息证明 bot 凭据 + 网络 + feishu API 都通。"
+mid = feishu.send_text(text)
+if mid:
+    print(f"✅ sent feishu message {mid}")
+    sys.exit(0)
+print("❌ feishu send failed — check ~/.claude/multi-window-bridge/logs/")
+sys.exit(1)
+PY

--- a/contrib/multi-window-bridge/bin/mwb-uninstall
+++ b/contrib/multi-window-bridge/bin/mwb-uninstall
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# multi-window-bridge uninstaller.
+#
+# Reverses mwb-install. DOES NOT touch lark-channel-bridge.
+# Keeps logs and registry.json so you can inspect post-mortem; deletes them
+# only with --purge.
+
+set -euo pipefail
+
+MWB="$HOME/.claude/multi-window-bridge"
+SETTINGS="$HOME/.claude/settings.json"
+ZSHRC="$HOME/.zshrc"
+LAUNCH_DIR="$HOME/Library/LaunchAgents"
+
+PURGE=0
+[[ "${1:-}" == "--purge" ]] && PURGE=1
+
+echo "→ multi-window-bridge uninstall (purge=$PURGE)"
+
+# 1. unload + remove plists
+for p in com.local.mwb-watchdog.plist com.local.mwb-receiver.plist; do
+    if [[ -f "$LAUNCH_DIR/$p" ]]; then
+        launchctl unload "$LAUNCH_DIR/$p" 2>/dev/null || true
+        rm -f "$LAUNCH_DIR/$p"
+        echo "  removed $LAUNCH_DIR/$p"
+    fi
+done
+
+# 2. strip MWB hooks from settings.json (preserve other hooks + non-hook keys)
+if [[ -f "$SETTINGS" ]]; then
+    ts="$(date +%s)"
+    cp "$SETTINGS" "$SETTINGS.bak.uninstall.$ts"
+    /usr/bin/python3 - <<'PY'
+import json, os
+path = os.path.expanduser("~/.claude/settings.json")
+with open(path) as fh:
+    cur = json.load(fh)
+hooks = cur.get("hooks", {})
+clean_hooks = {}
+for event, groups in hooks.items():
+    kept_groups = []
+    for grp in groups:
+        kept_hooks = []
+        for h in grp.get("hooks", []):
+            if "/multi-window-bridge/hooks/" in h.get("command", ""):
+                continue
+            kept_hooks.append(h)
+        if kept_hooks:
+            ng = dict(grp); ng["hooks"] = kept_hooks
+            kept_groups.append(ng)
+    if kept_groups:
+        clean_hooks[event] = kept_groups
+if clean_hooks:
+    cur["hooks"] = clean_hooks
+else:
+    cur.pop("hooks", None)
+with open(path, "w") as fh:
+    json.dump(cur, fh, indent=2, ensure_ascii=False)
+print("  stripped MWB hooks from settings.json")
+PY
+fi
+
+# 3. zshrc — remove the source line
+if [[ -f "$ZSHRC" ]]; then
+    /usr/bin/sed -i.bak.uninstall '/multi-window-bridge\/bin\/cc-register/d; /^# multi-window-bridge$/d' "$ZSHRC"
+    echo "  removed cc-register line from ~/.zshrc"
+fi
+
+# 4. optionally purge MWB home
+if (( PURGE )); then
+    rm -rf "$MWB"
+    echo "  purged $MWB (logs + registry deleted)"
+else
+    echo "  kept $MWB (run with --purge to delete)"
+fi
+
+echo "✅ uninstall complete. lark-channel-bridge is untouched."

--- a/contrib/multi-window-bridge/config/config.json
+++ b/contrib/multi-window-bridge/config/config.json
@@ -1,0 +1,44 @@
+{
+  "feishu": {
+    "chatId": "oc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "credentialFile": "~/.lark-channel/config.json",
+    "userOpenId": "ou_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    "perWindowGroups": {
+      "enabled": false,
+      "groupNameTemplate": "claude · {windowId} · {cwdBase}"
+    }
+  },
+  "notifications": {
+    "onInput": true,
+    "onToolAuth": false,
+    "onStop": true,
+    "onWatchdog": true,
+    "toolAuthIncludes": [
+      "Bash",
+      "Edit",
+      "Write",
+      "NotebookEdit",
+      "AskUserQuestion"
+    ],
+    "minIntervalSecondsPerWindow": 5,
+    "muteLarkChannelSessions": true,
+    "muteWindowIds": [],
+    "mode": "quiet"
+  },
+  "watchdog": {
+    "intervalSeconds": 60,
+    "staleThresholdSeconds": 600,
+    "rearmAfterAlertSeconds": 1800
+  },
+  "stage2": {
+    "enabled": false,
+    "pollIntervalSeconds": 30,
+    "allowAppleScriptPaste": false,
+    "warpAppPath": "/Applications/Warp.app",
+    "killOldPidBeforeResume": true,
+    "guardBusy": true,
+    "guardBusyKinds": [
+      "PreToolUse"
+    ]
+  }
+}

--- a/contrib/multi-window-bridge/daemon/receiver.py
+++ b/contrib/multi-window-bridge/daemon/receiver.py
@@ -1,0 +1,226 @@
+"""Receiver: poll the configured Feishu chat for replies, route by window_id.
+
+Reply protocols supported (in priority order):
+  1. **Prefix tag**: text body starts with `[window-id]` or `window-id:`
+     e.g.  `[kb-1] 继续干`  /  `kb-1: 继续干`
+  2. **Quote reply**: user quotes a notification we sent — Feishu API surfaces
+     the parent message_id; we look it up in registry.notifications.
+  3. Plain text with NO tag is ignored (avoids stealing messages destined for
+     lark-channel-bridge, which is also listening on the same chat).
+
+State (persisted at MWB/.receiver_state.json):
+  { "lastSeenTs": <unix>, "processedIds": [<recent msg_ids, capped 200>] }
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import signal
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+from common import MWB_HOME, load_config, log, now_ts  # noqa: E402
+import feishu  # noqa: E402
+import registry  # noqa: E402
+import router  # noqa: E402
+
+STATE_PATH = MWB_HOME / ".receiver_state.json"
+
+PREFIX_RE = re.compile(r"^\s*[\[【]\s*([A-Za-z0-9_\-]{1,60})\s*[\]】](!?)\s*(.+)$", re.DOTALL)
+COLON_RE = re.compile(r"^\s*([A-Za-z0-9_\-]{1,60})(!?)\s*[:：]\s*(.+)$", re.DOTALL)
+
+_RUN = True
+
+
+def _stop(_s, _f) -> None:  # noqa: ANN001
+    global _RUN
+    _RUN = False
+
+
+def _load_state() -> dict:
+    if STATE_PATH.exists():
+        try:
+            return json.loads(STATE_PATH.read_text())
+        except Exception:  # noqa: BLE001
+            pass
+    return {"lastSeenTs": now_ts() - 60, "processedIds": []}
+
+
+def _save_state(state: dict) -> None:
+    state["processedIds"] = state["processedIds"][-200:]
+    STATE_PATH.write_text(json.dumps(state))
+
+
+def _extract_text(msg: dict) -> str:
+    """Pluck plain text from a Feishu message envelope."""
+    body = msg.get("body", {})
+    content = body.get("content", "")
+    if not content:
+        return ""
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return ""
+    if msg.get("msg_type") == "text":
+        return parsed.get("text", "")
+    if msg.get("msg_type") == "post":
+        # Rich text — pull all text segments
+        out = []
+        for line in parsed.get("zh_cn", {}).get("content", []) or parsed.get("en_us", {}).get("content", []) or []:
+            for seg in line:
+                if seg.get("tag") == "text":
+                    out.append(seg.get("text", ""))
+        return " ".join(out)
+    return ""
+
+
+def _parse_reply(text: str) -> tuple[str, bool, str] | None:
+    """Returns (window_id, force_bypass_guard, reply_text) or None."""
+    for rx in (PREFIX_RE, COLON_RE):
+        m = rx.match(text)
+        if m:
+            return m.group(1), m.group(2) == "!", m.group(3).strip()
+    return None
+
+
+def _quoted_parent_id(msg: dict) -> str | None:
+    upper = msg.get("upper_message_id")
+    if upper:
+        return upper
+    parent = msg.get("parent_id")
+    return parent or None
+
+
+def _tick(cfg: dict, state: dict) -> None:
+    chat_id = cfg["feishu"]["chatId"]
+    since = max(state["lastSeenTs"] - 5, now_ts() - 24 * 3600)  # safety floor
+    items = feishu.list_chat_messages(chat_id, start_time=since, page_size=20)
+    # Feishu returns desc by create time; process oldest first.
+    items = list(reversed(items))
+    processed_set = set(state["processedIds"])
+    for msg in items:
+        mid = msg.get("message_id", "")
+        if not mid or mid in processed_set:
+            continue
+        # Skip messages sent BY the bot itself (sender is app)
+        sender_type = msg.get("sender", {}).get("sender_type")
+        if sender_type == "app":
+            state["processedIds"].append(mid)
+            continue
+        text = _extract_text(msg)
+        if not text:
+            state["processedIds"].append(mid)
+            continue
+
+        window_id = None
+        reply = None
+        force = False
+
+        parsed = _parse_reply(text)
+        if parsed:
+            window_id, force, reply = parsed
+            if not registry.lookup_by_window_id(window_id):
+                window_id = None
+
+        if not window_id:
+            parent_id = _quoted_parent_id(msg)
+            if parent_id:
+                wid = registry.find_window_for_notification(parent_id)
+                if wid:
+                    window_id = wid
+                    reply = text.strip()
+                    # Quote-reply path: no `!` syntax, default no force.
+                    force = False
+
+        if not window_id:
+            log("receiver.ignore", mid=mid, head=text[:60])
+            state["processedIds"].append(mid)
+            continue
+
+        log("receiver.route", mid=mid, windowId=window_id, force=force,
+            head=(reply or "")[:60])
+        try:
+            result = router.route(window_id, reply or "", force=force)
+            log("receiver.route.done", mid=mid, windowId=window_id, result=result)
+        except Exception as e:  # noqa: BLE001
+            log("receiver.route.err", mid=mid, err=str(e))
+        state["processedIds"].append(mid)
+
+    # Advance the time floor only as far as the most recent message we saw.
+    if items:
+        latest = items[-1]
+        ct = latest.get("create_time")
+        if ct:
+            try:
+                state["lastSeenTs"] = int(int(ct) / 1000)
+            except (ValueError, TypeError):
+                pass
+    state["lastSeenTs"] = max(state["lastSeenTs"], now_ts() - 3600)
+
+    # Drain pending queue: any windows that are now idle get their queued
+    # replies auto-fired. This is Option B (auto-continue after Claude finishes).
+    _drain_pending()
+
+
+IDLE_KINDS = ("Stop", "Notification", "SessionStart")
+
+
+def _drain_pending() -> None:
+    pending = router.list_pending()
+    for wid, items in list(pending.items()):
+        if not items:
+            continue
+        entry = registry.lookup_by_window_id(wid)
+        if not entry:
+            # Window is gone (claude died / session ended). Drop pending.
+            router.clear_pending(wid)
+            log("drain.window_gone", windowId=wid, dropped=len(items))
+            continue
+        last_kind = entry.get("lastHookKind", "")
+        if last_kind not in IDLE_KINDS:
+            # Still busy. Skip; next tick will retry.
+            continue
+        text = router.pop_pending(wid)
+        if not text:
+            continue
+        log("drain.firing", windowId=wid, head=text[:60])
+        try:
+            result = router.route(wid, text, force=True)
+            log("drain.fired", windowId=wid, result=result)
+        except Exception as e:  # noqa: BLE001
+            log("drain.err", windowId=wid, err=str(e))
+            # Re-queue at head so we retry next tick
+            router.add_pending(wid, text)
+
+
+def main() -> int:
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+    log("receiver.boot", pid=os.getpid())
+    state = _load_state()
+    while _RUN:
+        try:
+            cfg = load_config()
+            if not cfg["stage2"]["enabled"]:
+                # Stay alive but idle so launchd doesn't crash-loop us.
+                time.sleep(30)
+                continue
+            _tick(cfg, state)
+            _save_state(state)
+        except Exception as e:  # noqa: BLE001
+            log("receiver.tick.err", err=str(e))
+        interval = max(10, load_config()["stage2"]["pollIntervalSeconds"])
+        for _ in range(interval):
+            if not _RUN:
+                break
+            time.sleep(1)
+    log("receiver.exit")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/multi-window-bridge/daemon/router.py
+++ b/contrib/multi-window-bridge/daemon/router.py
@@ -1,0 +1,315 @@
+"""Router: given a (window_id, reply_text), resume the session in a new Warp tab.
+
+Strategy (Stage 2, Method A):
+  0. **Probe**: can osascript control Warp? If not → bail BEFORE killing.
+  1. Look up registry entry for window_id → sessionId + claudePid
+  2. **Busy guard**: refuse if Claude is mid-task (unless force=True)
+  3. SIGTERM old pid (so two `claude` processes don't fight over session.jsonl)
+  4. Put reply_text on the macOS clipboard
+  5. AppleScript: activate Warp → Cmd+T → type `claude --resume <sid>` → Enter
+  6. If allowAppleScriptPaste: Cmd+V + Enter; else user pastes manually
+
+A queue at MWB/pending.json holds replies that were refused (busy / no perm).
+The receiver daemon drains the queue when Claude transitions back to idle.
+"""
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+from common import MWB_HOME, file_lock, load_config, log  # noqa: E402
+import feishu  # noqa: E402
+import registry  # noqa: E402
+import json  # noqa: E402
+
+PENDING_PATH = MWB_HOME / "pending.json"
+
+
+def _load_pending() -> dict:
+    if PENDING_PATH.exists():
+        try:
+            return json.loads(PENDING_PATH.read_text())
+        except Exception:  # noqa: BLE001
+            pass
+    return {}
+
+
+def _save_pending(data: dict) -> None:
+    PENDING_PATH.write_text(json.dumps(data, ensure_ascii=False, indent=2))
+
+
+def add_pending(wid: str, text: str) -> int:
+    """Queue a reply for later auto-fire when window goes idle."""
+    with file_lock(PENDING_PATH):
+        p = _load_pending()
+        p.setdefault(wid, []).append({"text": text, "savedAt": int(time.time())})
+        _save_pending(p)
+        return len(p[wid])
+
+
+def pop_pending(wid: str) -> str | None:
+    with file_lock(PENDING_PATH):
+        p = _load_pending()
+        items = p.get(wid, [])
+        if not items:
+            return None
+        item = items.pop(0)
+        if not items:
+            del p[wid]
+        _save_pending(p)
+        return item["text"]
+
+
+def clear_pending(wid: str) -> int:
+    with file_lock(PENDING_PATH):
+        p = _load_pending()
+        n = len(p.get(wid, []))
+        if wid in p:
+            del p[wid]
+        _save_pending(p)
+        return n
+
+
+def list_pending() -> dict:
+    return _load_pending()
+
+
+def _pbcopy(text: str) -> bool:
+    try:
+        p = subprocess.Popen(["/usr/bin/pbcopy"], stdin=subprocess.PIPE)
+        p.communicate(text.encode("utf-8"))
+        return p.returncode == 0
+    except Exception as e:  # noqa: BLE001
+        log("router.pbcopy.fail", err=str(e))
+        return False
+
+
+def _osascript(script: str) -> tuple[int, str]:
+    try:
+        r = subprocess.run(
+            ["/usr/bin/osascript", "-e", script],
+            capture_output=True, text=True, timeout=10,
+        )
+        return r.returncode, (r.stderr or r.stdout).strip()
+    except Exception as e:  # noqa: BLE001
+        return -1, str(e)
+
+
+def probe_applescript() -> tuple[bool, str]:
+    """Return (ok, diagnostic). Verifies osascript can both 'tell Warp' and
+    drive System Events keystrokes — both Automation and Accessibility perms.
+    """
+    # Test Automation perm (tell Warp)
+    rc, out = _osascript('tell application "Warp" to return name as string')
+    if rc != 0:
+        return False, f"automation: {out[:200]}"
+    # Test Accessibility perm (System Events keystrokes — innocuous probe)
+    rc, out = _osascript('tell application "System Events" to return name of first process')
+    if rc != 0:
+        return False, f"accessibility: {out[:200]}"
+    return True, "ok"
+
+
+def _open_warp_tab_and_run(command: str, auto_paste_text: str | None) -> tuple[bool, str]:
+    """Open a fresh Warp tab, type `command`, press Enter.
+
+    If auto_paste_text is non-None, after 2.5s also Cmd+V + Enter.
+    Both stages need Accessibility permission for `osascript` (System Settings →
+    Privacy & Security → Accessibility → enable for osascript / Terminal /
+    whoever ran this).
+    """
+    # AppleScript-quote: backslashes + double quotes
+    cmd_q = command.replace("\\", "\\\\").replace('"', '\\"')
+    script = (
+        'tell application "Warp" to activate\n'
+        'delay 0.3\n'
+        'tell application "System Events"\n'
+        '    keystroke "t" using {command down}\n'
+        '    delay 0.6\n'
+        f'    keystroke "{cmd_q}"\n'
+        '    key code 36\n'  # Enter
+        'end tell\n'
+    )
+    rc, out = _osascript(script)
+    if rc != 0:
+        return False, f"osascript phase1 rc={rc}: {out}"
+    if auto_paste_text is not None:
+        if not _pbcopy(auto_paste_text):
+            return True, "tab opened but pbcopy failed; please paste manually"
+        # Wait longer so Claude TUI is fully booted AND any trust-folder prompt
+        # ("Is this a project you trust?") has rendered. The first Enter then
+        # accepts the default "Yes, I trust this folder" option if shown, or
+        # no-ops in Claude's chat input if not.
+        time.sleep(3.5)
+        paste_script = (
+            'tell application "Warp" to activate\n'
+            'tell application "System Events"\n'
+            '    -- Step 1: pre-emptively accept any first-time trust prompt\n'
+            '    --        (default option is "Yes, I trust this folder")\n'
+            '    key code 36\n'
+            '    delay 1.0\n'
+            '    -- Step 2: paste the actual reply and submit\n'
+            '    keystroke "v" using {command down}\n'
+            '    delay 0.3\n'
+            '    key code 36\n'
+            'end tell\n'
+        )
+        rc2, out2 = _osascript(paste_script)
+        if rc2 != 0:
+            return True, f"tab opened; auto-paste failed (rc={rc2}: {out2})"
+    return True, "ok"
+
+
+def route(window_id: str, reply_text: str, force: bool = False) -> str:
+    """Main entry: returns a human-readable status string for logging / feishu.
+
+    `force=True` bypasses the "Claude is busy mid-task" guard. Set this via
+    the `[wid]! ...` syntax from feishu.
+    """
+    cfg = load_config()
+    if not cfg["stage2"]["enabled"]:
+        return "stage2 disabled in config"
+
+    entry = registry.lookup_by_window_id(window_id)
+    if not entry:
+        return f"no such window: {window_id}"
+
+    sid = entry["sessionId"]
+    pid = entry.get("claudePid", -1)
+    cwd = entry.get("cwd", "~")
+
+    # PRE-FLIGHT: probe osascript permissions BEFORE killing anything.
+    # Without Accessibility + Automation perms, we'd kill old Claude and then
+    # fail to open a new tab — losing the user's running session.
+    ok, why = probe_applescript()
+    if not ok:
+        _pbcopy(reply_text)
+        add_pending(window_id, reply_text)
+        feishu.send_card(
+            title=f"⚠️ [{window_id}] 自动接管失败 (osascript 没权限)",
+            body=(
+                f"osascript 不能控制 Warp:\n```\n{why}\n```\n\n"
+                f"**原 Claude 进程没动** — 你的会话还活着。\n\n"
+                f"## 现在怎么办\n"
+                f"你的回复**已复制到剪贴板** + **存到 pending 队列**。\n"
+                f"在 Warp 里随便开个新 tab,跑:\n"
+                f"```bash\n"
+                f"claude --resume {sid}\n"
+                f"```\n"
+                f"Claude TUI 起来后 **Cmd+V + Enter**。\n\n"
+                f"## 一劳永逸:给 osascript 权限\n"
+                f"系统设置 → 隐私与安全性 →\n"
+                f"- **自动化**: 找到「osascript」,勾上「Warp」+「System Events」\n"
+                f"- **辅助功能**: + `/usr/bin/osascript`\n\n"
+                f"给完权限后,飞书再发 `[{window_id}]! 重试` 触发一次。"
+            ),
+            color="red",
+        )
+        log("router.no_applescript", windowId=window_id, why=why)
+        return f"no AppleScript permission: {why}"
+
+    # Safety guard: refuse kill if Claude is mid-task.
+    # When Claude calls a tool, lastHookKind transitions to "PreToolUse" and
+    # stays there until Stop (turn finished) or a new Notification fires. If
+    # we kill mid-tool, the tool's result is lost and the session.jsonl ends
+    # up with a tool_use that has no tool_result — Claude on --resume may
+    # re-run the tool (waste) or get confused (incorrect state).
+    guard = cfg["stage2"].get("guardBusy", True)
+    busy_kinds = cfg["stage2"].get("guardBusyKinds", ["PreToolUse"])
+    last_kind = entry.get("lastHookKind", "")
+    if guard and not force and last_kind in busy_kinds:
+        last_at = entry.get("lastHookAt", 0)
+        age = max(0, int(time.time()) - last_at)
+        summary = entry.get("lastHookSummary", "")
+        mins, sec = divmod(age, 60)
+        when = f"{mins}分{sec}秒前" if mins else f"{sec}秒前"
+        _pbcopy(reply_text)
+        feishu.send_card(
+            title=f"⏸ [{window_id}] 正在干活,已拒绝接管",
+            body=(
+                f"上一个事件: `{last_kind}` ({when})\n"
+                f"内容: `{summary[:200]}`\n\n"
+                f"**强行 kill 可能让任务半截死掉**(Bash 子进程会被一起杀,"
+                f"Edit/Write 已落地但 Claude resume 后不知道)。\n\n"
+                f"---\n\n"
+                f"你的回复已**复制到剪贴板**,可以手动粘到对应 Warp tab。\n\n"
+                f"**要强制接管**: 飞书回 `[{window_id}]! 你的话`(加感叹号绕过守卫)"
+            ),
+            color="yellow",
+        )
+        add_pending(window_id, reply_text)
+        log("router.refused_busy", windowId=window_id,
+            lastKind=last_kind, ageSec=age, summary=summary[:80])
+        return f"refused: busy ({last_kind}, {age}s ago)"
+
+    # Always copy reply to clipboard so user has a fallback no matter what.
+    _pbcopy(reply_text)
+
+    # Decoupled flow (ORDER MATTERS — opening tab BEFORE killing old):
+    #
+    #   1. Open new Warp tab + run `claude --resume <sid>` [implicitly tests
+    #      that keystroke perm works; if not, we still have old Claude alive]
+    #   2. If tab open succeeded → kill old PID
+    #   3. (After ~2.5s) auto-paste the reply if enabled
+    #
+    # The OLD ordering (kill → open tab) caused a disaster when the
+    # `keystroke` permission was missing: old Claude died but new tab never
+    # opened, stranding the user with a dead session.
+    cmd = f"cd {shlex.quote(cwd)} && claude --resume {shlex.quote(sid)}"
+    auto = reply_text if cfg["stage2"]["allowAppleScriptPaste"] else None
+    ok, msg = _open_warp_tab_and_run(cmd, auto)
+    log("router.resume", windowId=window_id, ok=ok, msg=msg, autoPaste=bool(auto))
+
+    if not ok:
+        # Tab open failed. Old Claude is STILL ALIVE — no damage.
+        # Queue the reply so the drain can retry once user fixes perms.
+        add_pending(window_id, reply_text)
+        feishu.send_card(
+            title=f"⚠️ [{window_id}] 接管失败 (原 Claude 没动)",
+            body=(
+                f"开 Warp tab 失败 — 通常是 `keystroke` 没辅助功能权限:\n"
+                f"```\n{msg[:400]}\n```\n\n"
+                f"**原 Claude 进程没被杀**,会话完好。\n\n"
+                f"## 现在怎么办\n"
+                f"你的回复**已复制到剪贴板** + **已存到 pending 队列**。\n\n"
+                f"1. 给 osascript 辅助功能权限:\n"
+                f"   系统设置 → 隐私与安全性 → **辅助功能** → 找 `osascript` 勾上\n"
+                f"   (找不到就 +/usr/bin/osascript)\n"
+                f"2. **重启 receiver** 让它拿到新权限:\n"
+                f"   `launchctl kickstart -k gui/$(id -u)/com.local.mwb-receiver`\n"
+                f"3. pending 队列里你这条会**自动重试**——只要 Claude 是 idle 状态。\n\n"
+                f"## 或者手动接管(立刻能用)\n"
+                f"在 Warp 里跑:\n```bash\nclaude --resume {sid}\n```\n"
+                f"剪贴板里是你的回复,TUI 起来后 Cmd+V + Enter。"
+            ),
+            color="red",
+        )
+        return f"⚠️ tab open failed (old Claude untouched): {msg}"
+
+    # Tab opened OK — now safe to kill old.
+    if cfg["stage2"]["killOldPidBeforeResume"]:
+        kill_ok, kill_msg = registry.kill_window_pid(window_id)
+        log("router.kill_old", windowId=window_id, ok=kill_ok, msg=kill_msg)
+
+    # User took control; clear any stale pending for this window.
+    clear_pending(window_id)
+    if auto is None:
+        feishu.send_text(
+            f"📲 [{window_id}] 已开新窗口跑 `claude --resume`,"
+            f"回复内容已复制到剪贴板。等 TUI 起来后到 Warp 里按 Cmd+V 回车就行。"
+        )
+    else:
+        feishu.send_text(f"📲 [{window_id}] 已开新窗口并自动粘入回复,请在 Warp 里检查。")
+    return msg
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("usage: router.py <window_id> <reply_text>")
+        sys.exit(2)
+    print(route(sys.argv[1], sys.argv[2]))

--- a/contrib/multi-window-bridge/daemon/watchdog.py
+++ b/contrib/multi-window-bridge/daemon/watchdog.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Watchdog: catches hung Claude sessions that hooks couldn't notify about.
+
+Algorithm (each tick):
+  1. Read registry
+  2. Prune entries whose claudePid is dead → log eviction (do not notify, hooks
+     would have already sent Stop / SessionEnd; if they didn't, the user already
+     closed the terminal so no signal needed).
+  3. For each surviving window:
+     - if (now - lastHookAt) > staleThresholdSeconds
+       AND (now - lastWatchdogAlertAt) > rearmAfterAlertSeconds
+       → send feishu "疑似卡死", stamp lastWatchdogAlertAt
+"""
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import time
+from datetime import datetime
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+from common import file_lock, is_muted, load_config, log, now_ts  # noqa: E402
+import feishu  # noqa: E402
+import registry  # noqa: E402
+
+_RUN = True
+
+
+def _stop(_signum, _frame) -> None:  # noqa: ANN001
+    global _RUN
+    _RUN = False
+
+
+def _tick(cfg: dict) -> None:
+    wd_cfg = cfg["watchdog"]
+    stale = wd_cfg["staleThresholdSeconds"]
+    notify_on_watchdog = cfg["notifications"].get("onWatchdog", True)
+
+    # Snapshot under lock — but we send feishu *outside* the lock to avoid I/O hold.
+    with file_lock(registry.REGISTRY_PATH):
+        data = registry._read()
+        evicted = registry._prune_dead(data)
+        if evicted:
+            registry._atomic_write(data)
+            log("watchdog.evicted", windowIds=evicted)
+        snapshot = {wid: dict(e) for wid, e in data["windows"].items()}
+
+    now = now_ts()
+    for wid, entry in snapshot.items():
+        last_hook = entry.get("lastHookAt", 0)
+        last_alerted_hook = entry.get("lastAlertedHookAt", 0)
+        age = now - last_hook
+        if age < stale:
+            continue
+        # Edge-trigger: only alert ONCE per "stale period". We've already alerted
+        # for this lastHookAt — don't repeat until the session shows life (new
+        # heartbeat → lastHookAt advances → we'd alert if it goes stale again).
+        if last_hook <= last_alerted_hook:
+            continue
+        if not notify_on_watchdog:
+            registry.update_watchdog_state(wid, last_alerted_hook_at=last_hook)
+            continue
+        if is_muted(session_id=entry.get("sessionId", ""), window_id=wid):
+            registry.update_watchdog_state(wid, last_alerted_hook_at=last_hook)
+            log("watchdog.muted", windowId=wid)
+            continue
+        cwd = entry.get("cwd", "?")
+        last_kind = entry.get("lastHookKind", "?")
+        title = f"⚠️ [{wid}] 疑似卡死"
+        body = (
+            f"📁 `{cwd}`\n\n"
+            f"⏱ 最后活动 **{age // 60} 分钟前** (事件: `{last_kind}`)\n"
+            f"💀 PID `{entry.get('claudePid')}` 仍存活但未触发任何 hook\n\n"
+            f"_(同一卡死只提醒这一次。session 若恢复活动再卡死,会再提醒)_"
+        )
+        msg_id = feishu.send_card(title, body, color="red")
+        if msg_id:
+            registry.record_notification(msg_id, wid, "Watchdog")
+        registry.update_watchdog_state(wid, last_alerted_hook_at=last_hook)
+        log("watchdog.alert", windowId=wid, ageMin=age // 60, msgId=msg_id)
+
+
+def main() -> int:
+    signal.signal(signal.SIGTERM, _stop)
+    signal.signal(signal.SIGINT, _stop)
+    log("watchdog.boot", pid=os.getpid())
+    while _RUN:
+        try:
+            cfg = load_config()
+            _tick(cfg)
+        except Exception as e:  # noqa: BLE001
+            log("watchdog.tick.error", err=str(e))
+        interval = max(10, load_config()["watchdog"]["intervalSeconds"])
+        # sleep in 1s slices so SIGTERM is responsive
+        for _ in range(interval):
+            if not _RUN:
+                break
+            time.sleep(1)
+    log("watchdog.exit")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/multi-window-bridge/hooks/notification.py
+++ b/contrib/multi-window-bridge/hooks/notification.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Notification hook: Claude is asking for user input. Push to feishu."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+from common import is_muted, load_config, log, now_ts, truncate, truncate_body  # noqa: E402
+import async_send  # noqa: E402
+import registry  # noqa: E402
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception as e:  # noqa: BLE001
+        log("hook.notification.parse_fail", err=str(e))
+        return 0
+
+    session_id = payload.get("session_id") or ""
+    message = payload.get("message") or ""
+    cwd = payload.get("cwd") or ""
+
+    cfg = load_config()
+    if not cfg["notifications"].get("onInput", True):
+        return 0
+
+    # Skip generic idle-pings. Claude Code fires Notification both for genuine
+    # attention requests (permission prompts, real questions) AND for routine
+    # idle-after-Stop ("Claude is waiting for your input"). Under bypassPerms
+    # the idle ones add zero info — Stop already told the user we're done. We
+    # still heartbeat so watchdog knows the session is alive.
+    msg_low = (message or "").strip().lower()
+    IDLE_MARKERS = (
+        "claude is waiting for your input",
+        "claude is waiting",
+        "is waiting for your input",
+    )
+    is_idle = any(m in msg_low for m in IDLE_MARKERS)
+
+    wid = registry.heartbeat(session_id, "Notification", truncate(message, 200))
+    if not wid:
+        # Window not yet registered (SessionStart may have raced). Skip silently.
+        log("hook.notification.no_window", sessionId=session_id[:8])
+        return 0
+
+    if is_idle:
+        # Heartbeat done (watchdog will know we're alive); don't spam feishu.
+        log("hook.notification.skipped_idle", windowId=wid)
+        return 0
+
+    if is_muted(session_id=session_id, window_id=wid):
+        log("hook.notification.muted", windowId=wid)
+        return 0
+
+    # Rate limit per window
+    min_interval = cfg["notifications"].get("minIntervalSecondsPerWindow", 5)
+    state_path = os.path.join(os.path.dirname(__file__), "..", "logs", ".last_notif.json")
+    try:
+        state = json.load(open(state_path)) if os.path.exists(state_path) else {}
+    except Exception:  # noqa: BLE001
+        state = {}
+    last = state.get(wid, 0)
+    if now_ts() - last < min_interval:
+        log("hook.notification.rate_limited", windowId=wid, ageSec=now_ts() - last)
+        return 0
+
+    # Stamp rate-limit BEFORE dispatch. Async dispatch can't tell us if send
+    # succeeds within hook lifetime, so we optimistically gate further attempts.
+    # If the async worker fails it logs hook.notification.send_failed; user can
+    # inspect logs but won't see a duplicate flood.
+    state[wid] = now_ts()
+    try:
+        json.dump(state, open(state_path, "w"))
+    except Exception:  # noqa: BLE001
+        pass
+    title = f"🟡 [{wid}] 需要你回复"
+    body = f"📁 `{cwd}`\n\n{truncate_body(message, 800)}"
+    async_send.dispatch_card(title, body, "yellow", wid, "Notification")
+    log("hook.notification.dispatched", windowId=wid, msg=truncate(message, 80))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/multi-window-bridge/hooks/pre_tool_use.py
+++ b/contrib/multi-window-bridge/hooks/pre_tool_use.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""PreToolUse hook: tool is about to run. Notify on sensitive tools.
+
+We DO NOT block (exit 0 always). The point is observability, not policy.
+
+Note: Under defaultMode=allow / bypassPermissions, Claude does NOT actually
+prompt the user for tool approval. So this hook fires as an FYI ("Claude is
+about to run X") rather than an auth request. The notification copy reflects
+that.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+from common import is_muted, load_config, log, truncate, truncate_body  # noqa: E402
+import async_send  # noqa: E402
+import registry  # noqa: E402
+
+
+def _summarize_tool(tool: str, ti: dict) -> tuple[str, str, str]:
+    """Returns (title_suffix, body_markdown, color) for a tool call."""
+    if tool == "Bash":
+        cmd = ti.get("command", "")
+        return ("即将执行 Bash", f"```bash\n{cmd}\n```", "blue")
+    if tool == "Edit":
+        fp = ti.get("file_path", "?")
+        old = ti.get("old_string", "")
+        new = ti.get("new_string", "")
+        diff = ""
+        if old or new:
+            diff = f"\n\n```diff\n- {old[:200]}\n+ {new[:200]}\n```"
+        return ("即将编辑文件", f"📄 `{fp}`{diff}", "blue")
+    if tool == "Write":
+        fp = ti.get("file_path", "?")
+        content_head = (ti.get("content", "") or "")[:200]
+        preview = f"\n\n```\n{content_head}\n```" if content_head else ""
+        return ("即将写文件", f"📄 `{fp}`{preview}", "blue")
+    if tool == "NotebookEdit":
+        nb = ti.get("notebook_path", "?")
+        cell = ti.get("cell_id", "?")
+        return ("即将改 notebook", f"📓 `{nb}` (cell `{cell}`)", "blue")
+    if tool == "AskUserQuestion":
+        # Special UX: Claude is asking the user a multi-choice question.
+        qs = ti.get("questions") or []
+        if not qs:
+            return ("Claude 想问你", "(没有问题内容)", "yellow")
+        parts = []
+        for q in qs:
+            qtext = q.get("question", "")
+            opts = q.get("options", [])
+            parts.append(f"**{qtext}**\n")
+            for i, opt in enumerate(opts, 1):
+                label = opt.get("label", "")
+                desc = opt.get("description", "")
+                parts.append(f"{i}. **{label}** — {desc}")
+            parts.append("")  # blank line between questions
+        return ("Claude 想问你", "\n".join(parts), "yellow")
+    return (f"即将执行 {tool}",
+            f"```json\n{json.dumps(ti, ensure_ascii=False, indent=2)[:600]}\n```",
+            "blue")
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception as e:  # noqa: BLE001
+        log("hook.pretool.parse_fail", err=str(e))
+        return 0
+
+    session_id = payload.get("session_id") or ""
+    tool = payload.get("tool_name") or ""
+    ti = payload.get("tool_input") or {}
+
+    cfg = load_config()
+    notify_cfg = cfg["notifications"]
+
+    # Always heartbeat (proves session alive for watchdog) BEFORE any return.
+    registry.heartbeat(session_id, "PreToolUse", f"{tool}")
+
+    # AskUserQuestion = 真正的"需要用户确认",任何模式都发。
+    # Bash / Edit / Write / NotebookEdit = "执行过程",受 mode 控制。
+    is_user_attention = (tool == "AskUserQuestion")
+    if not is_user_attention:
+        # Mode quiet (默认) → 不发"执行过程"通知
+        mode = notify_cfg.get("mode", "quiet")
+        if mode == "quiet":
+            return 0
+        # Mode verbose → 还要看老的 onToolAuth + toolAuthIncludes 细控
+        if not notify_cfg.get("onToolAuth", False):
+            return 0
+        allow = notify_cfg.get("toolAuthIncludes", ["Bash", "Edit", "Write"])
+        if tool not in allow:
+            return 0
+
+    # Build the notification payload (title suffix / body / color) from the call.
+    title_suffix, body, color = _summarize_tool(tool, ti)
+    icon = "🟡" if is_user_attention else "🔧"
+
+    wid = registry.heartbeat(session_id, "PreToolUse",
+                             f"{tool}: {truncate(body, 200)}")
+    if not wid:
+        return 0
+    if is_muted(session_id=session_id, window_id=wid):
+        log("hook.pretool.muted", windowId=wid, tool=tool)
+        return 0
+    title = f"{icon} [{wid}] {title_suffix}"
+    async_send.dispatch_card(title, truncate_body(body, 1200), color,
+                             wid, "PreToolUse")
+    log("hook.pretool.dispatched", windowId=wid, tool=tool,
+        summary=truncate(body, 80))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/multi-window-bridge/hooks/session_end.py
+++ b/contrib/multi-window-bridge/hooks/session_end.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""SessionEnd hook: remove window from registry."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+from common import log  # noqa: E402
+import registry  # noqa: E402
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception as e:  # noqa: BLE001
+        log("hook.session_end.parse_fail", err=str(e))
+        return 0
+    session_id = payload.get("session_id") or ""
+    reason = payload.get("reason") or "unknown"
+    wid = registry.unregister(session_id)
+    log("hook.session_end", windowId=wid, sessionId=session_id[:8], reason=reason)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/multi-window-bridge/hooks/session_start.py
+++ b/contrib/multi-window-bridge/hooks/session_start.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""SessionStart hook: register window in MWB registry.
+
+Stdin (Claude Code v1.x):
+  { "session_id": ..., "cwd": ..., "transcript_path": ..., "source": "startup|resume|...", ... }
+
+We register {session_id → window_id} using env MWB_WINDOW_ALIAS if set.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+from common import log, load_config  # noqa: E402
+import registry  # noqa: E402
+import session_chats  # noqa: E402
+
+
+def _spawn_group_create(window_id: str, cwd: str) -> None:
+    """Spawn detached group-create worker. Never raises."""
+    try:
+        worker = os.path.join(os.path.dirname(__file__), "..", "lib",
+                               "group_create_worker.py")
+        subprocess.Popen(
+            [sys.executable, worker, window_id, cwd],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+    except Exception as e:  # noqa: BLE001
+        log("hook.session_start.group_spawn_fail", err=str(e))
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception as e:  # noqa: BLE001
+        log("hook.session_start.parse_fail", err=str(e))
+        return 0
+
+    session_id = payload.get("session_id") or ""
+    cwd = payload.get("cwd") or os.getcwd()
+    transcript_path = payload.get("transcript_path") or ""
+    source = payload.get("source") or "unknown"
+    if not session_id:
+        return 0
+
+    alias = os.environ.get("MWB_WINDOW_ALIAS")
+    claude_pid = os.getppid()  # parent of hook is claude process
+
+    wid = None
+    try:
+        wid = registry.register(
+            session_id=session_id,
+            cwd=cwd,
+            claude_pid=claude_pid,
+            transcript_path=transcript_path,
+            alias=alias,
+        )
+        log("hook.session_start", windowId=wid, sessionId=session_id[:8],
+            cwd=cwd, source=source, pid=claude_pid, alias=alias)
+    except Exception as e:  # noqa: BLE001
+        log("hook.session_start.fail", err=str(e))
+
+    # Per-window-group: kick off async group creation if not yet mapped.
+    # No-ops if perWindowGroups.enabled=false OR mapping already exists.
+    if wid:
+        try:
+            cfg = load_config()
+            pwg = cfg.get("feishu", {}).get("perWindowGroups", {})
+            if pwg.get("enabled") and not session_chats.get_chat_for_window(wid):
+                _spawn_group_create(wid, cwd)
+        except Exception as e:  # noqa: BLE001
+            log("hook.session_start.group_check_fail", err=str(e))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/multi-window-bridge/hooks/stop.py
+++ b/contrib/multi-window-bridge/hooks/stop.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Stop hook: Claude finished a turn (idle). Optional notification."""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+from common import is_muted, load_config, log, truncate, truncate_body  # noqa: E402
+import async_send  # noqa: E402
+import registry  # noqa: E402
+
+
+def _last_assistant_text(transcript_path: str) -> str:
+    """Pluck the last assistant message text from the JSONL transcript."""
+    try:
+        with open(transcript_path) as fh:
+            lines = fh.readlines()
+    except Exception:  # noqa: BLE001
+        return ""
+    for line in reversed(lines):
+        try:
+            entry = json.loads(line)
+        except Exception:  # noqa: BLE001
+            continue
+        # Claude Code transcript format varies; try common shapes.
+        msg = entry.get("message") or entry
+        role = msg.get("role") or entry.get("type")
+        if role not in ("assistant", "ai"):
+            continue
+        content = msg.get("content")
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            for blk in content:
+                if isinstance(blk, dict) and blk.get("type") == "text":
+                    return blk.get("text", "")
+        return ""
+    return ""
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception as e:  # noqa: BLE001
+        log("hook.stop.parse_fail", err=str(e))
+        return 0
+
+    cfg = load_config()
+    if not cfg["notifications"].get("onStop", True):
+        return 0
+    if payload.get("stop_hook_active"):
+        # Already inside a stop-triggered loop; bail to avoid recursion.
+        return 0
+
+    session_id = payload.get("session_id") or ""
+    transcript_path = payload.get("transcript_path") or ""
+
+    # Dedup state: which assistant text did we LAST report for this session?
+    # If Stop fires again but transcript hasn't been updated with the new
+    # response yet, we must NOT resend the previous tail under a new "已完成".
+    import hashlib
+    import time as _t
+    state_path = os.path.join(os.path.dirname(__file__), "..", "logs",
+                              ".last_stop.json")
+    try:
+        state = json.load(open(state_path)) if os.path.exists(state_path) else {}
+    except Exception:  # noqa: BLE001
+        state = {}
+
+    def _h(s: str) -> str:
+        return hashlib.sha1((s or "").encode("utf-8")).hexdigest()[:12]
+
+    prev_hash = state.get(session_id, "")
+    last = _last_assistant_text(transcript_path)
+    # Retry up to ~5s if (empty) OR (same content as last time we reported).
+    # Claude Code writes the assistant message to transcript JSONL with a few
+    # seconds of lag after Stop fires; without this we'd return the previous
+    # turn's tail.
+    for _ in range(8):
+        if last and _h(last) != prev_hash:
+            break
+        _t.sleep(0.6)
+        last = _last_assistant_text(transcript_path)
+
+    wid = registry.heartbeat(session_id, "Stop", truncate(last, 200))
+    if not wid:
+        return 0
+    if is_muted(session_id=session_id, window_id=wid):
+        log("hook.stop.muted", windowId=wid, tail=truncate(last, 60))
+        return 0
+    cur_hash = _h(last) if last else ""
+    if cur_hash and cur_hash == prev_hash:
+        # Same content as last time we reported for this session. Either Stop
+        # double-fired, or transcript still hasn't caught up after 5s of retry.
+        # Either way, sending would just duplicate the previous "已完成". Skip.
+        log("hook.stop.skipped_duplicate", windowId=wid,
+            sessionId=session_id[:8], tail=truncate(last, 60))
+        return 0
+    state[session_id] = cur_hash
+    try:
+        json.dump(state, open(state_path, "w"))
+    except Exception:  # noqa: BLE001
+        pass
+
+    title = f"✅ [{wid}] 已完成"
+    body = truncate_body(last) or "(无文本输出)"
+    async_send.dispatch_card(title, body, "green", wid, "Stop")
+    log("hook.stop.dispatched", windowId=wid, tail=truncate(last, 60))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/multi-window-bridge/launchd/com.local.mwb-receiver.plist
+++ b/contrib/multi-window-bridge/launchd/com.local.mwb-receiver.plist
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- __HOME__ is substituted with $HOME by mwb-install at install time.
+     Stage 2 only. If `claude` is not on the default PATH below (e.g. it lives
+     under an nvm node dir), add that bin dir to PATH here. -->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.local.mwb-receiver</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/python3</string>
+        <string>__HOME__/.claude/multi-window-bridge/daemon/receiver.py</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>ProcessType</key>
+    <string>Interactive</string>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/.claude/multi-window-bridge/logs/receiver.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.claude/multi-window-bridge/logs/receiver.err.log</string>
+</dict>
+</plist>

--- a/contrib/multi-window-bridge/launchd/com.local.mwb-watchdog.plist
+++ b/contrib/multi-window-bridge/launchd/com.local.mwb-watchdog.plist
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- __HOME__ is substituted with $HOME by mwb-install at install time. -->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.local.mwb-watchdog</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/python3</string>
+        <string>__HOME__/.claude/multi-window-bridge/daemon/watchdog.py</string>
+    </array>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>__HOME__</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+        <key>Crashed</key>
+        <true/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+
+    <key>StandardOutPath</key>
+    <string>__HOME__/.claude/multi-window-bridge/logs/watchdog.out.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.claude/multi-window-bridge/logs/watchdog.err.log</string>
+</dict>
+</plist>

--- a/contrib/multi-window-bridge/lib/async_send.py
+++ b/contrib/multi-window-bridge/lib/async_send.py
@@ -1,0 +1,53 @@
+"""Fire-and-forget feishu sender for hooks.
+
+Why: Claude Code enforces a per-hook timeout (5-8s in our settings.json). The
+first feishu API call after token cache cold-start can take 10-30s due to
+network conditions. If we send synchronously, the hook gets SIGKILL'd before
+logging anything, and the user sees nothing.
+
+Solution: hook calls dispatch_*() which spawns a fully-detached subprocess.
+The subprocess does the actual send + logs result. The hook returns in <50ms.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+MWB_ROOT = Path(__file__).resolve().parent.parent
+WORKER = MWB_ROOT / "lib" / "send_worker.py"
+
+
+def _spawn(payload: dict, window_id: str, kind: str) -> None:
+    """Spawn detached worker. Never raises."""
+    try:
+        p = subprocess.Popen(
+            [sys.executable, str(WORKER), window_id, kind],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            close_fds=True,
+        )
+        if p.stdin:
+            p.stdin.write(json.dumps(payload, ensure_ascii=False).encode("utf-8"))
+            p.stdin.close()
+    except Exception:
+        pass
+
+
+def dispatch_text(text: str, window_id: str, kind: str) -> None:
+    """Send a plain-text message (no card)."""
+    _spawn({"mode": "text", "text": text}, window_id, kind)
+
+
+def dispatch_card(title: str, body: str, color: str,
+                  window_id: str, kind: str) -> None:
+    """Send a markdown-rendered interactive card."""
+    _spawn({"mode": "card", "title": title, "body": body, "color": color},
+           window_id, kind)
+
+
+# Back-compat alias (old hooks may still call .dispatch)
+dispatch = dispatch_text

--- a/contrib/multi-window-bridge/lib/common.py
+++ b/contrib/multi-window-bridge/lib/common.py
@@ -1,0 +1,141 @@
+"""Shared helpers: config loader, JSON file lock, logging.
+
+Stdlib-only. All paths anchor at MWB_HOME (~/.claude/multi-window-bridge).
+"""
+from __future__ import annotations
+
+import contextlib
+import datetime
+import fcntl
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterator
+
+# (lark_session_ids cache is module-level state defined below)
+
+MWB_HOME = Path.home() / ".claude" / "multi-window-bridge"
+CONFIG_PATH = MWB_HOME / "config" / "config.json"
+REGISTRY_PATH = MWB_HOME / "registry.json"
+LOG_DIR = MWB_HOME / "logs"
+
+
+def load_config() -> dict[str, Any]:
+    with CONFIG_PATH.open() as fh:
+        return json.load(fh)
+
+
+@contextlib.contextmanager
+def file_lock(path: Path, timeout: float = 5.0) -> Iterator[None]:
+    """Advisory exclusive lock on a sibling .lock file. Blocks up to timeout."""
+    lock_path = path.with_suffix(path.suffix + ".lock")
+    lock_path.touch(exist_ok=True)
+    deadline = time.monotonic() + timeout
+    fd = os.open(lock_path, os.O_RDWR)
+    try:
+        while True:
+            try:
+                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except BlockingIOError:
+                if time.monotonic() > deadline:
+                    raise TimeoutError(f"could not lock {lock_path} within {timeout}s")
+                time.sleep(0.05)
+        yield
+    finally:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+
+def log(kind: str, **fields: Any) -> None:
+    """Append a JSONL line to today's log file. Never raises on log errors."""
+    try:
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        path = LOG_DIR / f"{datetime.date.today().isoformat()}.log"
+        rec = {"ts": time.time(), "kind": kind, **fields}
+        with path.open("a") as fh:
+            fh.write(json.dumps(rec, ensure_ascii=False) + "\n")
+    except Exception as e:  # noqa: BLE001 — logs must never break callers
+        try:
+            sys.stderr.write(f"[mwb log error] {e}\n")
+        except Exception:
+            pass
+
+
+def now_ts() -> int:
+    return int(time.time())
+
+
+def truncate(s: str | None, n: int = 240) -> str:
+    """Single-line truncate for LOG entries. Replaces newlines with ⏎."""
+    if not s:
+        return ""
+    s = s.strip().replace("\r", " ").replace("\n", " ⏎ ")
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+_LARK_SESSIONS_CACHE: dict[str, Any] = {"ts": 0.0, "ids": set()}
+
+
+def lark_session_ids() -> set[str]:
+    """Read ~/.lark-channel/sessions.json and return all sessionIds.
+
+    Cached for 30s to avoid disk hit on every hook fire. Returns empty set on
+    any error (missing file / parse fail).
+    """
+    now = time.time()
+    if now - _LARK_SESSIONS_CACHE["ts"] < 30 and _LARK_SESSIONS_CACHE["ids"]:
+        return _LARK_SESSIONS_CACHE["ids"]
+    path = Path.home() / ".lark-channel" / "sessions.json"
+    ids: set[str] = set()
+    try:
+        data = json.loads(path.read_text())
+        if isinstance(data, dict):
+            for v in data.values():
+                sid = v.get("sessionId") if isinstance(v, dict) else None
+                if sid:
+                    ids.add(sid)
+    except Exception:  # noqa: BLE001
+        pass
+    _LARK_SESSIONS_CACHE["ts"] = now
+    _LARK_SESSIONS_CACHE["ids"] = ids
+    return ids
+
+
+def is_muted(session_id: str = "", window_id: str = "") -> bool:
+    """Should we suppress feishu dispatch for this session/window?
+
+    Two mute sources merge:
+    - notifications.muteWindowIds: explicit list (e.g. user's main chat tab)
+    - notifications.muteLarkChannelSessions: auto-mute any session that
+      lark-channel-bridge claims (avoids double-feishu when bot spawns claude)
+    """
+    cfg = load_config()
+    nc = cfg.get("notifications", {})
+    if window_id and window_id in nc.get("muteWindowIds", []):
+        return True
+    if session_id and nc.get("muteLarkChannelSessions", True):
+        if session_id in lark_session_ids():
+            return True
+    return False
+
+
+def truncate_body(s: str | None, n: int = 4000) -> str:
+    """Truncate for MESSAGE BODY. Preserves newlines so markdown renders.
+
+    Default 4000 chars. Feishu interactive cards allow up to ~30000 in a
+    single markdown element, but anything past 4000 starts hurting readability
+    on phone. When truncated, append a footer telling the user how much was
+    cut, so they know to grep the transcript for the full version.
+    """
+    if not s:
+        return ""
+    s = s.strip().replace("\r", "")
+    if len(s) <= n:
+        return s
+    omitted = len(s) - n
+    return s[: n - 1] + f"\n\n… (还有 {omitted} 字省略,完整内容看终端)"

--- a/contrib/multi-window-bridge/lib/feishu.py
+++ b/contrib/multi-window-bridge/lib/feishu.py
@@ -1,0 +1,262 @@
+"""Feishu (Lark) client — stdlib HTTP, reads creds from lark-channel-bridge.
+
+We do NOT modify lark-channel-bridge; we only read its config.json to share
+app_id / app_secret. We hit the Open API directly for /im/v1/messages.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+from common import MWB_HOME, load_config, log
+
+TOKEN_CACHE = MWB_HOME / ".tenant_token.json"
+OPEN_API = "https://open.feishu.cn/open-apis"
+
+
+def _resolve_secret(c: dict, secret_ref: Any) -> str:
+    """Resolve app_secret which may be a plain string OR an exec-provider object.
+
+    0.1.27- format: "secret": "abc123..."
+    0.1.28+ format: "secret": {"source": "exec", "provider": "bridge", "id": "app-cli_xxx"}
+        — needs to call the provider's command (e.g. lark-channel-bridge secrets get)
+        — protocol: stdin {"protocolVersion":1,"ids":[id]} → stdout {"values":{id:secret}}
+    """
+    if isinstance(secret_ref, str):
+        return secret_ref
+    if not isinstance(secret_ref, dict) or secret_ref.get("source") != "exec":
+        raise ValueError(f"unsupported app.secret format: {secret_ref!r}")
+    provider_name = secret_ref["provider"]
+    secret_id = secret_ref["id"]
+    provider = c.get("secrets", {}).get("providers", {}).get(provider_name)
+    if not provider or provider.get("source") != "exec":
+        raise ValueError(f"provider {provider_name!r} missing or not exec-type")
+    cmd = [provider["command"], *provider.get("args", [])]
+    req = json.dumps({"protocolVersion": 1, "ids": [secret_id]}).encode()
+    proc = subprocess.run(cmd, input=req, capture_output=True, timeout=10)
+    if proc.returncode != 0:
+        raise RuntimeError(f"secrets-getter exit {proc.returncode}: {proc.stderr.decode()[:200]}")
+    resp = json.loads(proc.stdout)
+    val = resp.get("values", {}).get(secret_id)
+    if not val:
+        raise RuntimeError(f"secrets-getter returned no value for {secret_id!r}: {proc.stdout.decode()[:200]}")
+    return val
+
+
+def _read_creds() -> tuple[str, str]:
+    cfg = load_config()
+    cred_path = Path(cfg["feishu"]["credentialFile"]).expanduser()
+    with cred_path.open() as fh:
+        c = json.load(fh)
+    app = c["accounts"]["app"]
+    return app["id"], _resolve_secret(c, app["secret"])
+
+
+def _http(method: str, path: str, payload: dict | None = None,
+          token: str | None = None, query: dict | None = None,
+          timeout: float = 8.0) -> dict[str, Any]:
+    url = f"{OPEN_API}{path}"
+    if query:
+        url += "?" + urllib.parse.urlencode(query)
+    data = json.dumps(payload).encode() if payload else None
+    headers = {"Content-Type": "application/json; charset=utf-8"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, data=data, method=method, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+        return json.loads(body)
+    except urllib.error.HTTPError as e:
+        body = e.read().decode("utf-8", errors="replace")
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            return {"code": -1, "msg": f"http {e.code}: {body[:200]}"}
+    except Exception as e:  # noqa: BLE001
+        return {"code": -1, "msg": f"network: {e}"}
+
+
+def _get_token() -> str | None:
+    # cached?
+    try:
+        if TOKEN_CACHE.exists():
+            cache = json.loads(TOKEN_CACHE.read_text())
+            if cache.get("expiresAt", 0) - 60 > time.time():
+                return cache["token"]
+    except Exception:  # noqa: BLE001
+        pass
+    app_id, app_secret = _read_creds()
+    resp = _http("POST", "/auth/v3/tenant_access_token/internal",
+                 payload={"app_id": app_id, "app_secret": app_secret})
+    if resp.get("code") != 0:
+        log("feishu.token.fail", resp=resp)
+        return None
+    token = resp["tenant_access_token"]
+    expires_in = resp.get("expire", 7200)
+    try:
+        TOKEN_CACHE.parent.mkdir(parents=True, exist_ok=True)
+        TOKEN_CACHE.write_text(json.dumps({"token": token, "expiresAt": time.time() + expires_in}))
+    except Exception:  # noqa: BLE001
+        pass
+    return token
+
+
+def send_text(text: str, chat_id: str | None = None) -> str | None:
+    """Send a plain-text message. Returns Feishu message_id or None on failure."""
+    cfg = load_config()
+    chat_id = chat_id or cfg["feishu"]["chatId"]
+    token = _get_token()
+    if not token:
+        log("feishu.send.no_token")
+        return None
+    resp = _http(
+        "POST",
+        "/im/v1/messages",
+        query={"receive_id_type": "chat_id"},
+        token=token,
+        payload={
+            "receive_id": chat_id,
+            "msg_type": "text",
+            "content": json.dumps({"text": text}, ensure_ascii=False),
+        },
+    )
+    if resp.get("code") != 0:
+        log("feishu.send.fail", resp=resp, text_head=text[:80])
+        return None
+    return resp.get("data", {}).get("message_id")
+
+
+def send_card(title: str, body: str, color: str = "default",
+              chat_id: str | None = None) -> str | None:
+    """Send a Feishu interactive card with markdown body.
+
+    color: header template — "green" / "blue" / "yellow" / "red" / "default".
+           Maps to Feishu's built-in palette.
+    body: markdown — supports **bold**, `code`, lists, line breaks, etc.
+    """
+    cfg = load_config()
+    chat_id = chat_id or cfg["feishu"]["chatId"]
+    token = _get_token()
+    if not token:
+        log("feishu.send.no_token")
+        return None
+    card = {
+        "config": {"wide_screen_mode": True, "enable_forward": True},
+        "header": {
+            "template": color,
+            "title": {"tag": "plain_text", "content": title},
+        },
+        "elements": [
+            {"tag": "markdown", "content": body or "(无内容)"},
+        ],
+    }
+    resp = _http(
+        "POST",
+        "/im/v1/messages",
+        query={"receive_id_type": "chat_id"},
+        token=token,
+        payload={
+            "receive_id": chat_id,
+            "msg_type": "interactive",
+            "content": json.dumps(card, ensure_ascii=False),
+        },
+    )
+    if resp.get("code") != 0:
+        log("feishu.send_card.fail", resp=resp, title=title[:80])
+        return None
+    return resp.get("data", {}).get("message_id")
+
+
+def create_group(name: str, member_open_ids: list[str],
+                 description: str = "") -> str | None:
+    """Create a feishu group chat with the bot + given users. Returns chat_id or None.
+
+    The bot calling this API is automatically the owner/member of the new chat.
+    member_open_ids gets added alongside.
+    """
+    token = _get_token()
+    if not token:
+        log("feishu.create_group.no_token")
+        return None
+    payload = {
+        "name": name,
+        "description": description,
+        "chat_mode": "group",
+        "chat_type": "private",
+        "external": False,
+        "user_id_list": member_open_ids,
+    }
+    resp = _http(
+        "POST",
+        "/im/v1/chats",
+        query={"user_id_type": "open_id", "set_bot_manager": "true"},
+        token=token,
+        payload=payload,
+    )
+    if resp.get("code") != 0:
+        log("feishu.create_group.fail", resp=resp, name=name)
+        return None
+    chat_id = resp.get("data", {}).get("chat_id")
+    log("feishu.create_group.ok", name=name, chatId=chat_id)
+    return chat_id
+
+
+def update_group(chat_id: str, name: str | None = None,
+                 description: str | None = None) -> bool:
+    """Update a group's name/description. Returns True on success."""
+    token = _get_token()
+    if not token:
+        log("feishu.update_group.no_token")
+        return False
+    payload: dict[str, Any] = {}
+    if name is not None:
+        payload["name"] = name
+    if description is not None:
+        payload["description"] = description
+    if not payload:
+        return True
+    resp = _http("PUT", f"/im/v1/chats/{chat_id}", token=token, payload=payload)
+    if resp.get("code") != 0:
+        log("feishu.update_group.fail", resp=resp, chatId=chat_id, name=name)
+        return False
+    log("feishu.update_group.ok", chatId=chat_id, name=name)
+    return True
+
+
+def list_chat_messages(chat_id: str, start_time: int | None = None,
+                       page_size: int = 20) -> list[dict[str, Any]]:
+    """List recent messages from a chat. start_time is unix seconds (inclusive)."""
+    token = _get_token()
+    if not token:
+        return []
+    query: dict[str, Any] = {
+        "container_id_type": "chat",
+        "container_id": chat_id,
+        "sort_type": "ByCreateTimeDesc",
+        "page_size": page_size,
+    }
+    if start_time:
+        query["start_time"] = str(start_time)
+    resp = _http("GET", "/im/v1/messages", query=query, token=token)
+    if resp.get("code") != 0:
+        log("feishu.list.fail", resp=resp)
+        return []
+    return resp.get("data", {}).get("items", []) or []
+
+
+def get_message(message_id: str) -> dict[str, Any] | None:
+    token = _get_token()
+    if not token:
+        return None
+    resp = _http("GET", f"/im/v1/messages/{message_id}", token=token)
+    if resp.get("code") != 0:
+        return None
+    items = resp.get("data", {}).get("items", [])
+    return items[0] if items else None

--- a/contrib/multi-window-bridge/lib/group_create_worker.py
+++ b/contrib/multi-window-bridge/lib/group_create_worker.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Detached worker: create a feishu group for a window if one doesn't exist yet.
+
+Invocation:
+  group_create_worker.py <windowId> <cwd>
+
+Runs free of any hook timeout. Idempotent — if windowId already has a mapping,
+no-ops. Otherwise creates the group via feishu API + adds the user from
+config.feishu.userOpenId + saves the mapping.
+
+Logs result via common.log.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from common import load_config, log  # noqa: E402
+import feishu  # noqa: E402
+import session_chats  # noqa: E402
+
+
+def _cwd_base(cwd: str) -> str:
+    """Render cwd for group name. Home directory → '~' (avoid redundant username).
+
+    Examples:
+      /Users/you           → ~
+      /Users/you/sandbox   → sandbox
+      /private/tmp/foo          → foo
+      /                         → /
+    """
+    home = str(Path.home())
+    if cwd == home:
+        return "~"
+    return Path(cwd).name or "/"
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        log("group_create_worker.bad_args", argv=sys.argv)
+        return 2
+    window_id = sys.argv[1]
+    cwd = sys.argv[2]
+
+    cfg = load_config()
+    feishu_cfg = cfg.get("feishu", {})
+    pwg = feishu_cfg.get("perWindowGroups", {})
+    if not pwg.get("enabled"):
+        log("group_create.skipped_disabled", windowId=window_id)
+        return 0
+
+    # Idempotency: already mapped?
+    existing = session_chats.get_chat_for_window(window_id)
+    if existing:
+        log("group_create.skipped_exists", windowId=window_id, chatId=existing)
+        return 0
+
+    user_open_id = feishu_cfg.get("userOpenId")
+    if not user_open_id:
+        log("group_create.no_user_open_id")
+        return 1
+
+    template = pwg.get("groupNameTemplate", "claude · {windowId} · {cwdBase}")
+    name = template.format(windowId=window_id, cwdBase=_cwd_base(cwd), cwd=cwd)
+
+    chat_id = feishu.create_group(
+        name=name,
+        member_open_ids=[user_open_id],
+        description=f"Auto-created by mwb for window {window_id} (cwd: {cwd})",
+    )
+    if not chat_id:
+        log("group_create.api_fail", windowId=window_id, name=name)
+        return 1
+
+    session_chats.set_chat_for_window(window_id, chat_id, cwd, name)
+    log("group_create.ok", windowId=window_id, chatId=chat_id, name=name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/multi-window-bridge/lib/registry.py
+++ b/contrib/multi-window-bridge/lib/registry.py
@@ -1,0 +1,216 @@
+"""Registry: maps window-id → {claudePid, sessionId, cwd, lastHookAt, ...}.
+
+Lives at ~/.claude/multi-window-bridge/registry.json. Atomic R/W with flock.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import signal
+from pathlib import Path
+from typing import Any
+
+from common import REGISTRY_PATH, file_lock, log, now_ts
+
+MAX_NOTIF_HISTORY = 200
+
+
+def _empty() -> dict[str, Any]:
+    return {"version": 1, "windows": {}, "notifications": {}}
+
+
+def _read() -> dict[str, Any]:
+    if not REGISTRY_PATH.exists():
+        return _empty()
+    try:
+        with REGISTRY_PATH.open() as fh:
+            data = json.load(fh)
+        if "windows" not in data:
+            return _empty()
+        return data
+    except json.JSONDecodeError:
+        log("registry.corrupt", path=str(REGISTRY_PATH))
+        return _empty()
+
+
+def _atomic_write(data: dict[str, Any]) -> None:
+    REGISTRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = REGISTRY_PATH.with_suffix(".json.tmp")
+    with tmp.open("w") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+    os.replace(tmp, REGISTRY_PATH)
+
+
+def _next_window_id(data: dict[str, Any], cwd: str, alias: str | None,
+                    claude_pid: int = 0) -> str:
+    if alias:
+        # User-supplied: use as-is (sanitized), append -2/-3 on collision
+        clean = re.sub(r"[^a-zA-Z0-9_\-]", "-", alias).strip("-") or "window"
+        existing = set(data["windows"].keys())
+        if clean not in existing:
+            return clean
+        n = 2
+        while f"{clean}-{n}" in existing:
+            n += 1
+        return f"{clean}-{n}"
+    # Auto-name: {basename}-{pid_last4} so multiple home-dir sessions disambiguate
+    # (e.g. "you-3736" + "you-7476") AND so any feishu alert lets the
+    # user `pgrep` and find the offending Claude immediately.
+    base = Path(cwd).name or "root"
+    base = re.sub(r"[^a-zA-Z0-9_\-]", "-", base).strip("-") or "root"
+    pid_suffix = str(claude_pid)[-4:].rjust(4, "0") if claude_pid else "0000"
+    candidate = f"{base}-{pid_suffix}"
+    existing = set(data["windows"].keys())
+    if candidate not in existing:
+        return candidate
+    # Pathological pid recycling: append numeric tail
+    n = 2
+    while f"{candidate}-{n}" in existing:
+        n += 1
+    return f"{candidate}-{n}"
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists but not ours; treat as alive
+
+
+def _prune_dead(data: dict[str, Any]) -> list[str]:
+    """Remove windows whose claudePid is dead. Returns evicted ids."""
+    evicted = []
+    for wid, entry in list(data["windows"].items()):
+        pid = entry.get("claudePid", -1)
+        if not _pid_alive(pid):
+            evicted.append(wid)
+            del data["windows"][wid]
+    return evicted
+
+
+# ── public API ─────────────────────────────────────────────────────────────
+
+def register(session_id: str, cwd: str, claude_pid: int, transcript_path: str,
+             alias: str | None) -> str:
+    """Create / refresh entry for a Claude session. Returns window-id."""
+    with file_lock(REGISTRY_PATH):
+        data = _read()
+        _prune_dead(data)
+        # If session_id already known, reuse window-id.
+        for wid, entry in data["windows"].items():
+            if entry.get("sessionId") == session_id:
+                entry["claudePid"] = claude_pid
+                entry["transcriptPath"] = transcript_path
+                entry["lastHookAt"] = now_ts()
+                entry["lastHookKind"] = "SessionStart"
+                _atomic_write(data)
+                return wid
+        wid = _next_window_id(data, cwd, alias, claude_pid)
+        data["windows"][wid] = {
+            "alias": alias or wid,
+            "cwd": cwd,
+            "claudePid": claude_pid,
+            "sessionId": session_id,
+            "transcriptPath": transcript_path,
+            "startedAt": now_ts(),
+            "lastHookAt": now_ts(),
+            "lastHookKind": "SessionStart",
+            "lastHookSummary": "",
+            "registeredManually": bool(alias),
+            "lastWatchdogAlertAt": 0,
+        }
+        _atomic_write(data)
+        return wid
+
+
+def heartbeat(session_id: str, kind: str, summary: str = "") -> str | None:
+    """Update lastHookAt/kind for the window matching session_id. Returns window-id or None."""
+    with file_lock(REGISTRY_PATH):
+        data = _read()
+        for wid, entry in data["windows"].items():
+            if entry.get("sessionId") == session_id:
+                entry["lastHookAt"] = now_ts()
+                entry["lastHookKind"] = kind
+                entry["lastHookSummary"] = summary
+                _atomic_write(data)
+                return wid
+        return None
+
+
+def unregister(session_id: str) -> str | None:
+    with file_lock(REGISTRY_PATH):
+        data = _read()
+        for wid, entry in list(data["windows"].items()):
+            if entry.get("sessionId") == session_id:
+                del data["windows"][wid]
+                _atomic_write(data)
+                return wid
+        return None
+
+
+def lookup_by_window_id(window_id: str) -> dict[str, Any] | None:
+    data = _read()
+    return data["windows"].get(window_id)
+
+
+def list_windows() -> dict[str, dict[str, Any]]:
+    return _read()["windows"]
+
+
+def record_notification(message_id: str, window_id: str, kind: str) -> None:
+    if not message_id:
+        return
+    with file_lock(REGISTRY_PATH):
+        data = _read()
+        notifs = data.setdefault("notifications", {})
+        notifs[message_id] = {"windowId": window_id, "kind": kind, "sentAt": now_ts()}
+        # FIFO trim
+        if len(notifs) > MAX_NOTIF_HISTORY:
+            for k in list(notifs.keys())[: len(notifs) - MAX_NOTIF_HISTORY]:
+                del notifs[k]
+        _atomic_write(data)
+
+
+def find_window_for_notification(message_id: str) -> str | None:
+    data = _read()
+    rec = data.get("notifications", {}).get(message_id)
+    return rec["windowId"] if rec else None
+
+
+def update_watchdog_state(window_id: str,
+                          last_alerted_hook_at: int = 0) -> None:
+    """Stamp watchdog alert state.
+
+    `last_alerted_hook_at`: the lastHookAt value at the time of this alert.
+    Watchdog uses it for edge-trigger logic — only fire again if lastHookAt
+    advances past this value (i.e., the session showed signs of life since
+    the previous alert).
+    """
+    with file_lock(REGISTRY_PATH):
+        data = _read()
+        if window_id in data["windows"]:
+            data["windows"][window_id]["lastWatchdogAlertAt"] = now_ts()
+            if last_alerted_hook_at:
+                data["windows"][window_id]["lastAlertedHookAt"] = last_alerted_hook_at
+            _atomic_write(data)
+
+
+def kill_window_pid(window_id: str) -> tuple[bool, str]:
+    """SIGTERM the claudePid for window_id. Returns (ok, message)."""
+    entry = lookup_by_window_id(window_id)
+    if not entry:
+        return False, f"no such window: {window_id}"
+    pid = entry.get("claudePid", -1)
+    if not _pid_alive(pid):
+        return True, f"pid {pid} already dead"
+    try:
+        os.kill(pid, signal.SIGTERM)
+        return True, f"sent SIGTERM to pid {pid}"
+    except Exception as e:  # noqa: BLE001
+        return False, f"kill {pid} failed: {e}"

--- a/contrib/multi-window-bridge/lib/send_worker.py
+++ b/contrib/multi-window-bridge/lib/send_worker.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Detached worker: reads a JSON payload from stdin, sends via feishu, logs.
+
+Invocation:
+  send_worker.py <window_id> <kind>
+  stdin = {"mode": "text", "text": "..."}
+          OR
+          {"mode": "card", "title": "...", "body": "...", "color": "green"}
+
+Runs free of any hook timeout. Logs result so we can audit.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from common import log, truncate  # noqa: E402
+import feishu  # noqa: E402
+import registry  # noqa: E402
+import session_chats  # noqa: E402
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        return 2
+    window_id = sys.argv[1]
+    kind = sys.argv[2]
+    kind_lc = {"Notification": "notification", "Stop": "stop",
+               "PreToolUse": "pretool"}.get(kind, kind.lower())
+
+    raw = sys.stdin.read()
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        # Back-compat: treat raw stdin as plain text.
+        payload = {"mode": "text", "text": raw}
+
+    # Per-window-group routing: if this window has its own chat, send there.
+    # Fall back to default chatId in config (handled inside feishu.send_*).
+    per_window_chat = session_chats.get_chat_for_window(window_id)
+
+    mode = payload.get("mode", "text")
+    try:
+        if mode == "card":
+            msg_id = feishu.send_card(
+                title=payload.get("title", ""),
+                body=payload.get("body", ""),
+                color=payload.get("color", "default"),
+                chat_id=per_window_chat,
+            )
+            preview = payload.get("title", "")
+        else:
+            text = payload.get("text", "")
+            msg_id = feishu.send_text(text, chat_id=per_window_chat)
+            preview = text
+    except Exception as e:  # noqa: BLE001
+        log(f"hook.{kind_lc}.fail", windowId=window_id, err=str(e))
+        return 1
+
+    if not msg_id:
+        log(f"hook.{kind_lc}.send_failed", windowId=window_id)
+        return 1
+    registry.record_notification(msg_id, window_id, kind)
+    log(f"hook.{kind_lc}.sent", windowId=window_id, msgId=msg_id,
+        msg=truncate(preview, 80))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/contrib/multi-window-bridge/lib/session_chats.py
+++ b/contrib/multi-window-bridge/lib/session_chats.py
@@ -1,0 +1,78 @@
+"""Per-window feishu chat mapping.
+
+State file: ~/.claude/multi-window-bridge/session_chats.json
+{
+  "windowChats": {
+    "<windowId>": {
+      "chatId": "oc_xxx",
+      "cwd": "/Users/you/sandbox",
+      "groupName": "claude · sandbox-7819 · sandbox",
+      "createdAt": 1779513491
+    }
+  }
+}
+
+Lookup is by windowId since mwb's identity unit is the window (registry.py).
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from common import MWB_HOME, log
+
+STATE_PATH = MWB_HOME / "session_chats.json"
+
+
+def _read() -> dict:
+    if not STATE_PATH.exists():
+        return {"windowChats": {}}
+    try:
+        return json.loads(STATE_PATH.read_text())
+    except Exception as e:  # noqa: BLE001
+        log("session_chats.read_fail", err=str(e))
+        return {"windowChats": {}}
+
+
+def _atomic_write(data: dict) -> None:
+    STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=".session_chats.", suffix=".tmp",
+                                dir=str(STATE_PATH.parent))
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(data, fh, ensure_ascii=False, indent=2)
+        os.replace(tmp, STATE_PATH)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def get_chat_for_window(window_id: str) -> str | None:
+    """Return chat_id for this window, or None if not yet mapped."""
+    data = _read()
+    entry = data.get("windowChats", {}).get(window_id)
+    return entry.get("chatId") if entry else None
+
+
+def set_chat_for_window(window_id: str, chat_id: str, cwd: str,
+                         group_name: str) -> None:
+    """Store the mapping. Caller has already created the group via feishu API."""
+    data = _read()
+    data.setdefault("windowChats", {})[window_id] = {
+        "chatId": chat_id,
+        "cwd": cwd,
+        "groupName": group_name,
+        "createdAt": int(time.time()),
+    }
+    _atomic_write(data)
+
+
+def list_all() -> dict:
+    """Return the full windowChats map (for /mwb-list integration etc)."""
+    return _read().get("windowChats", {})

--- a/contrib/multi-window-bridge/settings.patch.json
+++ b/contrib/multi-window-bridge/settings.patch.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Merge this `hooks` block into ~/.claude/settings.json. The mwb-install script does it automatically; this file is for reference / manual recovery.",
+  "hooks": {
+    "SessionStart": [
+      { "hooks": [ { "type": "command", "command": "/usr/bin/python3 __HOME__/.claude/multi-window-bridge/hooks/session_start.py", "timeout": 5 } ] }
+    ],
+    "Notification": [
+      { "hooks": [ { "type": "command", "command": "/usr/bin/python3 __HOME__/.claude/multi-window-bridge/hooks/notification.py", "timeout": 8 } ] }
+    ],
+    "PreToolUse": [
+      { "matcher": "Bash|Edit|Write|NotebookEdit", "hooks": [ { "type": "command", "command": "/usr/bin/python3 __HOME__/.claude/multi-window-bridge/hooks/pre_tool_use.py", "timeout": 8 } ] }
+    ],
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "/usr/bin/python3 __HOME__/.claude/multi-window-bridge/hooks/stop.py", "timeout": 8 } ] }
+    ],
+    "SessionEnd": [
+      { "hooks": [ { "type": "command", "command": "/usr/bin/python3 __HOME__/.claude/multi-window-bridge/hooks/session_end.py", "timeout": 5 } ] }
+    ]
+  }
+}


### PR DESCRIPTION
## What this is

`multi-window-bridge` is a small, **standalone, opt-in companion** to lark-channel-bridge, dropped under `contrib/` so it has **zero impact** on the package's TypeScript build, CI, or `package.json`.

Where lark-channel-bridge goes **Feishu → spawn a fresh Claude**, this goes the other way:

- **Claude → Feishu**: Claude Code hooks on your hand-opened (Warp) windows push status to Feishu — 🟡 needs-input / 🔧 tool-about-to-run / ✅ done / ⚠️ suspected-hang.
- **Per-window groups** (optional): auto-create one Feishu group per window so each session gets its own thread.
- **Stage 2** (off by default): a Feishu reply prefixed `[window-id]` resumes that session in a new Warp tab.

It's pure-stdlib Python, **reuses lark-channel-bridge's `~/.lark-channel/config.json` credentials**, and never modifies that project. A launchd watchdog catches hung sessions.

## How it coexists with lark-channel-bridge

Same bot, same chat, no conflict: it polls `im/v1/messages` over REST instead of subscribing to the event webhook, and only acts on messages tagged `[window-id]` — everything else is left for lark-channel-bridge. Full design in [`contrib/multi-window-bridge/ARCHITECTURE.md`](contrib/multi-window-bridge/ARCHITECTURE.md).

## Scope — take it or leave it

This is a different language and architecture from the core package, so I kept it fully self-contained in `contrib/` and touched nothing else. Completely understand if you'd rather it live as a **separate repo with just a README link** from here — happy to do that instead. No hard feelings if this isn't a fit.

## Notes

- **Conservative defaults**: Stage 2, per-window groups, and AppleScript auto-paste all ship **OFF**.
- **No secrets**: runtime state + tokens are gitignored; `config/config.json` ships with `oc_xxx…` / `ou_xxx…` placeholders only.
- **macOS-only** (launchd + Warp + osascript).
- Docs (README / ARCHITECTURE / FAILURE-MODES) are in Chinese, matching this repo's existing zh docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
