### PR TITLE
fix: add exponential backoff for WebSocket reconnection to prevent re…

### DIFF
--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -164,11 +164,20 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
     wsConfig: {
       // 3s liveness watchdog: if no inbound message arrives within 3s after
       // the last ping, SDK presumes connection dead and forces a reconnect.
-      pingTimeout: 3,
+      // Configurable via WS_PING_TIMEOUT env var (seconds). Default 10s for
+      // more tolerance on mobile/WiFi networks with variable latency.
+      pingTimeout: ((): number => {
+        const v = parseInt(process.env.WS_PING_TIMEOUT || '10', 10);
+        return isNaN(v) || v < 3 ? 10 : v;
+      })(),
     },
     // 8s handshake timeout (replaces hardcoded 15s). Fast-fail + fast-retry
     // beats slow-fail in unstable networks.
-    handshakeTimeoutMs: 8_000,
+    // Configurable via WS_HANDSHAKE_TIMEOUT env var (milliseconds).
+    handshakeTimeoutMs: ((): number => {
+      const v = parseInt(process.env.WS_HANDSHAKE_TIMEOUT || '8000', 10);
+      return isNaN(v) || v < 3000 ? 8000 : v;
+    })(),
     // Optional WS-layer proxy agent (only when HTTPS_PROXY / HTTP_PROXY env set).
     ...(netOverrides.agent ? { agent: netOverrides.agent } : {}),
   };
@@ -215,6 +224,7 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
 
   // Counter for stdout reconnect escalation; reset on `reconnected`.
   let consecutiveReconnects = 0;
+  let lastReconnectAt = 0;
 
   channel.on({
     message: async (msg) => {
@@ -259,12 +269,31 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
     },
     reconnecting: () => {
       consecutiveReconnects++;
-      log.warn('ws', 'reconnecting', { consecutive: consecutiveReconnects });
+      const now = Date.now();
+      if (!lastReconnectAt) lastReconnectAt = now;
+      const reconnectRateMs =
+        consecutiveReconnects > 1
+          ? (now - lastReconnectAt) / (consecutiveReconnects - 1)
+          : 0;
+      lastReconnectAt = now;
+      log.warn('ws', 'reconnecting', {
+        consecutive: consecutiveReconnects,
+        avgIntervalMs: Math.round(reconnectRateMs),
+      });
       // Stdout escalation — surface jitter that's hidden in the file log.
       if (consecutiveReconnects === 3) {
         console.error('⚠️ 已连续重连 3 次,网络可能不稳。');
       } else if (consecutiveReconnects === 10) {
         console.error('❌ 已连续重连 10 次,建议在飞书发 /reconnect 或重启 bot。');
+      }
+      // Detect reconnect-storm: rapid reconnects (<15s avg interval) suggest
+      // the SDK pingTimeout is too aggressive or the network is unstable.
+      if (consecutiveReconnects >= 5 && reconnectRateMs < 15_000) {
+        log.warn('ws', 'reconnect-storm', {
+          consecutive: consecutiveReconnects,
+          avgIntervalMs: Math.round(reconnectRateMs),
+          hint: 'reconnecting too fast; consider setting WS_PING_TIMEOUT to a higher value or checking network stability',
+        });
       }
     },
     reconnected: () => {

--- a/src/bot/keepalive.ts
+++ b/src/bot/keepalive.ts
@@ -33,6 +33,13 @@ const HTTP_PROBE_TIMEOUT_MS = 5_000;
 const DEAD_THRESHOLD = 3;
 const NETWORK_DOWN_LOG_EVERY = 20; // log roughly every 5min while network is down
 
+// Exponential backoff for force-reconnect. After repeated force-reconnect
+// cycles (each cycle = DEAD_THRESHOLD consecutive ws-stuck ticks), wait
+// progressively longer before triggering the next one. This prevents a
+// reconnect storm from hammering the Feishu WS gateway.
+const FORCE_RECONNECT_BACKOFF_BASE_MS = 30_000; // 30s base
+const FORCE_RECONNECT_BACKOFF_MAX_MS = 300_000; // 5min cap
+
 export interface KeepaliveDeps {
   channel: LarkChannel;
   /** HTTP probe target, typically `https://open.feishu.cn` or lark equivalent. */
@@ -51,6 +58,8 @@ export function startKeepalive(deps: KeepaliveDeps): KeepaliveHandle {
   let lastTick = 0;
   let consecutiveDown = 0;
   let networkDownTicks = 0;
+  let forceReconnectCount = 0;
+  let lastForceReconnectAt = 0;
   let stopped = false;
 
   const tick = async (): Promise<void> => {
@@ -83,6 +92,7 @@ export function startKeepalive(deps: KeepaliveDeps): KeepaliveHandle {
       }
       consecutiveDown = 0;
       networkDownTicks = 0;
+      forceReconnectCount = 0;
       return;
     }
 
@@ -113,10 +123,32 @@ export function startKeepalive(deps: KeepaliveDeps): KeepaliveHandle {
     });
 
     // (5) Counter-based debounce — wait for DEAD_THRESHOLD ticks before
-    //     force-reconnecting.
+    //     force-reconnecting, with exponential backoff between consecutive
+    //     force-reconnect cycles to avoid reconnection storms.
     if (consecutiveDown >= DEAD_THRESHOLD) {
-      log.warn('keepalive', 'force-reconnect', { state: status.state });
       consecutiveDown = 0;
+      forceReconnectCount++;
+      const backoffMs = Math.min(
+        FORCE_RECONNECT_BACKOFF_BASE_MS * Math.pow(2, forceReconnectCount - 1),
+        FORCE_RECONNECT_BACKOFF_MAX_MS,
+      );
+      const sinceLastForce =
+        lastForceReconnectAt > 0 ? Date.now() - lastForceReconnectAt : Infinity;
+      if (sinceLastForce < backoffMs) {
+        log.warn('keepalive', 'force-reconnect-skipped', {
+          state: status.state,
+          forceReconnectCount,
+          backoffMs,
+          waitRemainingMs: backoffMs - sinceLastForce,
+        });
+        return;
+      }
+      log.warn('keepalive', 'force-reconnect', {
+        state: status.state,
+        forceReconnectCount,
+        backoffMs,
+      });
+      lastForceReconnectAt = Date.now();
       try {
         await forceReconnect();
       } catch (err) {


### PR DESCRIPTION
…connect storms

Three improvements to prevent WS reconnection from spiraling into a tight loop that makes the bridge unresponsive:

1. pingTimeout configurable via WS_PING_TIMEOUT (default 10s, was 3s)
   - 3s is too aggressive for mobile/WiFi networks; 10s tolerates normal latency jitter without false-triggering reconnects.
   - handshakeTimeoutMs also configurable via WS_HANDSHAKE_TIMEOUT.

2. Exponential backoff in keepalive force-reconnect loop
   - After each force-reconnect cycle, wait 30s → 60s → 120s ... (capped at 5min) before triggering the next one.
   - Prevents hammering the Feishu WS gateway when reconnects keep failing (e.g. during network outages).

3. Reconnect-storm detection in WS reconnecting callback
   - Logs `ws.reconnect-storm` when reconnects happen faster than 15s avg interval for 5+ consecutive attempts.
   - Surfaces the hint to check WS_PING_TIMEOUT and network stability.

Closes the issue where bridge becomes unresponsive due to endless no-pong → handshake-timeout → reconnect cycles.