### PR TITLE
support codex bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lark-channel-bridge
 
-A lightweight bot that bridges Feishu / Lark messenger with your local Claude Code CLI. Run one command, scan a QR code to bind a Lark app, and talk to Claude from chat — read screenshots, edit code, anything you'd do at the terminal.
+A lightweight bot that bridges Feishu / Lark messenger with your local coding-agent CLI — **Claude Code** by default, or **OpenAI Codex**. Run one command, scan a QR code to bind a Lark app, and drive your agent from chat — read screenshots, edit code, anything you'd do at the terminal.
 
 [中文 README](./README.zh.md)
 
@@ -19,7 +19,7 @@ A lightweight bot that bridges Feishu / Lark messenger with your local Claude Co
 ## Prerequisites
 
 - Node.js **>= 20**
-- `claude` CLI installed and logged in — see https://docs.anthropic.com/en/docs/claude-code/quickstart
+- A coding-agent CLI installed and logged in — **either** `claude` ([Claude Code quickstart](https://docs.anthropic.com/en/docs/claude-code/quickstart)) **or** `codex` (`npm i -g @openai/codex` then `codex login`). See [Choosing the agent](#choosing-the-agent-claude-code-or-codex) below.
 - A Lark / Feishu **PersonalAgent** app (the QR-code wizard on first launch can create one for you).
 
 ## Install
@@ -42,6 +42,26 @@ The first run detects there's no app configured and **opens a QR-code wizard**:
 2. Scan it with the Feishu / Lark app.
 3. Pick or create a PersonalAgent app.
 4. Credentials are written to `~/.lark-channel/config.json`.
+
+## Choosing the agent: Claude Code or Codex
+
+By default the bridge drives the `claude` CLI. It can drive **OpenAI Codex** (`codex exec`) instead — same chat flow: streaming card, per-chat sessions (resumed across turns), `/stop`, and tool-call rendering. Select it in `~/.lark-channel/config.json`:
+
+```json
+{
+  "preferences": {
+    "agent": "codex",
+    "codexReasoningEffort": "medium"
+  }
+}
+```
+
+- **`agent`**: `"claude"` (default) or `"codex"`. This is a process-start choice — restart the bridge after changing it. Omitting it (or any value other than `"codex"`) keeps Claude.
+- **`codexReasoningEffort`** (Codex only): `"minimal" | "low" | "medium" | "high"`. Passed to `codex exec` as `model_reasoning_effort`; omit to let Codex use its own default. Ignored when `agent` is `"claude"`.
+
+The bridge spawns a fresh `codex exec` per message and resumes the Codex thread across turns. Usage/billing goes to whatever account your `codex` CLI is logged into — the same as running Codex yourself at the terminal; `codex exec` is not billed separately.
+
+> **Notes on the Codex agent.** Streaming is at message granularity (Codex emits whole messages, not token-by-token), so the card refreshes a little more coarsely than with Claude. Plain conversation and shell/tool calls are the well-tested path; the higher-level bridge conventions (the bot proactively sending callback cards, `lark-cli` OAuth) depend on Codex following injected instructions and are less battle-tested than under Claude.
 
 ## Commands
 
@@ -105,7 +125,7 @@ Daemon logs go to `~/.lark-channel/logs/daemon-stdout.log` and `daemon-stderr.lo
 | Path | Content |
 |---|---|
 | `~/.lark-channel/config.json` | App credentials (App ID / Secret), mode 600 |
-| `~/.lark-channel/sessions.json` | Claude session id + cwd per chat / topic (+ optional `/timeout` override) |
+| `~/.lark-channel/sessions.json` | Agent session/thread id + cwd per chat / topic (+ optional `/timeout` override) |
 | `~/.lark-channel/workspaces.json` | Named-workspace map |
 | `~/.lark-channel/processes.json` | Process registry for live `start` instances (used by `ps`/`stop`); dead PIDs are auto-pruned |
 | `~/.lark-channel/media/<chatId>/` | Downloaded images / files, cleaned up after 24h |

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,6 +1,6 @@
 # lark-channel-bridge
 
-把飞书 / Lark 消息和本地 Claude Code CLI 打通的轻量 bot，用一条命令起服务，扫码绑应用，在飞书里和 Claude 对话、让它读图 / 改代码。
+把飞书 / Lark 消息和本地编码 Agent CLI 打通的轻量 bot —— 默认用 **Claude Code**，也可改用 **OpenAI Codex**。用一条命令起服务，扫码绑应用，在飞书里和你的 Agent 对话、让它读图 / 改代码。
 
 [English README](./README.md)
 
@@ -19,7 +19,7 @@
 ## 前置条件
 
 - Node.js **≥ 20**
-- `claude` CLI 已安装并登录：https://docs.anthropic.com/en/docs/claude-code/quickstart
+- 一个编码 Agent CLI 已安装并登录 —— **二选一**：`claude`（[Claude Code 快速上手](https://docs.anthropic.com/en/docs/claude-code/quickstart)）**或** `codex`（`npm i -g @openai/codex` 后 `codex login`）。详见下方[选择 Agent](#选择-agentclaude-code-还是-codex)。
 - 一个飞书 / Lark PersonalAgent 应用（首次启动的扫码向导能帮你创建）
 
 ## 安装
@@ -42,6 +42,26 @@ lark-channel-bridge run
 2. 用飞书 App 扫码
 3. 选择 / 创建 PersonalAgent 应用
 4. 成功后凭据写入 `~/.lark-channel/config.json`
+
+## 选择 Agent：Claude Code 还是 Codex
+
+默认 bridge 驱动 `claude` CLI，也可以改成驱动 **OpenAI Codex**（`codex exec`）—— 聊天体验一致：流式卡片、每个 chat 独立会话（多轮自动续接）、`/stop`、工具调用渲染都在。在 `~/.lark-channel/config.json` 里选：
+
+```json
+{
+  "preferences": {
+    "agent": "codex",
+    "codexReasoningEffort": "medium"
+  }
+}
+```
+
+- **`agent`**：`"claude"`（默认）或 `"codex"`。这是**启动时**的选择 —— 改完要**重启 bridge**。不填（或填了非 `"codex"` 的值）都走 Claude。
+- **`codexReasoningEffort`**（仅 Codex）：`"minimal" | "low" | "medium" | "high"`。会作为 `model_reasoning_effort` 传给 `codex exec`；不填则用 Codex 自己的默认。`agent` 为 `"claude"` 时忽略此项。
+
+bridge 每条消息起一个新的 `codex exec` 进程，多轮之间 resume 同一个 Codex thread。用量 / 计费走你 `codex` CLI 登录的那个账户 —— 跟你自己在终端里跑 Codex 完全一样，`codex exec` 不单独计费。
+
+> **关于 Codex agent 的说明**：流式是**消息级**的（Codex 整条消息一起吐，不是逐 token），所以卡片刷新比 Claude 略粗。普通对话和 shell / 工具调用是充分验证过的主路径；更高级的 bridge 约定（bot 主动发回调卡片、`lark-cli` OAuth）依赖 Codex 遵循注入的提示，成熟度不如 Claude 下。
 
 ## 命令速查
 
@@ -105,7 +125,7 @@ daemon 的 stdout / stderr 写到 `~/.lark-channel/logs/daemon-stdout.log` 和 `
 | 路径 | 内容 |
 |---|---|
 | `~/.lark-channel/config.json` | 应用凭据（App ID / Secret），权限 600 |
-| `~/.lark-channel/sessions.json` | 每个 chat / 话题 的 Claude session id + cwd（+ 可选的 `/timeout` 覆盖） |
+| `~/.lark-channel/sessions.json` | 每个 chat / 话题 的 Agent session/thread id + cwd（+ 可选的 `/timeout` 覆盖） |
 | `~/.lark-channel/workspaces.json` | 工作空间映射 |
 | `~/.lark-channel/processes.json` | 当前在跑的 start 进程注册中心（`ps`/`stop` 用），死进程会被自动清理 |
 | `~/.lark-channel/media/<chatId>/` | 下载的图片 / 文件，24h 自动清理 |

--- a/docs/superpowers/specs/2026-05-27-codex-bridge-design.md
+++ b/docs/superpowers/specs/2026-05-27-codex-bridge-design.md
@@ -1,0 +1,129 @@
+# Codex 适配器设计 (Codex Bridge)
+
+- 日期: 2026-05-27
+- 分支: `feat/lisi/codex-bridge`
+- 状态: 已批准,进入实现
+
+## 背景与目标
+
+本项目 (`lark-channel-bridge`) 目前只能桥接本地 `claude` CLI。代码已为多 agent 预留了清晰的抽象层 (`src/agent/`):bot / card / session / workspace 层只依赖 `AgentAdapter` / `AgentEvent` 接口,不感知底层 agent。
+
+目标:新增一个 **Codex 适配器**,让用户可以把整个飞书桥接流程跑在 OpenAI Codex CLI (`codex exec`) 上,而不改动 bot 层。
+
+### v1 范围
+
+核心会话流 **+ 新 session 首轮注入精简版 bridge 约定**:
+
+- 发消息 → `codex exec` 跑 → 文本 / reasoning / 工具调用实时渲染到卡片 → 多轮 `resume` 续接 → `/stop` 能停。
+- 新 session 首轮把精简版 bridge 约定 prepend 进 prompt(`bridge_context` 别照抄、`chat_id` 怎么用、交互卡片回调、`lark-cli` OAuth 前台阻塞流)。
+- agent 选择走配置项 `preferences.agent`,默认 `claude`。
+
+### v1 不做 (YAGNI)
+
+图片输入 (`-i`)、`output_schema`、profile / reasoning-effort 配置、完整版 `BRIDGE_SYSTEM_PROMPT`、CLI flag 覆盖 agent 选择。
+
+## 已核实的 Codex 事实 (codex-cli 0.134.0)
+
+- `codex exec [OPTIONS] "<prompt>"` —— 非交互单次运行,prompt 走参数或 stdin。
+- `--json` —— 事件以 JSONL 打到 stdout。
+- `codex exec resume <SESSION_ID> [OPTIONS] "<prompt>"` —— 续接,`SESSION_ID` 为 UUID;`--last` 取最近。
+- `-C/--cd <DIR>` 工作目录;`--skip-git-repo-check` 允许在非 git 目录跑。
+- `--dangerously-bypass-approvals-and-sandbox` 绕过审批 + 沙箱;`-s read-only|workspace-write|danger-full-access` 选沙箱。
+- `-m/--model`;`-o/--output-last-message <FILE>`;`--ephemeral` 不落盘 session。
+
+### 实测 `--json` 事件 schema
+
+新建会话 + 执行一条 shell 命令时的真实输出:
+
+```
+{"type":"thread.started","thread_id":"019e68b8-...-uuid"}
+{"type":"turn.started"}
+{"type":"item.started","item":{"id":"item_0","type":"command_execution","command":"/bin/zsh -lc 'echo hi'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_0","type":"command_execution","command":"/bin/zsh -lc 'echo hi'","aggregated_output":"hi\n","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"done"}}
+{"type":"turn.completed","usage":{"input_tokens":37868,"cached_input_tokens":23808,"output_tokens":38,"reasoning_output_tokens":0}}
+```
+
+要点:
+- `thread.started.thread_id` 是会话标识 → 映射成 `AgentEvent.system.sessionId`。
+- 文本以 **item 级** `item.completed` 给出(非逐 token delta)→ 卡片按 item 粒度刷新。
+- `item.id` 跨 `item.started` / `item.completed` 稳定 → 直接满足 channel 的 idle-watchdog 配对。
+- usage 在 `turn.completed`,**无美元成本字段**。
+- stderr 可能有噪声(用户 codex 配置里挂的 MCP server 鉴权报错等)→ 只 `log.warn`,不上抛。
+
+## 架构
+
+镜像现有 `src/agent/claude/`,新增 `src/agent/codex/`:
+
+| 文件 | 职责 |
+|---|---|
+| `src/agent/codex/adapter.ts` | `CodexAdapter implements AgentAdapter`(`id='codex'`, `displayName='Codex'`)。spawn `codex exec`,进程管理(stop/SIGTERM/waitForExit)照搬 Claude 适配器结构 |
+| `src/agent/codex/stream-json.ts` | `translateEvent(raw)`:Codex JSONL → 统一 `AgentEvent`,无状态逐行映射 |
+| `src/agent/codex/bridge-prompt.ts` | 精简版 bridge 约定常量 `CODEX_BRIDGE_PROMPT`,仅新 session 首轮 prepend |
+| `src/agent/codex/stream-json.test.ts` | fixture 单测:真实 JSONL → 断言 `AgentEvent` 序列 |
+
+改动的现有文件:
+
+| 文件 | 改动 |
+|---|---|
+| `src/agent/index.ts` | 导出 `CodexAdapter` + 新增 `createAgent(cfg)` 工厂 |
+| `src/config/schema.ts` | `AppPreferences.agent?: 'claude' \| 'codex'` + `getAgentKind(cfg)`(默认 `'claude'`) |
+| `src/cli/commands/start.ts` | `new ClaudeAdapter()` → `createAgent(cfg)`;`isAvailable()` 失败报错按 agent 区分 |
+| `src/cli/commands/service.ts` | `new ClaudeAdapter()` → `createAgent(cfg)` |
+
+bot / card / session / workspace 层零改动。
+
+## `CodexAdapter.run()` 命令构造
+
+- **新 session**:`codex exec --json --skip-git-repo-check -C <cwd> <sandboxFlags> [-m <model>] "<注入约定 + prompt>"`
+- **resume**:`codex exec resume <sessionId> --json --skip-git-repo-check -C <cwd> <sandboxFlags> [-m <model>] "<prompt>"`(不注入约定)
+- `--skip-git-repo-check` 总是带,匹配 Claude "任意目录可跑"。
+- `permissionMode` 映射:
+  - `bypassPermissions`(bridge 默认)→ `--dangerously-bypass-approvals-and-sandbox`
+  - `plan` → `-s read-only`
+  - `acceptEdits` / `default` → `-s workspace-write`
+- `stdio: ['ignore', 'pipe', 'pipe']`,stdin 关闭避免 codex 等待 stdin。
+- `env: { ...process.env, LARK_CHANNEL: '1' }`(与 Claude 对齐)。
+- `stop()` / `waitForExit()` 与 Claude 适配器同构(SIGTERM → grace → SIGKILL)。
+
+## 事件翻译表
+
+| Codex 事件 | AgentEvent |
+|---|---|
+| `thread.started {thread_id}` | `system {sessionId: thread_id, cwd}` |
+| `turn.started` | 忽略 |
+| `item.started {type:command_execution, id, command}` | `tool_use {id, name:'shell', input:{command}}` |
+| `item.completed {type:command_execution, id, aggregated_output, exit_code}` | `tool_result {id, output:aggregated_output, isError: exit_code!==0}` |
+| `item.completed {type:agent_message, text}` | `text {delta:text}` |
+| `item.completed {type:reasoning, text/summary}` | `thinking {delta}`(字段名实现时按真实输出确认) |
+| `item.started/.completed {type:mcp_tool_call}` | `tool_use` / `tool_result` |
+| `turn.completed {usage}` | `usage {inputTokens, outputTokens}` 然后 `done` |
+| `turn.failed` / error item | `error {message}` |
+| 未知 `type` | 忽略(向前兼容) |
+
+说明:
+- `done` 不带 sessionId 无碍 —— channel 已从 `thread.started → system` 存了 sessionId。
+- `agent_message` / `reasoning` 只有 `item.completed`(无 `item.started`);`command_execution` 有 started + completed。
+- 翻译层无状态,逐行独立映射,与 Claude 的 `translateEvent` 同构。
+
+## 错误处理
+
+照搬 Claude `createEventStream` 收尾逻辑:
+- 非零退出码 → `error {message: "codex exited with code N: <stderr 截断>"}`。
+- spawn 失败(ENOENT,`child.pid` 为空)→ `error`。
+- `turn.failed` / error item → `error`。
+- stderr 行 → `log.warn('agent', 'stderr', ...)`,不进事件流。
+
+## 测试
+
+- **核心(进 CI)**:`stream-json.test.ts` —— 用本文档记录的真实 JSONL 作 fixture,逐行喂 `translateEvent`,断言产出的 `AgentEvent` 序列(system → tool_use → tool_result → text → usage → done)。纯确定性,无网络。
+- 适配器 `isAvailable()` / 命令构造:轻量单测(可对 arg 构造做纯函数化后断言)。
+- 真实 `codex exec` e2e 不进 CI(需 auth + 消耗额度)。
+
+## 验收标准
+
+1. `preferences.agent: 'codex'` 时,`lark-channel-bridge run` 启动后能用 Codex 回复飞书消息。
+2. 文本 / 工具调用实时渲染到卡片;多轮对话经 `resume` 续接同一 thread。
+3. `/stop` 能停止运行中的 Codex 进程。
+4. `preferences.agent` 缺省 / `'claude'` 时行为与现状完全一致。
+5. `pnpm typecheck` 与 `pnpm test` 通过。

--- a/src/agent/codex/adapter.test.ts
+++ b/src/agent/codex/adapter.test.ts
@@ -21,6 +21,21 @@ describe('buildCodexArgs', () => {
     expect(args.at(-1)).toBe('next turn');
   });
 
+  it('does NOT pass -C on resume (codex exec resume rejects it)', () => {
+    const args = buildCodexArgs({ prompt: 'next', sessionId: 'thr-123', cwd: '/work/proj' });
+    expect(args).not.toContain('-C');
+  });
+
+  it('does NOT pass an -s sandbox mode on resume (resume rejects -s)', () => {
+    const args = buildCodexArgs({ prompt: 'next', sessionId: 'thr-123', permissionMode: 'plan' });
+    expect(args).not.toContain('-s');
+  });
+
+  it('still passes the bypass flag on resume (resume accepts it)', () => {
+    const args = buildCodexArgs({ prompt: 'next', sessionId: 'thr-123' });
+    expect(args).toContain('--dangerously-bypass-approvals-and-sandbox');
+  });
+
   it('passes the working directory via -C', () => {
     const args = buildCodexArgs({ prompt: 'x', cwd: '/work/proj' });
     const i = args.indexOf('-C');

--- a/src/agent/codex/adapter.test.ts
+++ b/src/agent/codex/adapter.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { buildCodexArgs } from './adapter';
+import { CODEX_BRIDGE_PROMPT } from './bridge-prompt';
+
+describe('buildCodexArgs', () => {
+  it('starts a new run with exec + streaming json + git-check skip', () => {
+    const args = buildCodexArgs({ prompt: 'hello' });
+    expect(args.slice(0, 3)).toEqual(['exec', '--json', '--skip-git-repo-check']);
+  });
+
+  it('prepends the bridge prompt on a new session', () => {
+    const args = buildCodexArgs({ prompt: 'hello' });
+    const finalPrompt = args.at(-1) ?? '';
+    expect(finalPrompt.startsWith(CODEX_BRIDGE_PROMPT)).toBe(true);
+    expect(finalPrompt).toContain('hello');
+  });
+
+  it('resumes by session id and does NOT re-inject the bridge prompt', () => {
+    const args = buildCodexArgs({ prompt: 'next turn', sessionId: 'thr-123' });
+    expect(args.slice(0, 4)).toEqual(['exec', 'resume', 'thr-123', '--json']);
+    expect(args.at(-1)).toBe('next turn');
+  });
+
+  it('passes the working directory via -C', () => {
+    const args = buildCodexArgs({ prompt: 'x', cwd: '/work/proj' });
+    const i = args.indexOf('-C');
+    expect(i).toBeGreaterThan(-1);
+    expect(args[i + 1]).toBe('/work/proj');
+  });
+
+  it('omits -C when no cwd is given', () => {
+    expect(buildCodexArgs({ prompt: 'x' })).not.toContain('-C');
+  });
+
+  it('maps the default (bypass) permission mode to the bypass flag', () => {
+    expect(buildCodexArgs({ prompt: 'x' })).toContain(
+      '--dangerously-bypass-approvals-and-sandbox',
+    );
+  });
+
+  it('maps plan mode to a read-only sandbox', () => {
+    const args = buildCodexArgs({ prompt: 'x', permissionMode: 'plan' });
+    const i = args.indexOf('-s');
+    expect(args[i + 1]).toBe('read-only');
+    expect(args).not.toContain('--dangerously-bypass-approvals-and-sandbox');
+  });
+
+  it('maps acceptEdits to a workspace-write sandbox', () => {
+    const args = buildCodexArgs({ prompt: 'x', permissionMode: 'acceptEdits' });
+    const i = args.indexOf('-s');
+    expect(args[i + 1]).toBe('workspace-write');
+  });
+
+  it('passes the model via -m when set', () => {
+    const args = buildCodexArgs({ prompt: 'x', model: 'gpt-5.1-codex' });
+    const i = args.indexOf('-m');
+    expect(args[i + 1]).toBe('gpt-5.1-codex');
+  });
+});

--- a/src/agent/codex/adapter.test.ts
+++ b/src/agent/codex/adapter.test.ts
@@ -56,4 +56,15 @@ describe('buildCodexArgs', () => {
     const i = args.indexOf('-m');
     expect(args[i + 1]).toBe('gpt-5.1-codex');
   });
+
+  it('passes reasoning effort via -c when configured', () => {
+    const args = buildCodexArgs({ prompt: 'x' }, { reasoningEffort: 'medium' });
+    const i = args.indexOf('-c');
+    expect(i).toBeGreaterThan(-1);
+    expect(args[i + 1]).toBe('model_reasoning_effort="medium"');
+  });
+
+  it('omits the reasoning-effort flag when not configured', () => {
+    expect(buildCodexArgs({ prompt: 'x' })).not.toContain('-c');
+  });
 });

--- a/src/agent/codex/adapter.ts
+++ b/src/agent/codex/adapter.ts
@@ -25,14 +25,18 @@ type CodexChild = ChildProcessByStdio<null, Readable, Readable>;
  * Map the adapter's permission mode onto Codex's sandbox/approval flags.
  * Default (undefined) matches the Claude adapter's default — fully
  * autonomous — since the bridge runs headless with no human to approve.
+ *
+ * `codex exec resume` accepts ONLY the bypass flag, not `-s <mode>` — so on
+ * resume we emit nothing for the sandbox modes and let the persisted session
+ * keep its original policy. (`-C` is likewise exec-only; see buildCodexArgs.)
  */
-function sandboxArgs(mode: AgentRunOptions['permissionMode']): string[] {
+function permissionArgs(mode: AgentRunOptions['permissionMode'], resuming: boolean): string[] {
   switch (mode) {
     case 'plan':
-      return ['-s', 'read-only'];
+      return resuming ? [] : ['-s', 'read-only'];
     case 'acceptEdits':
     case 'default':
-      return ['-s', 'workspace-write'];
+      return resuming ? [] : ['-s', 'workspace-write'];
     default:
       return ['--dangerously-bypass-approvals-and-sandbox'];
   }
@@ -47,16 +51,19 @@ function sandboxArgs(mode: AgentRunOptions['permissionMode']): string[] {
  *              the persisted thread already carries the conventions.
  */
 export function buildCodexArgs(opts: AgentRunOptions, cfg: CodexRunConfig = {}): string[] {
-  const args = opts.sessionId ? ['exec', 'resume', opts.sessionId] : ['exec'];
+  const resuming = Boolean(opts.sessionId);
+  const args = resuming ? ['exec', 'resume', opts.sessionId as string] : ['exec'];
   args.push('--json', '--skip-git-repo-check');
-  if (opts.cwd) args.push('-C', opts.cwd);
-  args.push(...sandboxArgs(opts.permissionMode));
+  // `-C/--cd` is an exec-only flag; `codex exec resume` rejects it. On resume
+  // the working directory comes from the spawned process's cwd instead.
+  if (!resuming && opts.cwd) args.push('-C', opts.cwd);
+  args.push(...permissionArgs(opts.permissionMode, resuming));
   if (opts.model) args.push('-m', opts.model);
   if (cfg.reasoningEffort) {
     args.push('-c', `model_reasoning_effort="${cfg.reasoningEffort}"`);
   }
 
-  const prompt = opts.sessionId ? opts.prompt : `${CODEX_BRIDGE_PROMPT}${opts.prompt}`;
+  const prompt = resuming ? opts.prompt : `${CODEX_BRIDGE_PROMPT}${opts.prompt}`;
   args.push(prompt);
   return args;
 }

--- a/src/agent/codex/adapter.ts
+++ b/src/agent/codex/adapter.ts
@@ -3,12 +3,20 @@ import { spawn } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import type { Readable } from 'node:stream';
 import { log } from '../../core/logger';
+import type { CodexReasoningEffort } from '../../config/schema';
 import type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from '../types';
 import { CODEX_BRIDGE_PROMPT } from './bridge-prompt';
 import { translateEvent } from './stream-json';
 
 export interface CodexAdapterOptions {
   binary?: string;
+  /** Reasoning effort passed as `-c model_reasoning_effort=<value>`. */
+  reasoningEffort?: CodexReasoningEffort;
+}
+
+/** Per-run Codex config that isn't part of the generic AgentRunOptions. */
+interface CodexRunConfig {
+  reasoningEffort?: CodexReasoningEffort;
 }
 
 type CodexChild = ChildProcessByStdio<null, Readable, Readable>;
@@ -38,12 +46,15 @@ function sandboxArgs(mode: AgentRunOptions['permissionMode']): string[] {
  * Resume:      `exec resume <id> [flags] "<user prompt>"` — no re-injection,
  *              the persisted thread already carries the conventions.
  */
-export function buildCodexArgs(opts: AgentRunOptions): string[] {
+export function buildCodexArgs(opts: AgentRunOptions, cfg: CodexRunConfig = {}): string[] {
   const args = opts.sessionId ? ['exec', 'resume', opts.sessionId] : ['exec'];
   args.push('--json', '--skip-git-repo-check');
   if (opts.cwd) args.push('-C', opts.cwd);
   args.push(...sandboxArgs(opts.permissionMode));
   if (opts.model) args.push('-m', opts.model);
+  if (cfg.reasoningEffort) {
+    args.push('-c', `model_reasoning_effort="${cfg.reasoningEffort}"`);
+  }
 
   const prompt = opts.sessionId ? opts.prompt : `${CODEX_BRIDGE_PROMPT}${opts.prompt}`;
   args.push(prompt);
@@ -53,11 +64,13 @@ export function buildCodexArgs(opts: AgentRunOptions): string[] {
 export class CodexAdapter implements AgentAdapter {
   readonly id = 'codex';
   readonly displayName = 'Codex';
+  readonly reasoningEffort?: CodexReasoningEffort;
 
   private readonly binary: string;
 
   constructor(opts: CodexAdapterOptions = {}) {
     this.binary = opts.binary ?? 'codex';
+    this.reasoningEffort = opts.reasoningEffort;
   }
 
   async isAvailable(): Promise<boolean> {
@@ -69,7 +82,7 @@ export class CodexAdapter implements AgentAdapter {
   }
 
   run(opts: AgentRunOptions): AgentRun {
-    const args = buildCodexArgs(opts);
+    const args = buildCodexArgs(opts, { reasoningEffort: this.reasoningEffort });
 
     const child = spawn(this.binary, args, {
       cwd: opts.cwd,

--- a/src/agent/codex/adapter.ts
+++ b/src/agent/codex/adapter.ts
@@ -1,0 +1,207 @@
+import type { ChildProcessByStdio } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import type { Readable } from 'node:stream';
+import { log } from '../../core/logger';
+import type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from '../types';
+import { CODEX_BRIDGE_PROMPT } from './bridge-prompt';
+import { translateEvent } from './stream-json';
+
+export interface CodexAdapterOptions {
+  binary?: string;
+}
+
+type CodexChild = ChildProcessByStdio<null, Readable, Readable>;
+
+/**
+ * Map the adapter's permission mode onto Codex's sandbox/approval flags.
+ * Default (undefined) matches the Claude adapter's default — fully
+ * autonomous — since the bridge runs headless with no human to approve.
+ */
+function sandboxArgs(mode: AgentRunOptions['permissionMode']): string[] {
+  switch (mode) {
+    case 'plan':
+      return ['-s', 'read-only'];
+    case 'acceptEdits':
+    case 'default':
+      return ['-s', 'workspace-write'];
+    default:
+      return ['--dangerously-bypass-approvals-and-sandbox'];
+  }
+}
+
+/**
+ * Build the argv (after the `codex` binary) for one run. Pure + exported so
+ * the flag mapping and prompt injection are unit-testable without spawning.
+ *
+ * New session: `exec [flags] "<bridge prompt + user prompt>"`.
+ * Resume:      `exec resume <id> [flags] "<user prompt>"` — no re-injection,
+ *              the persisted thread already carries the conventions.
+ */
+export function buildCodexArgs(opts: AgentRunOptions): string[] {
+  const args = opts.sessionId ? ['exec', 'resume', opts.sessionId] : ['exec'];
+  args.push('--json', '--skip-git-repo-check');
+  if (opts.cwd) args.push('-C', opts.cwd);
+  args.push(...sandboxArgs(opts.permissionMode));
+  if (opts.model) args.push('-m', opts.model);
+
+  const prompt = opts.sessionId ? opts.prompt : `${CODEX_BRIDGE_PROMPT}${opts.prompt}`;
+  args.push(prompt);
+  return args;
+}
+
+export class CodexAdapter implements AgentAdapter {
+  readonly id = 'codex';
+  readonly displayName = 'Codex';
+
+  private readonly binary: string;
+
+  constructor(opts: CodexAdapterOptions = {}) {
+    this.binary = opts.binary ?? 'codex';
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return new Promise((resolve) => {
+      const child = spawn(this.binary, ['--version'], { stdio: 'ignore' });
+      child.on('error', () => resolve(false));
+      child.on('exit', (code) => resolve(code === 0));
+    });
+  }
+
+  run(opts: AgentRunOptions): AgentRun {
+    const args = buildCodexArgs(opts);
+
+    const child = spawn(this.binary, args, {
+      cwd: opts.cwd,
+      env: { ...process.env, LARK_CHANNEL: '1' },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    log.info('agent', 'spawn', {
+      agent: 'codex',
+      pid: child.pid ?? null,
+      cwd: opts.cwd ?? process.cwd(),
+      hasSession: Boolean(opts.sessionId),
+      promptChars: opts.prompt.length,
+      model: opts.model,
+    });
+
+    // Listeners MUST be attached synchronously here, before we return — the
+    // 'error'/exit events can fire in the next tick; deferring to the async
+    // generator body would let them fire into the void and hang the stream.
+    const stderrChunks: Buffer[] = [];
+    let stderrBuffer = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+      stderrBuffer += chunk.toString('utf8');
+      let nl = stderrBuffer.indexOf('\n');
+      while (nl !== -1) {
+        const line = stderrBuffer.slice(0, nl);
+        stderrBuffer = stderrBuffer.slice(nl + 1);
+        if (line.trim()) log.warn('agent', 'stderr', { line });
+        nl = stderrBuffer.indexOf('\n');
+      }
+    });
+
+    let runtimeError: Error | null = null;
+    child.on('error', (err) => {
+      runtimeError = err;
+    });
+    child.on('exit', (code, signal) => {
+      log.info('agent', 'exit', { pid: child.pid ?? null, code, signal });
+    });
+
+    const stopGraceMs = opts.stopGraceMs ?? 5000;
+
+    return {
+      events: createEventStream(child, stderrChunks, () => runtimeError),
+      async stop() {
+        if (child.exitCode !== null || child.signalCode !== null) return;
+        log.info('agent', 'stop-sigterm', { pid: child.pid ?? null, graceMs: stopGraceMs });
+        child.kill('SIGTERM');
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            if (child.exitCode === null && child.signalCode === null) {
+              log.warn('agent', 'stop-sigkill', {
+                pid: child.pid ?? null,
+                graceMs: stopGraceMs,
+                reason: 'grace-period-expired',
+              });
+              child.kill('SIGKILL');
+            }
+            resolve();
+          }, stopGraceMs);
+          child.once('exit', () => {
+            clearTimeout(timer);
+            resolve();
+          });
+        });
+      },
+      waitForExit(timeoutMs: number): Promise<boolean> {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          return Promise.resolve(true);
+        }
+        return new Promise<boolean>((resolve) => {
+          const onExit = (): void => {
+            clearTimeout(timer);
+            resolve(true);
+          };
+          const timer = setTimeout(() => {
+            child.removeListener('exit', onExit);
+            resolve(false);
+          }, timeoutMs);
+          child.once('exit', onExit);
+        });
+      },
+    };
+  }
+}
+
+async function* createEventStream(
+  child: CodexChild,
+  stderrChunks: Buffer[],
+  getError: () => Error | null,
+): AsyncGenerator<AgentEvent> {
+  if (!child.pid) {
+    const err = getError();
+    yield {
+      type: 'error',
+      message: err ? `failed to spawn codex: ${err.message}` : 'spawn returned no pid',
+    };
+    return;
+  }
+
+  const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  try {
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      yield* translateEvent(parsed);
+    }
+  } finally {
+    rl.close();
+  }
+
+  const exitCode = await new Promise<number | null>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve(child.exitCode);
+    } else {
+      child.once('exit', (code) => resolve(code));
+    }
+  });
+
+  const runtimeError = getError();
+  if (exitCode !== 0 && exitCode !== null) {
+    const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+    const detail = stderr ? `: ${stderr.slice(0, 500)}` : '';
+    yield { type: 'error', message: `codex exited with code ${exitCode}${detail}` };
+  } else if (runtimeError) {
+    yield { type: 'error', message: `codex runtime error: ${runtimeError.message}` };
+  }
+}

--- a/src/agent/codex/bridge-prompt.ts
+++ b/src/agent/codex/bridge-prompt.ts
@@ -1,0 +1,27 @@
+/**
+ * Condensed bridge conventions, prepended to the prompt on the FIRST turn of
+ * a Codex session only (resume carries its own history, so we don't re-inject).
+ *
+ * Codex `exec` has no `--append-system-prompt` equivalent, so unlike the
+ * Claude adapter — which feeds a fuller system prompt out-of-band — we inline a
+ * trimmed version here. It covers the four things that actually break without
+ * guidance: not echoing bridge XML, using chat_id, the card-callback marker,
+ * and the lark-cli OAuth foreground-blocking flow.
+ */
+export const CODEX_BRIDGE_PROMPT = `# lark-channel-bridge 运行约定（请先读完再回答）
+
+你在 lark-channel-bridge 里运行：飞书/Lark 用户的消息被桥接到本地 codex CLI。以下是必须遵守的约定，它们不是用户问题的一部分：
+
+1. 每条用户消息顶部可能带 <bridge_context>（chat_id、chat_type=p2p/group、sender）以及 <quoted_message> / <interactive_card> 块。这些是 bridge 注入的元数据，**不要把这些 XML 标签照抄进回复**——对用户不可见。用户的真实问题在这些块之后。
+
+2. 你要主动给当前会话发消息或交互卡片时，用 lark-cli 发到 bridge_context.chat_id：
+   lark-cli im send-card --chat-id <chat_id> --card '<CardKit 2.0 JSON>'
+   若希望用户点击按钮后回调到你（同一会话续接）：按钮 value 对象必须含 "__claude_cb": true，可附带任意状态字段。点击后 bridge 会把 payload（去掉该 marker）作为 [card-click] {...} 发回给你。纯展示卡片不要加该 marker。
+
+3. 飞书 OAuth（lark-cli auth login）：
+   - 只在 chat_type=p2p 里发起；群里不要发起（device code 会绑错身份），改为提示用户私聊你。
+   - 用两阶段、前台阻塞方式：先 lark-cli auth login --no-wait --json 秒返回拿到 verification_url（用代码块原样发给用户，不要 Markdown 链接化），紧接着同一轮里前台运行 lark-cli auth login --device-code <code> 阻塞等待用户点完。不要丢到后台。
+
+现在开始处理用户的实际请求：
+
+`;

--- a/src/agent/codex/stream-json.test.ts
+++ b/src/agent/codex/stream-json.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import type { AgentEvent } from '../types';
+import { translateEvent } from './stream-json';
+
+/** Collect every AgentEvent produced for a single raw Codex event line. */
+function emit(raw: unknown): AgentEvent[] {
+  return [...translateEvent(raw)];
+}
+
+describe('translateEvent (codex stream-json)', () => {
+  it('maps thread.started to a system event carrying the thread id as sessionId', () => {
+    expect(emit({ type: 'thread.started', thread_id: 'thr-123' })).toEqual([
+      { type: 'system', sessionId: 'thr-123' },
+    ]);
+  });
+
+  it('ignores turn.started', () => {
+    expect(emit({ type: 'turn.started' })).toEqual([]);
+  });
+
+  it('maps a completed agent_message item to a text event', () => {
+    const raw = {
+      type: 'item.completed',
+      item: { id: 'item_1', type: 'agent_message', text: 'done' },
+    };
+    expect(emit(raw)).toEqual([{ type: 'text', delta: 'done' }]);
+  });
+
+  it('maps a completed reasoning item to a thinking event', () => {
+    const raw = {
+      type: 'item.completed',
+      item: { id: 'r_0', type: 'reasoning', text: 'considering options' },
+    };
+    expect(emit(raw)).toEqual([{ type: 'thinking', delta: 'considering options' }]);
+  });
+
+  it('opens a tool_use when a command_execution item starts', () => {
+    const raw = {
+      type: 'item.started',
+      item: {
+        id: 'item_0',
+        type: 'command_execution',
+        command: "/bin/zsh -lc 'echo hi'",
+        aggregated_output: '',
+        exit_code: null,
+        status: 'in_progress',
+      },
+    };
+    expect(emit(raw)).toEqual([
+      {
+        type: 'tool_use',
+        id: 'item_0',
+        name: 'shell',
+        input: { command: "/bin/zsh -lc 'echo hi'" },
+      },
+    ]);
+  });
+
+  it('closes a successful command_execution as a non-error tool_result', () => {
+    const raw = {
+      type: 'item.completed',
+      item: {
+        id: 'item_0',
+        type: 'command_execution',
+        command: "/bin/zsh -lc 'echo hi'",
+        aggregated_output: 'hi\n',
+        exit_code: 0,
+        status: 'completed',
+      },
+    };
+    expect(emit(raw)).toEqual([
+      { type: 'tool_result', id: 'item_0', output: 'hi\n', isError: false },
+    ]);
+  });
+
+  it('marks a non-zero command_execution as an error tool_result', () => {
+    const raw = {
+      type: 'item.completed',
+      item: {
+        id: 'item_2',
+        type: 'command_execution',
+        command: '/bin/zsh -lc false',
+        aggregated_output: '',
+        exit_code: 1,
+        status: 'completed',
+      },
+    };
+    expect(emit(raw)).toEqual([
+      { type: 'tool_result', id: 'item_2', output: '', isError: true },
+    ]);
+  });
+
+  it('maps turn.completed to a usage event followed by done', () => {
+    const raw = {
+      type: 'turn.completed',
+      usage: {
+        input_tokens: 37868,
+        cached_input_tokens: 23808,
+        output_tokens: 38,
+        reasoning_output_tokens: 0,
+      },
+    };
+    expect(emit(raw)).toEqual([
+      { type: 'usage', inputTokens: 37868, outputTokens: 38 },
+      { type: 'done' },
+    ]);
+  });
+
+  it('maps turn.failed to an error event', () => {
+    const raw = { type: 'turn.failed', error: { message: 'model overloaded' } };
+    expect(emit(raw)).toEqual([{ type: 'error', message: 'model overloaded' }]);
+  });
+
+  it('ignores unknown event types for forward compatibility', () => {
+    expect(emit({ type: 'some.future.event', foo: 1 })).toEqual([]);
+    expect(emit(null)).toEqual([]);
+    expect(emit('not an object')).toEqual([]);
+  });
+
+  it('translates a full real text-only run in order', () => {
+    const lines: unknown[] = [
+      { type: 'thread.started', thread_id: 'thr-abc' },
+      { type: 'turn.started' },
+      { type: 'item.completed', item: { id: 'item_0', type: 'agent_message', text: 'ok' } },
+      {
+        type: 'turn.completed',
+        usage: { input_tokens: 18887, output_tokens: 17 },
+      },
+    ];
+    const events = lines.flatMap(emit);
+    expect(events).toEqual([
+      { type: 'system', sessionId: 'thr-abc' },
+      { type: 'text', delta: 'ok' },
+      { type: 'usage', inputTokens: 18887, outputTokens: 17 },
+      { type: 'done' },
+    ]);
+  });
+
+  it('translates a full real command run in order', () => {
+    const lines: unknown[] = [
+      { type: 'thread.started', thread_id: 'thr-def' },
+      { type: 'turn.started' },
+      {
+        type: 'item.started',
+        item: {
+          id: 'item_0',
+          type: 'command_execution',
+          command: "/bin/zsh -lc 'echo hi'",
+          exit_code: null,
+          status: 'in_progress',
+        },
+      },
+      {
+        type: 'item.completed',
+        item: {
+          id: 'item_0',
+          type: 'command_execution',
+          command: "/bin/zsh -lc 'echo hi'",
+          aggregated_output: 'hi\n',
+          exit_code: 0,
+          status: 'completed',
+        },
+      },
+      { type: 'item.completed', item: { id: 'item_1', type: 'agent_message', text: 'done' } },
+      { type: 'turn.completed', usage: { input_tokens: 37868, output_tokens: 38 } },
+    ];
+    const events = lines.flatMap(emit);
+    expect(events).toEqual([
+      { type: 'system', sessionId: 'thr-def' },
+      { type: 'tool_use', id: 'item_0', name: 'shell', input: { command: "/bin/zsh -lc 'echo hi'" } },
+      { type: 'tool_result', id: 'item_0', output: 'hi\n', isError: false },
+      { type: 'text', delta: 'done' },
+      { type: 'usage', inputTokens: 37868, outputTokens: 38 },
+      { type: 'done' },
+    ]);
+  });
+});

--- a/src/agent/codex/stream-json.ts
+++ b/src/agent/codex/stream-json.ts
@@ -1,0 +1,124 @@
+import type { AgentEvent } from '../types';
+
+/**
+ * Codex `exec --json` emits one JSON object per line. The shapes we consume
+ * (codex-cli 0.134.0), captured live:
+ *
+ *   {"type":"thread.started","thread_id":"<uuid>"}
+ *   {"type":"turn.started"}
+ *   {"type":"item.started","item":{"id":"item_0","type":"command_execution",...}}
+ *   {"type":"item.completed","item":{"id":"item_0","type":"command_execution",
+ *      "aggregated_output":"hi\n","exit_code":0,"status":"completed"}}
+ *   {"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"done"}}
+ *   {"type":"turn.completed","usage":{"input_tokens":..,"output_tokens":..}}
+ *
+ * Unlike Claude's stream-json, text arrives at item granularity (one
+ * `agent_message` item = one finished message), not as token deltas — the
+ * card simply refreshes per item.
+ */
+interface CodexItem {
+  id?: string;
+  type?: string;
+  text?: string;
+  /** reasoning items may carry a `summary` instead of `text` on some models. */
+  summary?: string;
+  command?: string;
+  aggregated_output?: string;
+  exit_code?: number | null;
+  status?: string;
+}
+
+interface CodexUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+}
+
+interface CodexRawEvent {
+  type?: string;
+  thread_id?: string;
+  item?: CodexItem;
+  usage?: CodexUsage;
+  error?: { message?: string };
+  message?: string;
+}
+
+export function* translateEvent(raw: unknown): Generator<AgentEvent> {
+  if (!raw || typeof raw !== 'object') return;
+  const evt = raw as CodexRawEvent;
+
+  switch (evt.type) {
+    case 'thread.started':
+      if (evt.thread_id) yield { type: 'system', sessionId: evt.thread_id };
+      return;
+
+    case 'item.started':
+      yield* translateItem(evt.item, /* started */ true);
+      return;
+
+    case 'item.completed':
+      yield* translateItem(evt.item, /* started */ false);
+      return;
+
+    case 'turn.completed':
+      if (evt.usage) {
+        yield {
+          type: 'usage',
+          inputTokens: evt.usage.input_tokens,
+          outputTokens: evt.usage.output_tokens,
+        };
+      }
+      yield { type: 'done' };
+      return;
+
+    case 'turn.failed':
+    case 'error':
+      yield { type: 'error', message: evt.error?.message ?? evt.message ?? 'codex run failed' };
+      return;
+
+    default:
+      // turn.started and any future event types: nothing to surface.
+      return;
+  }
+}
+
+function* translateItem(item: CodexItem | undefined, started: boolean): Generator<AgentEvent> {
+  if (!item || !item.type) return;
+
+  switch (item.type) {
+    case 'agent_message':
+      // Messages only arrive as item.completed.
+      if (!started && typeof item.text === 'string' && item.text) {
+        yield { type: 'text', delta: item.text };
+      }
+      return;
+
+    case 'reasoning': {
+      if (started) return;
+      const delta = item.text ?? item.summary;
+      if (typeof delta === 'string' && delta) yield { type: 'thinking', delta };
+      return;
+    }
+
+    case 'command_execution':
+      if (!item.id) return;
+      if (started) {
+        yield {
+          type: 'tool_use',
+          id: item.id,
+          name: 'shell',
+          input: { command: item.command ?? '' },
+        };
+      } else {
+        yield {
+          type: 'tool_result',
+          id: item.id,
+          output: item.aggregated_output ?? '',
+          isError: typeof item.exit_code === 'number' && item.exit_code !== 0,
+        };
+      }
+      return;
+
+    default:
+      return;
+  }
+}

--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import type { AppConfig } from '../config/schema';
-import { createAgent } from './index';
+import type { AppConfig, CodexReasoningEffort } from '../config/schema';
+import { CodexAdapter, createAgent } from './index';
 
-function cfg(agent?: 'claude' | 'codex'): AppConfig {
+function cfg(agent?: 'claude' | 'codex', codexReasoningEffort?: CodexReasoningEffort): AppConfig {
   return {
     accounts: { app: { id: 'cli_x', secret: 's', tenant: 'feishu' } },
-    preferences: agent ? { agent } : {},
+    preferences: { ...(agent ? { agent } : {}), ...(codexReasoningEffort ? { codexReasoningEffort } : {}) },
   };
 }
 
@@ -20,5 +20,10 @@ describe('createAgent', () => {
 
   it('returns the Codex adapter when configured for codex', () => {
     expect(createAgent(cfg('codex')).id).toBe('codex');
+  });
+
+  it('wires the configured codex reasoning effort into the adapter', () => {
+    const agent = createAgent(cfg('codex', 'medium'));
+    expect((agent as CodexAdapter).reasoningEffort).toBe('medium');
   });
 });

--- a/src/agent/index.test.ts
+++ b/src/agent/index.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import type { AppConfig } from '../config/schema';
+import { createAgent } from './index';
+
+function cfg(agent?: 'claude' | 'codex'): AppConfig {
+  return {
+    accounts: { app: { id: 'cli_x', secret: 's', tenant: 'feishu' } },
+    preferences: agent ? { agent } : {},
+  };
+}
+
+describe('createAgent', () => {
+  it('returns the Claude adapter by default', () => {
+    expect(createAgent(cfg()).id).toBe('claude');
+  });
+
+  it('returns the Claude adapter when configured for claude', () => {
+    expect(createAgent(cfg('claude')).id).toBe('claude');
+  });
+
+  it('returns the Codex adapter when configured for codex', () => {
+    expect(createAgent(cfg('codex')).id).toBe('codex');
+  });
+});

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,2 +1,14 @@
+import type { AppConfig } from '../config/schema';
+import { getAgentKind } from '../config/schema';
+import { ClaudeAdapter } from './claude/adapter';
+import { CodexAdapter } from './codex/adapter';
+import type { AgentAdapter } from './types';
+
 export type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from './types';
 export { ClaudeAdapter } from './claude/adapter';
+export { CodexAdapter } from './codex/adapter';
+
+/** Pick the agent adapter the config asks for. Defaults to Claude. */
+export function createAgent(cfg: Pick<AppConfig, 'preferences'>): AgentAdapter {
+  return getAgentKind(cfg) === 'codex' ? new CodexAdapter() : new ClaudeAdapter();
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,5 +1,5 @@
 import type { AppConfig } from '../config/schema';
-import { getAgentKind } from '../config/schema';
+import { getAgentKind, getCodexReasoningEffort } from '../config/schema';
 import { ClaudeAdapter } from './claude/adapter';
 import { CodexAdapter } from './codex/adapter';
 import type { AgentAdapter } from './types';
@@ -10,5 +10,7 @@ export { CodexAdapter } from './codex/adapter';
 
 /** Pick the agent adapter the config asks for. Defaults to Claude. */
 export function createAgent(cfg: Pick<AppConfig, 'preferences'>): AgentAdapter {
-  return getAgentKind(cfg) === 'codex' ? new CodexAdapter() : new ClaudeAdapter();
+  return getAgentKind(cfg) === 'codex'
+    ? new CodexAdapter({ reasoningEffort: getCodexReasoningEffort(cfg) })
+    : new ClaudeAdapter();
 }

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -1,4 +1,4 @@
-import { ClaudeAdapter } from '../../agent/claude/adapter';
+import { createAgent } from '../../agent';
 import { isComplete } from '../../config/schema';
 import { loadConfig } from '../../config/store';
 import { daemonStderrPath, daemonStdoutPath } from '../../daemon/paths';
@@ -138,7 +138,7 @@ async function reportConnectAfter(
 
   const entry = await waitForServiceConnect(appId, beforePids);
   if (entry) {
-    const agent = new ClaudeAdapter();
+    const agent = createAgent(cfg);
     const verbZh = verb === 'started' ? '已启动' : '已重启';
     console.log(
       `✓ ${verbZh}  bot: ${entry.botName} (${entry.appId})  agent: ${agent.displayName} (${agent.id})  进程: ${entry.id}`,

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -1,7 +1,7 @@
 import dns from 'node:dns';
 import { createInterface } from 'node:readline';
 import pkg from '../../../package.json';
-import { ClaudeAdapter } from '../../agent/claude/adapter';
+import { createAgent } from '../../agent';
 import { startChannel, type BridgeChannel } from '../../bot/channel';
 import { runRegistrationWizard } from '../../bot/wizard';
 import type { Controls } from '../../commands';
@@ -76,10 +76,15 @@ export async function runStart(opts: StartOptions): Promise<void> {
 
   await preFlightChecks({ skipCheckLarkCli: opts.skipCheckLarkCli });
 
-  const agent = new ClaudeAdapter();
+  const agent = createAgent(cfg);
   if (!(await agent.isAvailable())) {
-    console.error('✗ 未找到 claude CLI。请先安装 Claude Code：');
-    console.error('  https://docs.anthropic.com/en/docs/claude-code/quickstart');
+    if (agent.id === 'codex') {
+      console.error('✗ 未找到 codex CLI。请先安装 OpenAI Codex 并登录：');
+      console.error('  npm install -g @openai/codex   (然后 codex login)');
+    } else {
+      console.error('✗ 未找到 claude CLI。请先安装 Claude Code：');
+      console.error('  https://docs.anthropic.com/en/docs/claude-code/quickstart');
+    }
     process.exit(1);
   }
 

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AppConfig } from './schema';
-import { getAgentKind } from './schema';
+import { getAgentKind, getCodexReasoningEffort } from './schema';
 
 function cfg(agent?: unknown): AppConfig {
   return {
@@ -24,5 +24,27 @@ describe('getAgentKind', () => {
 
   it('falls back to claude for unrecognized values', () => {
     expect(getAgentKind(cfg('gpt-9000'))).toBe('claude');
+  });
+});
+
+function withEffort(effort?: unknown): AppConfig {
+  return {
+    accounts: { app: { id: 'cli_x', secret: 's', tenant: 'feishu' } },
+    preferences: { codexReasoningEffort: effort } as never,
+  };
+}
+
+describe('getCodexReasoningEffort', () => {
+  it('returns undefined when unset (let codex use its own default)', () => {
+    expect(getCodexReasoningEffort(withEffort())).toBeUndefined();
+  });
+
+  it('returns the configured effort level', () => {
+    expect(getCodexReasoningEffort(withEffort('medium'))).toBe('medium');
+    expect(getCodexReasoningEffort(withEffort('high'))).toBe('high');
+  });
+
+  it('returns undefined for unrecognized values', () => {
+    expect(getCodexReasoningEffort(withEffort('turbo'))).toBeUndefined();
   });
 });

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import type { AppConfig } from './schema';
+import { getAgentKind } from './schema';
+
+function cfg(agent?: unknown): AppConfig {
+  return {
+    accounts: { app: { id: 'cli_x', secret: 's', tenant: 'feishu' } },
+    preferences: agent === undefined ? {} : ({ agent } as never),
+  };
+}
+
+describe('getAgentKind', () => {
+  it('defaults to claude when unset', () => {
+    expect(getAgentKind(cfg())).toBe('claude');
+  });
+
+  it('returns claude when explicitly claude', () => {
+    expect(getAgentKind(cfg('claude'))).toBe('claude');
+  });
+
+  it('returns codex when set to codex', () => {
+    expect(getAgentKind(cfg('codex'))).toBe('codex');
+  });
+
+  it('falls back to claude for unrecognized values', () => {
+    expect(getAgentKind(cfg('gpt-9000'))).toBe('claude');
+  });
+});

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -3,6 +3,9 @@ export type TenantBrand = 'feishu' | 'lark';
 /** Which local coding-agent CLI the bridge drives. Default 'claude'. */
 export type AgentKind = 'claude' | 'codex';
 
+/** Codex reasoning-effort levels, passed as `model_reasoning_effort`. */
+export type CodexReasoningEffort = 'minimal' | 'low' | 'medium' | 'high';
+
 /**
  * SecretRef points at a secret stored outside this file — keeps secrets out
  * of `config.json` so backups / accidental git commits / log dumps don't
@@ -100,6 +103,12 @@ export interface AppPreferences {
    * yet — by design, since it's a deploy-time choice.
    */
   agent?: AgentKind;
+  /**
+   * Reasoning effort for the Codex agent (`agent: 'codex'`). When set, the
+   * bridge passes `-c model_reasoning_effort=<value>` to `codex exec`. Unset
+   * = let Codex use its own default. Ignored when agent is 'claude'.
+   */
+  codexReasoningEffort?: CodexReasoningEffort;
   /** Reply rendering mode for IM (group/p2p) messages. Default 'card'. */
   messageReply?: MessageReplyMode;
   /**
@@ -216,6 +225,17 @@ export function getMessageReplyMode(cfg: AppConfig): MessageReplyMode {
  * from sites that only hold a possibly-incomplete config. */
 export function getAgentKind(cfg: Pick<AppConfig, 'preferences'>): AgentKind {
   return cfg.preferences?.agent === 'codex' ? 'codex' : 'claude';
+}
+
+/** Resolve the Codex reasoning effort. Unknown / unset → undefined (Codex
+ * picks its own default). Accepts the minimal shape, like getAgentKind. */
+export function getCodexReasoningEffort(
+  cfg: Pick<AppConfig, 'preferences'>,
+): CodexReasoningEffort | undefined {
+  const raw = cfg.preferences?.codexReasoningEffort;
+  return raw === 'minimal' || raw === 'low' || raw === 'medium' || raw === 'high'
+    ? raw
+    : undefined;
 }
 
 /** Resolve the show-tool-calls preference with default fallback. */

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,5 +1,8 @@
 export type TenantBrand = 'feishu' | 'lark';
 
+/** Which local coding-agent CLI the bridge drives. Default 'claude'. */
+export type AgentKind = 'claude' | 'codex';
+
 /**
  * SecretRef points at a secret stored outside this file — keeps secrets out
  * of `config.json` so backups / accidental git commits / log dumps don't
@@ -90,6 +93,13 @@ export interface AppAccess {
 }
 
 export interface AppPreferences {
+  /**
+   * Which local coding-agent CLI to drive: 'claude' (Claude Code, the
+   * default) or 'codex' (OpenAI Codex). Selected at process start; switching
+   * requires editing config.json and restarting the bridge. No CLI surface
+   * yet — by design, since it's a deploy-time choice.
+   */
+  agent?: AgentKind;
   /** Reply rendering mode for IM (group/p2p) messages. Default 'card'. */
   messageReply?: MessageReplyMode;
   /**
@@ -198,6 +208,14 @@ export function getMessageReplyMode(cfg: AppConfig): MessageReplyMode {
   }
   if (raw === 'card' || raw === 'markdown' || raw === 'text') return raw;
   return 'markdown';
+}
+
+/** Resolve which agent CLI to drive. Unknown / unset values fall back to
+ * 'claude' so existing deployments are unaffected on upgrade. Accepts the
+ * minimal shape (just `preferences`) because it's called at process-start
+ * from sites that only hold a possibly-incomplete config. */
+export function getAgentKind(cfg: Pick<AppConfig, 'preferences'>): AgentKind {
+  return cfg.preferences?.agent === 'codex' ? 'codex' : 'claude';
 }
 
 /** Resolve the show-tool-calls preference with default fallback. */


### PR DESCRIPTION
> Starting June 15, 2026, claude -p (non-interactive / headless mode) will be split out of the subscription's rate-limit pool and billed instead from a separate,…Starting June 15, 2026, claude -p (non-interactive / headless mode) will be split out of the subscription's rate-limit pool and billed instead from a separate, dollar-denominated credit pool.

Codex support based on the original process.