### PR TITLE
fix: use cmd.exe to spawn claude on Windows to avoid shell escaping

### DIFF
--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -113,7 +113,9 @@ export class ClaudeAdapter implements AgentAdapter {
 
   async isAvailable(): Promise<boolean> {
     return new Promise((resolve) => {
-      const child = spawn(this.binary, ['--version'], { stdio: 'ignore' });
+      const child = process.platform === 'win32'
+        ? spawn('cmd', ['/d', '/c', this.binary, '--version'], { stdio: 'ignore' })
+        : spawn(this.binary, ['--version'], { stdio: 'ignore' });
       child.on('error', () => resolve(false));
       child.on('exit', (code) => resolve(code === 0));
     });
@@ -134,11 +136,17 @@ export class ClaudeAdapter implements AgentAdapter {
     if (opts.sessionId) args.push('--resume', opts.sessionId);
     if (opts.model) args.push('--model', opts.model);
 
-    const child = spawn(this.binary, args, {
-      cwd: opts.cwd,
-      env: { ...process.env, LARK_CHANNEL: '1' },
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
+    const child = process.platform === 'win32'
+      ? spawn('cmd', ['/d', '/c', this.binary, ...args], {
+          cwd: opts.cwd,
+          env: { ...process.env, LARK_CHANNEL: '1' },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        })
+      : spawn(this.binary, args, {
+          cwd: opts.cwd,
+          env: { ...process.env, LARK_CHANNEL: '1' },
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
 
     log.info('agent', 'spawn', {
       pid: child.pid ?? null,


### PR DESCRIPTION
On Windows, `spawn('claude', args)` fails with `EINVAL` because 'claude' without extension cannot be resolved by `CreateProcess`. Using `shell: true` appears to fix resolution, but causes the prompt text (which contains XML tags like `<bridge_context>`) to be interpreted by `cmd.exe` as shell redirection operators, producing "incorrect syntax" errors.

This PR fixes the issue by explicitly spawning through `cmd /d /c claude ...args` on Windows, passing each argument as a separate array element so `CreateProcess` handles quoting correctly without re-interpretation by `cmd.exe`.

The same approach is already used elsewhere in the codebase — see `preflight.ts` for `isLarkCliInstalled()` and `runCapture()`.

## Changes
- `isAvailable()`: on Windows, uses `spawn('cmd', ['/d', '/c', this.binary, '--version'])` 
- `run()`: on Windows, uses `spawn('cmd', ['/d', '/c', this.binary, ...args])` 

## Testing
- Windows 11 + Node.js v24.14.0
- Verified `claude --version` resolves correctly
- Verified prompt with XML tags (`<bridge_context>`) and special characters (`&`) are passed intact
- Verified bridge successfully connects, receives messages, and spawns Claude Code