### PR TITLE
fix(resume): match Claude Code project-dir encoding in encodeCwd

### DIFF
--- a/src/session/history.ts
+++ b/src/session/history.ts
@@ -12,7 +12,7 @@ export interface SessionSummary {
 }
 
 function encodeCwd(cwd: string): string {
-  return cwd.replace(/\//g, '-');
+  return cwd.replace(/[^a-zA-Z0-9]/g, '-');
 }
 
 function claudeProjectDir(cwd: string): string {


### PR DESCRIPTION
## What
One-line fix for `encodeCwd` so `/resume` can locate Claude Code session transcripts when the working directory path contains non-alphanumeric characters.

```diff
 function encodeCwd(cwd: string): string {
-  return cwd.replace(/\//g, '-');
+  return cwd.replace(/[^a-zA-Z0-9]/g, '-');
 }
```

## Why
Claude Code encodes `~/.claude/projects/<dir>` by replacing **every** non-alphanumeric character with `-` (e.g. `OneDrive-amazon.com` → `OneDrive-amazon-com`). The previous `encodeCwd` only replaced `/`, so any cwd containing a `.`, space, or CJK character mapped to a non-existent directory → `readdir` `ENOENT` → `/resume` reported no history despite transcripts existing on disk.

## Verification
Across an existing `~/.claude/projects/` install, every directory name contains only `[a-zA-Z0-9-]`, and re-encoding known cwds with the new rule reproduces the real directory names exactly (`.`→`-`, space→`-`, CJK→`-`, no collapsing of consecutive separators). After the change, `/resume` correctly lists all sessions for a cwd containing `.`.

Fixes #70