### PR TITLE
fix(security): enforce user allowlist on cloud-doc comment mentions

### DIFF
--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -252,8 +252,8 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
     },
     comment: async (evt) => {
       await withTrace({ chatId: 'comment' }, async () => {
-        await handleCommentMention({ channel, evt, agent, sessions, workspaces }).catch((err) =>
-          log.fail('comment', err),
+        await handleCommentMention({ channel, evt, agent, sessions, workspaces, controls }).catch(
+          (err) => log.fail('comment', err),
         );
       }).catch((err) => log.fail('comment', err));
     },

--- a/src/bot/comments.test.ts
+++ b/src/bot/comments.test.ts
@@ -1,0 +1,149 @@
+import type { CommentEvent, LarkChannel } from '@larksuiteoapi/node-sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentAdapter } from '../agent/types';
+import type { Controls } from '../commands';
+import type { AppConfig } from '../config/schema';
+import type { SessionStore } from '../session/store';
+import type { WorkspaceStore } from '../workspace/store';
+import { handleCommentMention } from './comments';
+
+// Reactions touch the live channel API; stub them out so the access-gate
+// tests don't need to mock the reaction endpoints. addCommentReaction
+// returning false also means the finally-block never calls remove.
+vi.mock('./reaction', () => ({
+  addCommentReaction: vi.fn(async () => false),
+  removeCommentReaction: vi.fn(async () => {}),
+}));
+
+function cfgWithAllowedUsers(allowedUsers: string[]): AppConfig {
+  return {
+    accounts: { app: { id: 'cli_x', secret: 's', tenant: 'feishu' } },
+    preferences: { access: { allowedUsers } },
+  } as AppConfig;
+}
+
+function makeControls(cfg: AppConfig): Controls {
+  return {
+    restart: async () => {},
+    exit: async () => {},
+    configPath: '/tmp/config.json',
+    cfg,
+    processId: 'test',
+  };
+}
+
+function makeEvent(operatorOpenId: string): CommentEvent {
+  return {
+    fileToken: 'doctoken',
+    fileType: 'docx',
+    commentId: 'c1',
+    replyId: undefined,
+    mentionedBot: true,
+    operator: { openId: operatorOpenId },
+  } as unknown as CommentEvent;
+}
+
+/** Channel whose comment-fetch chain succeeds, so a request that passes the
+ * access gate reaches `agent.run`. resolveTarget's wiki lookup throws → the
+ * code falls back to the passthrough token. */
+function makeHappyChannel(): LarkChannel {
+  return {
+    rawClient: {
+      wiki: { v2: { space: { getNode: async () => { throw new Error('not a wiki node'); } } } },
+      drive: {
+        v1: {
+          fileComment: {
+            get: async () => ({
+              data: {
+                reply_list: {
+                  replies: [
+                    {
+                      reply_id: 'r1',
+                      content: { elements: [{ type: 'text_run', text_run: { text: 'hello' } }] },
+                    },
+                  ],
+                },
+              },
+            }),
+            create: async () => ({}),
+          },
+        },
+      },
+      request: async () => ({}),
+    },
+  } as unknown as LarkChannel;
+}
+
+function makeAgent(): { agent: AgentAdapter; run: ReturnType<typeof vi.fn> } {
+  const run = vi.fn(() => ({
+    events: (async function* () {
+      yield { type: 'done' };
+    })(),
+    stop: async () => {},
+    waitForExit: async () => true,
+  }));
+  const agent = {
+    id: 'claude',
+    displayName: 'Claude Code',
+    isAvailable: async () => true,
+    run,
+  } as unknown as AgentAdapter;
+  return { agent, run };
+}
+
+const sessions = {
+  resumeFor: () => undefined,
+  set: () => {},
+} as unknown as SessionStore;
+const workspaces = {
+  cwdFor: () => undefined,
+} as unknown as WorkspaceStore;
+
+describe('handleCommentMention access control', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('drops a cloud-doc @mention from a non-allowlisted operator without running the agent', async () => {
+    const { agent, run } = makeAgent();
+    // A near-empty channel is fine: the request must be rejected before any
+    // channel API call. If the gate regresses, agent.run (or a channel call)
+    // would be reached and the assertions below would fail.
+    const channel = {} as unknown as LarkChannel;
+    await handleCommentMention({
+      channel,
+      evt: makeEvent('ou_attacker'),
+      agent,
+      sessions,
+      workspaces,
+      controls: makeControls(cfgWithAllowedUsers(['ou_owner'])),
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it('runs the agent for an allowlisted operator', async () => {
+    const { agent, run } = makeAgent();
+    await handleCommentMention({
+      channel: makeHappyChannel(),
+      evt: makeEvent('ou_owner'),
+      agent,
+      sessions,
+      workspaces,
+      controls: makeControls(cfgWithAllowedUsers(['ou_owner'])),
+    });
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('still allows all operators when the allowlist is empty (back-compat default)', async () => {
+    const { agent, run } = makeAgent();
+    await handleCommentMention({
+      channel: makeHappyChannel(),
+      evt: makeEvent('ou_anybody'),
+      agent,
+      sessions,
+      workspaces,
+      controls: makeControls(cfgWithAllowedUsers([])),
+    });
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/bot/comments.ts
+++ b/src/bot/comments.ts
@@ -1,6 +1,8 @@
 import { homedir } from 'node:os';
 import type { CommentEvent, LarkChannel } from '@larksuiteoapi/node-sdk';
 import type { AgentAdapter } from '../agent/types';
+import type { Controls } from '../commands';
+import { isUserAllowed } from '../config/schema';
 import { log } from '../core/logger';
 import type { SessionStore } from '../session/store';
 import type { WorkspaceStore } from '../workspace/store';
@@ -12,6 +14,7 @@ export interface CommentDeps {
   agent: AgentAdapter;
   sessions: SessionStore;
   workspaces: WorkspaceStore;
+  controls: Controls;
 }
 
 // File types supported by drive.v1.fileComment.get; other types (slides,
@@ -59,7 +62,7 @@ interface CommentContext {
  * a reply in the same comment thread.
  */
 export async function handleCommentMention(deps: CommentDeps): Promise<void> {
-  const { channel, evt, agent, sessions, workspaces } = deps;
+  const { channel, evt, agent, sessions, workspaces, controls } = deps;
   // Log every comment event we receive, regardless of whether we'll act on it.
   // `mentionedBot` and `replyId` here let us tell apart top-level comments
   // from thread replies (the latter requires SDK ≥ 1.65.0-alpha.0).
@@ -73,6 +76,20 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
   });
   if (!evt.mentionedBot) {
     log.info('comment', 'skip', { reason: 'not-mentioned' });
+    return;
+  }
+  // Access control. The cloud-doc comment path is a third entry point into
+  // the agent (alongside IM messages in intakeMessage and button clicks in
+  // handleCardAction) and must honor the same operator allowlist. Without
+  // this gate any tenant member who can @-mention the bot in a doc comment
+  // could drive the agent, bypassing `allowedUsers` entirely. Silent drop,
+  // matching the other two entry points (a denial reply would just confirm
+  // the bot exists). `allowedChats` is an IM-chat concept with no cloud-doc
+  // equivalent, so only the user allowlist applies here.
+  if (!isUserAllowed(controls.cfg, evt.operator.openId)) {
+    log.info('comment', 'skip-not-allowed-user', {
+      sender: evt.operator.openId.slice(-6),
+    });
     return;
   }
   if (!SUPPORTED_FILE_TYPES.has(evt.fileType)) {


### PR DESCRIPTION
## Summary

The bridge has three entry points that hand a user-supplied prompt to the local Claude Code agent: IM messages (`intakeMessage`), interactive-card button clicks (`handleCardAction`), and **cloud-doc comment @-mentions** (`handleCommentMention`). The first two enforce the operator's access allowlist via `isUserAllowed(...)`. The comment path did not — it only checked `evt.mentionedBot` and the file type, then ran the agent. So the `preferences.access.allowedUsers` allowlist — documented as "who can interact with the bot" — was silently not applied to the comment channel.

## Impact

A tenant member who is **not** on `allowedUsers` could drive the agent anyway: create or comment on any cloud doc the bot can see, `@`-mention the bot, and their comment text is run as the agent prompt. The agent is spawned with `--permission-mode bypassPermissions` by default (`src/agent/claude/adapter.ts`), so this is autonomous tool execution (Bash/Read/Edit/…) on the operator's host, with the result posted back as a comment reply the requester can read. The user allowlist is the operator's primary access boundary for a hardened deployment, and this path bypassed it entirely (CWE-862, Missing Authorization).

Note: `allowedChats` is an IM-chat concept with no cloud-doc analogue, so only the user allowlist is relevant here — matching the existing rationale that `allowedChats` is a group-only gate.

## Location

`src/bot/comments.ts` — `handleCommentMention()` (no `isUserAllowed` check before `agent.run`).

## Fix

Thread the existing `Controls` (carrying the live `AppConfig`) into the comment handler and apply the same `isUserAllowed(controls.cfg, evt.operator.openId)` gate the IM and card paths already use, placed right after the `mentionedBot` check and before any Feishu API call or agent run. Unauthorized commenters are silently dropped (matching the other two entry points — a denial reply would just confirm the bot exists). Empty/undefined `allowedUsers` still means "allow all", so existing unrestricted deployments are unchanged.

Files changed:
- `src/bot/comments.ts` — add the access gate + `controls` dep.
- `src/bot/channel.ts` — pass `controls` to `handleCommentMention`.
- `src/bot/comments.test.ts` — regression tests (blocked when not allowlisted, allowed when listed, allow-all when list empty).

## Detected by

Aeon + manual review (semgrep/trufflehog/osv ran clean on this surface).
- Severity: high
- CWE-862 (Missing Authorization)

## Verification

- `tsc --noEmit` — clean.
- `vitest run` — `src/bot/comments.test.ts` 3/3 pass (no test suite existed before; these are new).

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
