### PR TITLE
feat: make bridge sessions visible to Claude resume

### DIFF
--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -33,6 +33,7 @@ import {
 import { resolveAppSecret } from '../config/secret-resolver';
 import { log, reportMetric, withTrace } from '../core/logger';
 import { MediaCache, type LocalAttachment } from '../media/cache';
+import { makeClaudeSessionCliResumable } from '../session/claude-journal';
 import type { SessionStore } from '../session/store';
 import type { WorkspaceStore } from '../workspace/store';
 import { ActiveRuns, type RunHandle } from './active-runs';
@@ -720,6 +721,7 @@ async function processAgentStream(
   let idleFired = false;
   let timer: NodeJS.Timeout | undefined;
   const inFlightTools = new Set<string>();
+  let activeSession: { sessionId: string; cwd: string } | undefined;
   const armOrPauseIdle = (): void => {
     if (!idleTimeoutMs) return;
     if (timer) clearTimeout(timer);
@@ -758,6 +760,7 @@ async function processAgentStream(
       if (evt.type === 'system') {
         if (evt.sessionId) {
           const effectiveCwd = evt.cwd ?? cwd;
+          activeSession = { sessionId: evt.sessionId, cwd: effectiveCwd };
           sessions.set(scope, evt.sessionId, effectiveCwd);
           log.info('session', 'set', { sessionId: evt.sessionId });
         }
@@ -776,6 +779,9 @@ async function processAgentStream(
           if (outputTokens !== undefined) reportMetric('tokens_out', outputTokens);
         }
         continue;
+      }
+      if (evt.type === 'done' && evt.sessionId) {
+        activeSession = { sessionId: evt.sessionId, cwd: activeSession?.cwd ?? cwd };
       }
 
       const prevTerminal = state.terminal;
@@ -823,6 +829,26 @@ async function processAgentStream(
     if (!exited) {
       log.warn('agent', 'post-done-timeout', { graceMs: POST_DONE_EXIT_GRACE_MS });
       await handle.run.stop();
+    }
+  }
+
+  if (activeSession) {
+    try {
+      const result = await makeClaudeSessionCliResumable(
+        activeSession.cwd,
+        activeSession.sessionId,
+      );
+      if (result.changed) {
+        log.info('session', 'cli-resumable', {
+          sessionId: activeSession.sessionId,
+          rewrittenEntries: result.rewrittenEntries,
+        });
+      }
+    } catch (err) {
+      log.fail('session', err, {
+        step: 'cli-resumable',
+        sessionId: activeSession.sessionId,
+      });
     }
   }
 }
@@ -911,4 +937,3 @@ function stripAttachmentRefs(text: string, fileKeys: string[]): string {
   }
   return out.replace(/\n{3,}/g, '\n\n');
 }
-

--- a/src/session/claude-journal.ts
+++ b/src/session/claude-journal.ts
@@ -1,0 +1,58 @@
+import { readFile, rename, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { claudeProjectDir } from './claude-paths';
+
+export interface ClaudeJournalPatchResult {
+  path: string;
+  changed: boolean;
+  rewrittenEntries: number;
+}
+
+export async function makeClaudeSessionCliResumable(
+  cwd: string,
+  sessionId: string,
+  homeDir?: string,
+): Promise<ClaudeJournalPatchResult> {
+  // Claude's resume picker treats `entrypoint: "cli"` as a user-facing
+  // conversation. Print-mode persists bridge runs as `sdk-cli`, so normalize
+  // the persisted transcript after the child process has closed the journal.
+  const path = join(claudeProjectDir(cwd, homeDir), `${sessionId}.jsonl`);
+  let text: string;
+  try {
+    text = await readFile(path, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { path, changed: false, rewrittenEntries: 0 };
+    }
+    throw err;
+  }
+
+  let rewrittenEntries = 0;
+  const lines = text.split('\n').map((line) => {
+    if (!line) return line;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return line;
+    }
+    if (!isRecord(parsed)) return line;
+    if (parsed.sessionId !== sessionId || parsed.entrypoint !== 'sdk-cli') return line;
+    parsed.entrypoint = 'cli';
+    rewrittenEntries++;
+    return JSON.stringify(parsed);
+  });
+
+  if (rewrittenEntries === 0) {
+    return { path, changed: false, rewrittenEntries: 0 };
+  }
+
+  const tmpPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+  await writeFile(tmpPath, lines.join('\n'), 'utf8');
+  await rename(tmpPath, path);
+  return { path, changed: true, rewrittenEntries };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}

--- a/src/session/claude-paths.ts
+++ b/src/session/claude-paths.ts
@@ -1,0 +1,10 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+export function encodeClaudeProjectPath(cwd: string): string {
+  return cwd.replace(/[^A-Za-z0-9]/g, '-');
+}
+
+export function claudeProjectDir(cwd: string, homeDir: string = homedir()): string {
+  return join(homeDir, '.claude', 'projects', encodeClaudeProjectPath(cwd));
+}

--- a/src/session/history.ts
+++ b/src/session/history.ts
@@ -1,22 +1,14 @@
 import { createReadStream } from 'node:fs';
 import { readdir, stat } from 'node:fs/promises';
-import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { createInterface } from 'node:readline';
+import { claudeProjectDir } from './claude-paths';
 
 export interface SessionSummary {
   sessionId: string;
   mtime: number;
   preview: string;
   lineCount: number;
-}
-
-function encodeCwd(cwd: string): string {
-  return cwd.replace(/\//g, '-');
-}
-
-function claudeProjectDir(cwd: string): string {
-  return join(homedir(), '.claude', 'projects', encodeCwd(cwd));
 }
 
 /** Return the most recent `limit` jsonl sessions for the given cwd, newest first. */

--- a/test/session/claude-journal.test.ts
+++ b/test/session/claude-journal.test.ts
@@ -1,0 +1,77 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { makeClaudeSessionCliResumable } from '../../src/session/claude-journal';
+import { claudeProjectDir, encodeClaudeProjectPath } from '../../src/session/claude-paths';
+
+const homes: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(homes.splice(0).map((home) => rm(home, { recursive: true, force: true })));
+});
+
+describe('Claude journal compatibility', () => {
+  it('uses Claude Code project directory encoding', () => {
+    expect(encodeClaudeProjectPath('/private/tmp/bridge-entrypoint-probe.dnWNmj')).toBe(
+      '-private-tmp-bridge-entrypoint-probe-dnWNmj',
+    );
+  });
+
+  it('marks matching sdk-cli transcript entries as cli resumable', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'bridge-claude-home-'));
+    homes.push(home);
+
+    const cwd = '/private/tmp/bridge-entrypoint-probe.dnWNmj';
+    const sessionId = '1177c32f-b17e-43a8-a9e1-dce2faeb1d6d';
+    const otherSessionId = '2177c32f-b17e-43a8-a9e1-dce2faeb1d6d';
+    const dir = claudeProjectDir(cwd, home);
+    await mkdir(dir, { recursive: true });
+    const journalPath = join(dir, `${sessionId}.jsonl`);
+    await writeFile(
+      journalPath,
+      [
+        JSON.stringify({ type: 'queue-operation', sessionId, operation: 'add' }),
+        JSON.stringify({
+          type: 'user',
+          sessionId,
+          entrypoint: 'sdk-cli',
+          message: { role: 'user', content: 'hello' },
+        }),
+        JSON.stringify({ type: 'assistant', sessionId, entrypoint: 'sdk-cli' }),
+        JSON.stringify({ type: 'assistant', sessionId: otherSessionId, entrypoint: 'sdk-cli' }),
+        '{malformed',
+      ].join('\n') + '\n',
+      'utf8',
+    );
+
+    const result = await makeClaudeSessionCliResumable(cwd, sessionId, home);
+
+    expect(result).toMatchObject({ changed: true, rewrittenEntries: 2 });
+    const lines = (await readFile(journalPath, 'utf8')).trimEnd().split('\n');
+    expect(JSON.parse(lines[1]!).entrypoint).toBe('cli');
+    expect(JSON.parse(lines[2]!).entrypoint).toBe('cli');
+    expect(JSON.parse(lines[3]!).entrypoint).toBe('sdk-cli');
+    expect(lines[4]).toBe('{malformed');
+  });
+
+  it('reports unchanged when the journal has no sdk-cli entries for the session', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'bridge-claude-home-'));
+    homes.push(home);
+
+    const cwd = '/Users/example/project';
+    const sessionId = '3177c32f-b17e-43a8-a9e1-dce2faeb1d6d';
+    const dir = claudeProjectDir(cwd, home);
+    await mkdir(dir, { recursive: true });
+    await writeFile(
+      join(dir, `${sessionId}.jsonl`),
+      `${JSON.stringify({ type: 'user', sessionId, entrypoint: 'cli' })}\n`,
+      'utf8',
+    );
+
+    await expect(makeClaudeSessionCliResumable(cwd, sessionId, home)).resolves.toMatchObject({
+      changed: false,
+      rewrittenEntries: 0,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize Claude journal entries produced by the bridge from `entrypoint: "sdk-cli"` to `entrypoint: "cli"` after the Claude process exits, so Claude Code CLI `claude --resume` shows those sessions.
- Share Claude project directory encoding with `/resume`, matching current Claude Code behavior for non-alphanumeric path characters.
- Add tests for journal normalization and path encoding.

## Why
Bridge runs invoke Claude through `claude -p --output-format stream-json`. Claude persists these print-mode transcripts with `entrypoint: "sdk-cli"`. The Claude Code CLI resume picker displays user-facing `entrypoint: "cli"` conversations, while Bolt scans jsonl files directly and showed bridge-created sessions alongside regular Claude sessions. That created inconsistent session visibility between Bolt and Claude Code CLI.

The first line also differs (`queue-operation` for print-mode, `mode` for interactive CLI sessions), and the decisive picker filter in the current Claude Code 2.1.156 behavior is the transcript `entrypoint` field. The bridge is a user-facing Claude Code surface, so its persisted conversations should remain recoverable from Claude Code CLI as well as Bolt.

## Validation
- `./node_modules/.bin/tsc --noEmit`
- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/tsup`
- Manual probe with Claude Code 2.1.156: changing a print-mode journal entry from `sdk-cli` to `cli` makes it appear in `claude --resume`.
