### PR TITLE
fix: enable shell mode on Windows for claude spawn

### DIFF
--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -113,7 +113,7 @@ export class ClaudeAdapter implements AgentAdapter {
 
   async isAvailable(): Promise<boolean> {
     return new Promise((resolve) => {
-      const child = spawn(this.binary, ['--version'], { stdio: 'ignore' });
+      const child = spawn(this.binary, ['--version'], { stdio: 'ignore', shell: process.platform === 'win32' });
       child.on('error', () => resolve(false));
       child.on('exit', (code) => resolve(code === 0));
     });
@@ -135,6 +135,7 @@ export class ClaudeAdapter implements AgentAdapter {
     if (opts.model) args.push('--model', opts.model);
 
     const child = spawn(this.binary, args, {
+      shell: process.platform === 'win32',
       cwd: opts.cwd,
       env: { ...process.env, LARK_CHANNEL: '1' },
       stdio: ['ignore', 'pipe', 'pipe'],


### PR DESCRIPTION
## Summary
On Windows, the `claude` binary installed via npm is a POSIX shell script (without a `.exe` or `.cmd` extension). Node.js `spawn()` cannot execute it directly without `shell: true`, causing the bridge to report "claude CLI not found" even when Claude Code is properly installed.

## Fix
Added `shell: process.platform === 'win32'` to two `spawn()` calls in `src/agent/claude/adapter.ts`:
1. The availability check (`isAvailable()`)
2. The actual agent run (`run()`)

This is a no-op on macOS/Linux (`shell: false`) and enables proper execution on Windows.

## Tested
- Built and ran successfully on Windows 11
- Bridge connects to Feishu and Claude Code works correctly