### PR TITLE
fix: actionable error + honest status when keystore can't be decrypted (hostname drift)

### DIFF
--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -267,14 +267,24 @@ export async function runServiceStatus(): Promise<void> {
 
   const cfg = await loadConfig();
   const appId = cfg.accounts?.app?.id;
-  const entry = appId
-    ? readAndPrune().find((e) => e.appId === appId && Boolean(e.botName))
-    : undefined;
+  // readAndPrune() drops entries whose pid is no longer alive, so `liveEntries`
+  // reflects bot processes that are *actually* running right now.
+  const liveEntries = appId
+    ? readAndPrune().filter((e) => e.appId === appId)
+    : readAndPrune();
+  const entry = liveEntries.find((e) => Boolean(e.botName));
 
   const { pid, lastExit } = adapter.parseStatus(adapter.describeStatus());
 
   if (entry) {
     console.log(`✓ bot ${entry.botName} (${entry.appId}) 正在后台运行`);
+  } else if (liveEntries.length === 0) {
+    // launchd reports the service "loaded", but no live bot process exists.
+    // With KeepAlive=true a crash-looping bot keeps the launchd job alive while
+    // nothing is actually serving — don't print a misleading "✓ 正在后台运行".
+    console.log('⚠️  服务已加载,但当前没有存活的 bot 进程 — 可能在崩溃重启。');
+    console.log('   请查看下方 daemon-stderr.log;若是 keystore 解密失败,');
+    console.log('   跑 `lark-channel-bridge secrets set --app-id <你的 app id>` 重存后再 `restart`。');
   } else {
     console.log('✓ bot 正在后台运行');
   }

--- a/src/config/keystore.ts
+++ b/src/config/keystore.ts
@@ -121,7 +121,25 @@ export async function getSecret(id: string): Promise<string | undefined> {
   const env = store.entries[id];
   if (!env) return undefined;
   const key = await deriveKey();
-  return decrypt(key, env);
+  try {
+    return decrypt(key, env);
+  } catch (err) {
+    // An AES-GCM auth failure here ("Unsupported state or unable to
+    // authenticate data") almost always means the derived key changed since
+    // the secret was stored: deriveKey() seeds on `hostname()|username`, and
+    // macOS in particular rewrites the hostname on network changes and
+    // duplicate-name resolution (LocalHostName -> "MacBook-Pro-2", etc).
+    // Surface the remedy instead of letting a raw crypto error crash-loop the
+    // daemon under KeepAlive.
+    const appId = id.startsWith('app-') ? id.slice(4) : id;
+    throw new Error(
+      `Failed to decrypt keystore entry "${id}". The keystore key is derived ` +
+        `from this machine's hostname + username; if either changed since the ` +
+        `secret was stored, the entry can no longer be decrypted. Re-store it:\n` +
+        `  lark-channel-bridge secrets set --app-id ${appId}\n` +
+        `(underlying error: ${(err as Error).message})`,
+    );
+  }
 }
 
 /** Store / overwrite the secret for `id`. */


### PR DESCRIPTION
## Problem

The keystore key is derived from the machine identity (`src/config/keystore.ts`):

```ts
const seed = `${hostname()}|${userInfo().username}`;
return pbkdf2Sync(seed, salt, PBKDF2_ITER, KEY_LEN, 'sha256');
```

On macOS `os.hostname()` is **not stable**: when `scutil --get HostName` is unset (the default), `gethostname(2)` falls back to `LocalHostName.local`, and macOS rewrites `LocalHostName`/`ComputerName` on its own — duplicate-name resolution on a network appends `-2`, `(3)`, etc. (`MacBook-Pro` → `MacBook-Pro-2` → `MacBook-Pro-5`).

Once the hostname differs from when the secret was stored, `secrets.enc` can no longer be decrypted. The result is hard to diagnose:

1. `status` prints `✓ bot ... 正在后台运行` — but **no bot process is actually alive**. With `KeepAlive=true`, launchd keeps the job loaded while every spawn dies immediately.
2. `daemon-stderr.log` fills with hundreds of identical, opaque errors:
   ```
   Error: Unsupported state or unable to authenticate data
       at Decipheriv.final (node:internal/crypto/cipher)
       at decrypt / getSecret (src/config/keystore.ts)
       at resolveExecRef (src/config/secret-resolver.ts)
       at startChannel ...
   ```
3. Nothing points the user toward the cause or the fix.

### Reproduce
1. `secrets set --app-id cli_xxx` + `start` → works.
2. `sudo scutil --set HostName different-name` (or let macOS rename the host).
3. `restart` → crash-loop; `status` still says running.

## Changes

- **`keystore.getSecret`** — catch the AES-GCM auth failure and rethrow with the likely cause (hostname/username changed) and the exact remedy: `lark-channel-bridge secrets set --app-id <id>`. Self-recoverable instead of an opaque crash-loop.
- **`service status`** — `readAndPrune()` already drops dead pids. When launchd reports the service loaded but there are **zero live registry entries** for the app, print a warning (likely crash-looping → check stderr → re-store the secret) instead of a misleading `✓ 正在后台运行`.

No happy-path behavior change. `tsc --noEmit` passes.

## Not included (happy to follow up)

The underlying fragility is binding the key to the hostname at all. Didn't want to change the threat model unilaterally, but options if you'd prefer a deeper fix:
- persist a random 32-byte key in a `chmod 600` file and drop hostname/username from derivation;
- or store the hostname used at encrypt time in the envelope and emit a targeted "hostname changed from X to Y" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
