### PR TITLE
feat: display skill name in tool cards

### DIFF
--- a/src/card/tool-render.ts
+++ b/src/card/tool-render.ts
@@ -72,6 +72,8 @@ function summarizeInput(name: string, input: unknown): string {
     case 'Agent':
     case 'Task':
       return pick('description') || pick('subagent_type');
+    case 'Skill':
+      return pick('skill');
     default:
       return pick('command') || pick('file_path') || pick('path') || pick('query');
   }
@@ -105,6 +107,17 @@ function renderInput(tool: ToolEntry): string {
       return str('url') ? `**URL** ${str('url')}` : '';
     case 'WebSearch':
       return str('query') ? `**Query** \`${truncate(str('query'), BODY_FIELD_MAX)}\`` : '';
+    case 'Skill': {
+      const skillName = str('skill');
+      const skillArgs = str('args');
+      if (skillName) {
+        const lines: string[] = [];
+        lines.push(`**Skill** \`${skillName}\``);
+        if (skillArgs) lines.push(`**Args** \`${truncate(skillArgs, BODY_FIELD_MAX)}\``);
+        return lines.join('\n');
+      }
+      return '';
+    }
     default:
       return '';
   }


### PR DESCRIPTION
When Claude invokes a Skill tool (e.g. superpowers:brainstorming), the bridge card currently only shows "⏳ Skill" with no indication of which skill is being used.

This adds a case 'Skill' to both summarizeInput and renderInput, extracting the skill name (and optional args) from the tool input.