### PR TITLE
docs: mention group message scope during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The first run detects there's no app configured and **opens a QR-code wizard**:
 
 1. A QR code renders in your terminal.
 2. Scan it with the Feishu / Lark app.
-3. Pick or create a PersonalAgent app.
+3. Pick or create a PersonalAgent app, and confirm its scopes include `im:message.group_msg`.
 4. Credentials are written to `~/.lark-channel/config.json`.
 
 ## Commands

--- a/README.zh.md
+++ b/README.zh.md
@@ -40,7 +40,7 @@ lark-channel-bridge run
 
 1. 终端渲染一个二维码
 2. 用飞书 App 扫码
-3. 选择 / 创建 PersonalAgent 应用
+3. 选择 / 创建 PersonalAgent 应用，并确认权限里包含 `im:message.group_msg`
 4. 成功后凭据写入 `~/.lark-channel/config.json`
 
 ## 命令速查

--- a/src/bot/wizard.ts
+++ b/src/bot/wizard.ts
@@ -2,6 +2,8 @@ import { registerApp } from '@larksuiteoapi/node-sdk';
 import qrcode from 'qrcode-terminal';
 import type { AppConfig, TenantBrand } from '../config/schema';
 
+const GROUP_MESSAGE_SCOPE = 'im:message.group_msg';
+
 export async function runRegistrationWizard(): Promise<AppConfig> {
   console.log('\n未检测到飞书应用配置，进入扫码创建向导。\n');
 
@@ -43,6 +45,8 @@ export async function runRegistrationWizard(): Promise<AppConfig> {
       '  ⚠️ 未拿到扫码用户的 open_id；首次启动时 bridge 会自行调 application/v6 API 解析当前 owner。',
     );
   }
+
+  console.log(`  群聊使用需确认应用权限包含: ${GROUP_MESSAGE_SCOPE}`);
 
   const cfg: AppConfig = {
     accounts: {


### PR DESCRIPTION
## Summary
- Mention that group chat usage requires the `im:message.group_msg` scope during first-run setup.
- Print the group-message scope reminder after QR-code app creation succeeds.

## Test plan
- [x] pnpm typecheck