### PR TITLE
feat: /new --clean command deletes the current session's JSONL history file

### DIFF
--- a/src/card/templates.ts
+++ b/src/card/templates.ts
@@ -147,7 +147,8 @@ export function helpCard(): object {
       [
         '**命令列表**',
         '',
-        '- `/new` `/reset` — 清空当前 chat 的会话',
+        '- `/new` `/reset` — 清空当前 chat 的会话（历史可通过 `/resume` 恢复）',
+        '- `/new --clean` — 清空会话并永久删除历史对话记录',
         '- `/new chat [name]` — 新建群+新会话，自动拉你进群',
         '- `/resume [N]` — 列出并恢复历史会话（最多 N 条）',
         '- `/cd <path>` — 切换工作目录（会重置 session）',

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -203,19 +203,24 @@ async function handleNew(args: string, ctx: CommandContext): Promise<void> {
     return handleNewChat(rawName, ctx);
   }
 
+  // /new --clean  — new session + permanently delete the current JSONL history
+  const clean = trimmed === '--clean';
+
   const wasRunning = ctx.activeRuns.interrupt(ctx.scope);
 
-  // Delete the JSONL file before clearing the pointer so the sessionId is
-  // still available here. Silently ignores missing files.
-  const prev = ctx.sessions.getRaw(ctx.scope);
-  if (prev?.sessionId && prev.cwd) {
-    await deleteSession(prev.cwd, prev.sessionId).catch((err) => {
-      log.warn('command', '/new delete-session failed', { err: String(err) });
-    });
+  if (clean) {
+    const prev = ctx.sessions.getRaw(ctx.scope);
+    if (prev?.sessionId && prev.cwd) {
+      await deleteSession(prev.cwd, prev.sessionId).catch((err) => {
+        log.warn('command', '/new --clean delete-session failed', { err: String(err) });
+      });
+    }
   }
 
   ctx.sessions.clear(ctx.scope);
-  await reply(ctx, wasRunning ? '已中断当前任务并开始新会话。' : '已开始新会话。');
+
+  const base = wasRunning ? '已中断当前任务并开始新会话。' : '已开始新会话。';
+  await reply(ctx, clean ? `${base}\n_历史对话记录已永久删除。_` : base);
 }
 
 async function handleNewChat(rawName: string, ctx: CommandContext): Promise<void> {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -34,7 +34,7 @@ import {
   reduce,
   type RunState,
 } from '../card/run-state';
-import { formatRelTime, listRecentSessions } from '../session/history';
+import { deleteSession, formatRelTime, listRecentSessions } from '../session/history';
 import { isAlive, readAndPrune, resolveTarget } from '../runtime/registry';
 import type { SessionStore } from '../session/store';
 import { validateAppCredentials } from '../utils/feishu-auth';
@@ -204,6 +204,16 @@ async function handleNew(args: string, ctx: CommandContext): Promise<void> {
   }
 
   const wasRunning = ctx.activeRuns.interrupt(ctx.scope);
+
+  // Delete the JSONL file before clearing the pointer so the sessionId is
+  // still available here. Silently ignores missing files.
+  const prev = ctx.sessions.getRaw(ctx.scope);
+  if (prev?.sessionId && prev.cwd) {
+    await deleteSession(prev.cwd, prev.sessionId).catch((err) => {
+      log.warn('command', '/new delete-session failed', { err: String(err) });
+    });
+  }
+
   ctx.sessions.clear(ctx.scope);
   await reply(ctx, wasRunning ? '已中断当前任务并开始新会话。' : '已开始新会话。');
 }

--- a/src/session/history.ts
+++ b/src/session/history.ts
@@ -1,5 +1,5 @@
 import { createReadStream } from 'node:fs';
-import { readdir, stat } from 'node:fs/promises';
+import { readdir, rm, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
@@ -17,6 +17,15 @@ function encodeCwd(cwd: string): string {
 
 function claudeProjectDir(cwd: string): string {
   return join(homedir(), '.claude', 'projects', encodeCwd(cwd));
+}
+
+/**
+ * Delete the JSONL file for `sessionId` under `cwd`. Silently ignores
+ * ENOENT (file already gone). Throws on other I/O errors.
+ */
+export async function deleteSession(cwd: string, sessionId: string): Promise<void> {
+  const path = join(claudeProjectDir(cwd), `${sessionId}.jsonl`);
+  await rm(path, { force: true });
 }
 
 /** Return the most recent `limit` jsonl sessions for the given cwd, newest first. */


### PR DESCRIPTION
Previously /new only removed the sessionId pointer in sessions.json, leaving the .jsonl file on disk indefinitely. Over time these files accumulate in ~/.claude/projects/ with no automatic cleanup.

Changes:
- Add deleteSession(cwd, sessionId) to session/history.ts, using fs/promises.rm({ force: true }) so missing files are silently ignored
- In handleNew, read the current sessionId/cwd before clearing the pointer, then call deleteSession to remove the file
- Deletion errors are caught and logged as warnings so /new always succeeds regardless of file-system state

Edge cases handled:
- No active session (first /new): skips deletion safely
- File already deleted manually: force:true ignores ENOENT
- I/O errors (permissions etc.): caught, warn-logged, /new continues