### PR TITLE
Reserve external orchestration messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Daemon logs go to `~/.lark-channel/logs/daemon-stdout.log` and `daemon-stderr.lo
 | `/help` | Help card |
 | Any other `/xxx` | Forwarded verbatim to Claude |
 
+Reserved external orchestration messages in group chats are ignored by this bridge instead of being sent to Claude: `/study`, `/stop study`, and messages tagged like `[study-room:...]` or `[orchestrator:...]`. This lets sidecar tools coordinate multiple bot agents in the same group without duplicate Claude runs.
+
 **Reply policy**: in a DM, the bot replies to anything. In a **group (including topic groups), the bot only replies when `@`-mentioned** (default since 0.1.22); unmentioned messages are ignored. `@all` is never answered. Cloud-doc comments must mention the bot. To restore the older "always answer in groups" behaviour: `/config` → "Require @bot in groups" → No.
 
 ## Data directories

--- a/README.zh.md
+++ b/README.zh.md
@@ -98,6 +98,8 @@ daemon 的 stdout / stderr 写到 `~/.lark-channel/logs/daemon-stdout.log` 和 `
 | `/help` | 帮助卡片 |
 | 其它 `/xxx` | 原样交给 Claude |
 
+群聊中的外部编排保留消息会被 bridge 忽略，不会送进 Claude：`/study`、`/stop study`，以及形如 `[study-room:...]` 或 `[orchestrator:...]` 的消息。这样外部 sidecar 工具可以在同一个群里协调多个 bot agent，而不会触发重复的 Claude run。
+
 **消息策略**：私聊 = 不需要 @，任何消息都回；**群（含话题群）= 默认要 @bot 才回**（0.1.22 起的新默认），不 @ 时 bot 完全沉默；@全员永远不响应；云文档评论必须 @bot。要恢复"群里也不强制 @"的老行为：`/config` → "群里需要 @ bot" → 选"否"。
 
 ## 数据目录

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -44,6 +44,7 @@ import { PendingQueue } from './pending-queue';
 import { ProcessPool } from './process-pool';
 import { fetchQuotedContext, renderQuotedBlock, type QuotedContext } from './quote';
 import { addWorkingReaction, removeReaction } from './reaction';
+import { classifyReservedExternalMessage } from './reserved-external-message';
 
 const DEBOUNCE_MS = 600;
 
@@ -403,6 +404,20 @@ async function intakeMessage(deps: IntakeDeps): Promise<void> {
     !msg.mentionedBot
   ) {
     log.info('intake', 'skip-no-mention', { scope, chatType: msg.chatType });
+    return;
+  }
+
+  // External orchestration sidecars may also listen in the same group.
+  // Reserve their protocol-looking messages so they do not become ordinary
+  // prompts for the local Claude agent.
+  const reservedExternalReason = msg.chatType !== 'p2p'
+    ? classifyReservedExternalMessage(msg.content)
+    : undefined;
+  if (reservedExternalReason) {
+    log.info('intake', 'skip-reserved-external-message', {
+      scope,
+      reason: reservedExternalReason,
+    });
     return;
   }
 

--- a/src/bot/reserved-external-message.ts
+++ b/src/bot/reserved-external-message.ts
@@ -1,0 +1,28 @@
+/**
+ * Some messages are meant for external group orchestrators rather than this
+ * bridge's local coding agent. Reserve those protocol-looking messages so
+ * bridge bots can coexist with sidecar tools without launching duplicate runs.
+ */
+const EXTERNAL_MARKER_RE = /\[(?:study-room|agent-room|orchestrator):[^\]\s]+\]/i;
+const STUDY_START_RE = /(?:^|\s)\/study(?:\b|\s|$)/i;
+const STUDY_STOP_RE = /(?:^|\s)\/stop\s+study(?:\b|\s|$)/i;
+
+export type ReservedExternalMessageReason =
+  | 'external-marker'
+  | 'external-study'
+  | 'external-stop-study';
+
+export function classifyReservedExternalMessage(
+  content: string,
+): ReservedExternalMessageReason | undefined {
+  const normalized = content.trim();
+  if (!normalized) return undefined;
+  if (EXTERNAL_MARKER_RE.test(normalized)) return 'external-marker';
+  if (STUDY_STOP_RE.test(normalized)) return 'external-stop-study';
+  if (STUDY_START_RE.test(normalized)) return 'external-study';
+  return undefined;
+}
+
+export function isReservedExternalMessage(content: string): boolean {
+  return classifyReservedExternalMessage(content) !== undefined;
+}

--- a/test/reserved-external-message.test.ts
+++ b/test/reserved-external-message.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import {
+  classifyReservedExternalMessage,
+  isReservedExternalMessage,
+} from '../src/bot/reserved-external-message';
+
+describe('reserved external message classifier', () => {
+  it('reserves external study start commands', () => {
+    expect(classifyReservedExternalMessage('/study topic: memory review')).toBe('external-study');
+    expect(classifyReservedExternalMessage('please /study topic: memory review')).toBe(
+      'external-study',
+    );
+    expect(isReservedExternalMessage('/study')).toBe(true);
+  });
+
+  it('reserves external stop-study commands before ordinary /stop handling', () => {
+    expect(classifyReservedExternalMessage('/stop study')).toBe('external-stop-study');
+    expect(classifyReservedExternalMessage('please /stop study now')).toBe('external-stop-study');
+  });
+
+  it('reserves common external transcript markers', () => {
+    expect(classifyReservedExternalMessage('[study-room:room-1] @Claude here is my note')).toBe(
+      'external-marker',
+    );
+    expect(classifyReservedExternalMessage('[orchestrator:run-1] @Claude note')).toBe(
+      'external-marker',
+    );
+  });
+
+  it('does not reserve unrelated commands or prose', () => {
+    expect(isReservedExternalMessage('/status')).toBe(false);
+    expect(isReservedExternalMessage('/stop')).toBe(false);
+    expect(isReservedExternalMessage('Can you study this file?')).toBe(false);
+    expect(isReservedExternalMessage('/studying')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Reserve external orchestration messages in group chats so they are not forwarded to Claude as ordinary prompts.

This gives bridge operators a small interoperability hook for sidecar tools that coordinate multiple bot agents in the same Feishu/Lark group. Protocol-looking group messages such as `/study`, `/stop study`, or tagged transcript lines like `[study-room:...]` / `[orchestrator:...]` should be handled by the external coordinator rather than launching duplicate Claude runs.

## Changes

- Add a generic reserved external message classifier for:
  - `/study ...`
  - `/stop study ...`
  - `[study-room:...]`, `[agent-room:...]`, `[orchestrator:...]` markers
- Skip those messages during group/topic intake after existing access-control and mention checks.
- Leave p2p chats untouched.
- Document the reserved messages in both README files.
- Add Vitest coverage for the classifier.

## Checks

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
