### PR TITLE
fix: clean comment replies and bot context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lark-channel-bridge",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Bridge Feishu/Lark messenger with local CLI coding agents",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/agent/bridge-system-prompt.ts
+++ b/src/agent/bridge-system-prompt.ts
@@ -1,3 +1,5 @@
+import type { AgentBotIdentity } from './types';
+
 export const BRIDGE_SYSTEM_PROMPT = `# lark-channel-bridge 运行约定
 
 你正在 lark-channel-bridge 里跑：把飞书/Lark 用户消息桥到本地 agent CLI。
@@ -8,14 +10,25 @@ export const BRIDGE_SYSTEM_PROMPT = `# lark-channel-bridge 运行约定
 
 \`\`\`
 <bridge_context>
-chat_id: oc_xxx
-chat_type: p2p
-sender_id: ou_xxx
-sender_name: ...
+{"chatId":"oc_xxx","chatType":"p2p","senderId":"ou_xxx","senderName":"...",
+ "senderType":"user|bot","botOpenId":"ou_xxx","mentions":[{"openId":"ou_xxx","name":"...","isBot":true}], ...}
 </bridge_context>
 \`\`\`
 
-里面是当前对话的 chat_id、chat 类型（p2p / group）、发送者。这些是 bridge 注入的元数据，**不要照抄、不要在你的回复里渲染**——它对用户不可见。
+里面是当前对话的 chat_id、chat 类型（p2p / group）、发送者。关键字段：
+
+- \`senderType\`：发送者是人（\`user\`）还是另一个 bot（\`bot\`）；缺省表示未知
+- \`botOpenId\`：**你自己**的 open_id
+- \`mentions\`：这条消息 @ 到的账号列表（含 open_id 和 isBot），需要 @ 某人/某 bot 时从这里取 id
+
+多条消息在短时间内合并送达时，\`user_input\` 里每段会带 \`[名字 (user|bot)]:\` 行首标注以区分发送者——这是 bridge 注入的展示格式，**你回复时不要模仿这种标注**。这些都是 bridge 注入的元数据，**不要照抄、不要在你的回复里渲染**——它对用户不可见。
+
+## 与其他 bot 协作（bot-at-bot）
+
+- 自我识别：\`bridge_context.botOpenId\` 是你自己的 open_id；消息内容或 mentions 里出现这个 id 就是指你自己。
+- 飞书机制：bot **只有被真实 @（结构化 mention）才能收到群消息**。纯文本写 "@名字"、或不带 @ 的普通回复，其他 bot 一律收不到。这条限制只针对 bot——人类用户能看到群里所有消息，回复人类不需要 @。
+- 需要某个 bot 接着处理时，必须真实 @ 它（open_id 优先从 \`bridge_context.mentions\` 里取）。除此之外**默认不要 @ 其他 bot**——互相 @ 会形成死循环；用户明确要求转交/通知某个 bot 时按要求执行。
+- 与其他 bot 对话时，没有新信息要补充就简短收尾，不要追问、不要客套往返。
 
 ## quoted_message
 
@@ -109,6 +122,21 @@ bridge 会给你的子进程注入当前运行 profile 的环境变量:
 5. 如果用户中途想取消，他们会发 \`/stop\`——那时被 kill 是预期行为，不用兜底。
 `;
 
-export function prefixBridgeSystemPrompt(prompt: string): string {
-  return `${BRIDGE_SYSTEM_PROMPT}\n\n## user_message\n\n${prompt}`;
+/**
+ * Compose the bridge system prompt, appending a concrete self-identity line
+ * when the bot's IM identity is known. Falls back to the base prompt (which
+ * still references `bridge_context.botOpenId`) when identity is unavailable,
+ * e.g. before the channel handshake completes.
+ */
+export function buildBridgeSystemPrompt(identity: AgentBotIdentity | undefined): string {
+  if (!identity?.openId) return BRIDGE_SYSTEM_PROMPT;
+  const nameSuffix = identity.name ? `，名字是「${identity.name}」` : '';
+  return `${BRIDGE_SYSTEM_PROMPT}\n## 你的身份\n\n你的 open_id 是 \`${identity.openId}\`${nameSuffix}。消息内容或 mentions 里出现这个 open_id 都是指你自己。\n`;
+}
+
+export function prefixBridgeSystemPrompt(
+  prompt: string,
+  identity: AgentBotIdentity | undefined,
+): string {
+  return `${buildBridgeSystemPrompt(identity)}\n\n## user_message\n\n${prompt}`;
 }

--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -2,12 +2,13 @@ import { createInterface } from 'node:readline';
 import type { Readable } from 'node:stream';
 import { log } from '../../core/logger';
 import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
-import { BRIDGE_SYSTEM_PROMPT } from '../bridge-system-prompt';
+import { buildBridgeSystemPrompt } from '../bridge-system-prompt';
 import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel-env';
 import { checkAgentAvailability, type AgentAvailability } from '../preflight';
 import {
   CLAUDE_DEFAULT_PERMISSION_MODE,
   type AgentAdapter,
+  type AgentBotIdentity,
   type AgentEvent,
   type AgentRun,
   type AgentRunOptions,
@@ -27,10 +28,15 @@ export class ClaudeAdapter implements AgentAdapter {
 
   private readonly binary: string;
   private readonly larkChannel: LarkChannelEnvContext | undefined;
+  private botIdentity: AgentBotIdentity | undefined;
 
   constructor(opts: ClaudeAdapterOptions = {}) {
     this.binary = opts.binary ?? 'claude';
     this.larkChannel = opts.larkChannel;
+  }
+
+  setBotIdentity(identity: AgentBotIdentity): void {
+    this.botIdentity = identity;
   }
 
   async isAvailable(): Promise<boolean> {
@@ -60,7 +66,7 @@ export class ClaudeAdapter implements AgentAdapter {
       '--permission-mode',
       opts.permissionMode ?? CLAUDE_DEFAULT_PERMISSION_MODE,
       '--append-system-prompt',
-      BRIDGE_SYSTEM_PROMPT,
+      buildBridgeSystemPrompt(this.botIdentity),
     ];
     if (opts.sessionId) args.push('--resume', opts.sessionId);
     if (opts.model) args.push('--model', opts.model);

--- a/src/agent/codex/adapter.ts
+++ b/src/agent/codex/adapter.ts
@@ -13,7 +13,13 @@ import {
   type AgentAvailability,
   type AgentPreflightDiagnostic,
 } from '../preflight';
-import type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from '../types';
+import type {
+  AgentAdapter,
+  AgentBotIdentity,
+  AgentEvent,
+  AgentRun,
+  AgentRunOptions,
+} from '../types';
 import { buildCodexArgs } from './argv';
 import {
   CodexBinaryPinDriftError,
@@ -51,6 +57,7 @@ export class CodexAdapter implements AgentAdapter {
   private readonly sandbox: SandboxMode;
   private readonly defaultStopGraceMs: number;
   private readonly larkChannel: LarkChannelEnvContext | undefined;
+  private botIdentity: AgentBotIdentity | undefined;
 
   constructor(opts: CodexAdapterOptions) {
     this.binary = opts.binary;
@@ -63,6 +70,10 @@ export class CodexAdapter implements AgentAdapter {
     this.sandbox = opts.sandbox ?? 'danger-full-access';
     this.defaultStopGraceMs = opts.stopGraceMs ?? 5000;
     this.larkChannel = opts.larkChannel;
+  }
+
+  setBotIdentity(identity: AgentBotIdentity): void {
+    this.botIdentity = identity;
   }
 
   async isAvailable(): Promise<boolean> {
@@ -175,7 +186,7 @@ export class CodexAdapter implements AgentAdapter {
     child.stdin.on('error', (err) => {
       log.warn('agent', 'stdin-error', { message: err.message });
     });
-    child.stdin.end(prefixBridgeSystemPrompt(opts.prompt), 'utf8');
+    child.stdin.end(prefixBridgeSystemPrompt(opts.prompt, this.botIdentity), 'utf8');
 
     const stopGraceMs = opts.stopGraceMs ?? this.defaultStopGraceMs;
 

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -1,10 +1,22 @@
 export type BridgePromptSource = 'im' | 'card' | 'comment';
 
+export interface BridgePromptMention {
+  openId?: string;
+  name?: string;
+  isBot?: boolean;
+}
+
 export interface BridgePromptContext {
   chatId: string;
   chatType: string;
   senderId: string;
   senderName?: string;
+  /** Whether the sender is a human user or another bot ('app' sender). */
+  senderType?: 'user' | 'bot';
+  /** The bridge bot's own open_id — "this id is you" for self-identification. */
+  botOpenId?: string;
+  /** Accounts @-mentioned in the triggering message(s), deduped across the batch. */
+  mentions?: BridgePromptMention[];
   threadId?: string;
   messageIds?: string[];
   source: BridgePromptSource;

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -65,6 +65,16 @@ export interface AgentRun {
   waitForExit(timeoutMs: number): Promise<boolean>;
 }
 
+/**
+ * The bridge bot's own IM identity, resolved by the channel after the WS
+ * handshake (`/open-apis/bot/v3/info`). Injected into adapters so the agent
+ * system prompt can state "this open_id is you" with the real value.
+ */
+export interface AgentBotIdentity {
+  openId: string;
+  name?: string;
+}
+
 export interface AgentAdapter {
   readonly id: string;
   readonly displayName: string;
@@ -72,4 +82,10 @@ export interface AgentAdapter {
   checkAvailability?(): Promise<AgentAvailability>;
   prepareRun?(opts: AgentRunOptions): Promise<void>;
   run(opts: AgentRunOptions): AgentRun;
+  /**
+   * Late-bound identity injection: the adapter is constructed before the
+   * channel connects, so the channel calls this once botIdentity is known.
+   * Adapters that don't bake identity into their prompts may omit it.
+   */
+  setBotIdentity?(identity: AgentBotIdentity): void;
 }

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -9,6 +9,7 @@ import { claudeCapability, codexCapability } from '../agent/capability';
 import {
   buildAgentPrompt,
   type BridgePromptInteractiveCard,
+  type BridgePromptMention,
   type BridgePromptQuotedMessage,
 } from '../agent/prompt';
 import type { AgentAdapter, AgentEvent } from '../agent/types';
@@ -379,6 +380,15 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
   const knownChatsRefresh = startKnownChatsRefreshTimer(channel, controls);
 
   const identity = channel.botIdentity;
+  // Late-bind the bot's own IM identity into the agent adapter so the system
+  // prompt can state "this open_id is you" with the real value. Covers both
+  // initial start and credential-swap reconnects (both go through here).
+  if (identity?.openId) {
+    agent.setBotIdentity?.({
+      openId: identity.openId,
+      ...(identity.name ? { name: identity.name } : {}),
+    });
+  }
   log.info('ws', 'connected', {
     bot: identity?.name ?? 'unknown',
     openId: identity?.openId ?? '-',
@@ -666,7 +676,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     }
   }
 
-  const prompt = buildPrompt(batch, attachments, quotes);
+  const prompt = buildPrompt(batch, attachments, quotes, channel.botIdentity);
   log.info('prompt', 'built', { promptChars: prompt.length, quotes: quotes.length });
 
   // For topic groups: thread the reply so it lands in the same topic as the
@@ -994,16 +1004,32 @@ function buildPrompt(
   batch: NormalizedMessage[],
   attachments: LocalAttachment[],
   quotes: QuotedContext[] = [],
+  botIdentity?: { openId: string; name?: string },
 ): string {
   const first = batch[0];
   if (!first) return '';
 
   const fileKeys = batch.flatMap((m) => m.resources.map((r) => r.fileKey));
+  // When the debounce window merged messages (possibly from several senders —
+  // common in bot-at-bot group chats), annotate each segment with its sender
+  // so the agent can tell who said what. Single-message batches stay verbatim.
+  const annotate = batch.length > 1;
   const texts = batch
-    .map((m) => stripAttachmentRefs(m.content, fileKeys).trim())
+    .map((m) => {
+      const text = stripAttachmentRefs(m.content, fileKeys).trim();
+      if (!text) return '';
+      return annotate ? `${senderAnnotation(m)} ${text}` : text;
+    })
     .filter(Boolean);
   const userPart =
-    texts.length > 0 ? texts.join('\n\n') : attachments.length > 0 ? '请看下面的附件。' : '';
+    texts.length > 0
+      ? texts.join('\n\n')
+      : attachments.length > 0
+        ? '请看下面的附件。'
+        : '（对方发来一条没有正文的消息——通常是只 @ 了你的唤醒（ping）。请简短回应。）';
+
+  const senderType = senderTypeOf(first);
+  const mentions = mergeMentions(batch);
 
   return buildAgentPrompt({
     context: {
@@ -1011,6 +1037,9 @@ function buildPrompt(
       chatType: first.chatType,
       senderId: first.senderId,
       ...(first.senderName ? { senderName: first.senderName } : {}),
+      ...(senderType ? { senderType } : {}),
+      ...(botIdentity?.openId ? { botOpenId: botIdentity.openId } : {}),
+      ...(mentions.length > 0 ? { mentions } : {}),
       ...(first.threadId ? { threadId: first.threadId } : {}),
       messageIds: batch.map((m) => m.messageId),
       source: 'im',
@@ -1021,6 +1050,44 @@ function buildPrompt(
     interactiveCards: batch.map(toPromptInteractiveCard).filter(isDefined),
     attachments: attachments.map(toPromptAttachment),
   });
+}
+
+/**
+ * Classify the sender as human or bot from the raw Feishu event
+ * (`sender.sender_type`: 'user' = human, 'app' = bot). The normalizer drops
+ * this field, so read it off `msg.raw` (`includeRawEvent: true` above).
+ * Unknown / missing values return undefined — omit rather than guess.
+ */
+function senderTypeOf(msg: NormalizedMessage): 'user' | 'bot' | undefined {
+  const raw = msg.raw as { sender?: { sender_type?: unknown } } | undefined;
+  const senderType = raw?.sender?.sender_type;
+  if (senderType === 'user') return 'user';
+  if (senderType === 'app' || senderType === 'bot') return 'bot';
+  return undefined;
+}
+
+function senderAnnotation(msg: NormalizedMessage): string {
+  const name = msg.senderName ?? msg.senderId;
+  const type = senderTypeOf(msg);
+  return type ? `[${name} (${type})]:` : `[${name}]:`;
+}
+
+function mergeMentions(batch: NormalizedMessage[]): BridgePromptMention[] {
+  const seen = new Set<string>();
+  const out: BridgePromptMention[] = [];
+  for (const msg of batch) {
+    for (const mention of msg.mentions ?? []) {
+      const dedupeKey = mention.openId ?? `${mention.name ?? ''}:${mention.key}`;
+      if (seen.has(dedupeKey)) continue;
+      seen.add(dedupeKey);
+      out.push({
+        ...(mention.openId ? { openId: mention.openId } : {}),
+        ...(mention.name ? { name: mention.name } : {}),
+        ...(mention.isBot !== undefined ? { isBot: mention.isBot } : {}),
+      });
+    }
+  }
+  return out;
 }
 
 function replyQuoteTargetForMessage(

--- a/src/bot/comments.ts
+++ b/src/bot/comments.ts
@@ -343,6 +343,10 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
             case 'text':
               answer += e.delta;
               break;
+            case 'tool_use':
+            case 'tool_result':
+              answer = '';
+              break;
             case 'system':
               break;
             case 'error':
@@ -521,7 +525,7 @@ export function buildCommentPrompt(
   );
   parts.push('');
   parts.push(
-    '回复要求：直接用纯文本，不要 markdown（不要 ** __ # - * > ` 之类的标记），不要代码块。云文档评论框不渲染 markdown，会原样显示这些符号。',
+    '回复要求：直接用纯文本，不要 markdown（不要 ** __ # - * > ` 之类的标记），不要代码块；不要输出内部思考、内部分析、读取步骤、工具调用过程或工具日志。若用户要求解释依据，只说明用户可见的依据和结论。云文档评论框不渲染 markdown，会原样显示这些符号。',
   );
   return parts.join('\n');
 }

--- a/tests/helpers/fake-agent.ts
+++ b/tests/helpers/fake-agent.ts
@@ -1,5 +1,6 @@
 import type {
   AgentAdapter,
+  AgentBotIdentity,
   AgentEvent,
   AgentRun,
   AgentRunOptions,
@@ -64,6 +65,7 @@ export class FakeAgentAdapter implements AgentAdapter {
   readonly displayName: string;
   readonly runs: FakeAgentRun[] = [];
   readonly runOptions: AgentRunOptions[] = [];
+  botIdentity: AgentBotIdentity | undefined;
   #available: boolean;
   #eventRuns: AgentEvent[][];
   #waitForExitResults: boolean[];
@@ -84,6 +86,10 @@ export class FakeAgentAdapter implements AgentAdapter {
 
   async isAvailable(): Promise<boolean> {
     return this.#available;
+  }
+
+  setBotIdentity(identity: AgentBotIdentity): void {
+    this.botIdentity = identity;
   }
 
   run(opts: AgentRunOptions): AgentRun {

--- a/tests/integration/bot/bot-at-bot-context.test.ts
+++ b/tests/integration/bot/bot-at-bot-context.test.ts
@@ -1,0 +1,421 @@
+import type { NormalizedMessage } from '@larksuiteoapi/node-sdk';
+import { realpath } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createDefaultProfileConfig } from '../../../src/config/profile-schema.js';
+import { SessionStore } from '../../../src/session/store.js';
+import { WorkspaceStore } from '../../../src/workspace/store.js';
+import { FakeAgentAdapter } from '../../helpers/fake-agent.js';
+import { createTmpProfile, type TmpProfile } from '../../helpers/tmp-profile.js';
+
+const sdkMock = vi.hoisted(() => ({
+  channel: undefined as FakeLarkChannel | undefined,
+  createLarkChannel: vi.fn(() => {
+    if (!sdkMock.channel) throw new Error('fake channel not configured');
+    return sdkMock.channel;
+  }),
+}));
+
+vi.mock('@larksuiteoapi/node-sdk', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@larksuiteoapi/node-sdk')>();
+  return {
+    ...actual,
+    createLarkChannel: sdkMock.createLarkChannel,
+  };
+});
+
+import { startChannel } from '../../../src/bot/channel.js';
+
+interface MessageHandlerMap {
+  message?: (msg: NormalizedMessage) => Promise<void> | void;
+}
+
+interface FakeLarkChannel {
+  botIdentity: { openId: string; name: string };
+  rawClient: {
+    request: ReturnType<typeof vi.fn>;
+    application: {
+      v6: {
+        application: {
+          get: ReturnType<typeof vi.fn>;
+        };
+      };
+    };
+    im: {
+      v1: {
+        message: {
+          get: ReturnType<typeof vi.fn>;
+        };
+        messageReaction: {
+          create: ReturnType<typeof vi.fn>;
+          delete: ReturnType<typeof vi.fn>;
+        };
+      };
+    };
+  };
+  on(handlers: MessageHandlerMap): void;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  getChatMode(chatId: string): Promise<'group' | 'topic'>;
+  getConnectionStatus(): { state: 'connected'; reconnectAttempts: number };
+  send(chatId: string, content: unknown, options?: unknown): Promise<void>;
+  stream(chatId: string, input: unknown, options?: unknown): Promise<void>;
+}
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  sdkMock.channel = undefined;
+  sdkMock.createLarkChannel.mockClear();
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+describe('bot identity injection into the agent adapter', () => {
+  it('passes channel.botIdentity to the adapter after connect', async () => {
+    const h = await createHarness();
+
+    await startTestBridge(h);
+
+    expect(h.agent.botIdentity).toEqual({ openId: 'ou_bot', name: 'Bridge' });
+  });
+});
+
+describe('sender identity in bridge_context', () => {
+  it('marks a bot sender via raw sender_type and injects botOpenId and mentions', async () => {
+    const h = await createHarness();
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(
+      message({
+        messageId: 'om_from_bot',
+        senderId: 'ou_hermes',
+        senderName: 'HermesBot',
+        content: '@Bridge 部署完成，请验证',
+        rawSenderType: 'app',
+        mentions: [
+          { key: '@_user_1', openId: 'ou_bot', name: 'Bridge', isBot: true },
+          { key: '@_user_2', openId: 'ou_human', name: '张三', isBot: false },
+        ],
+      }),
+    );
+    await waitFor(() => h.agent.runOptions.length === 1);
+
+    const context = readSection(h.agent.runOptions[0]?.prompt ?? '', 'bridge_context') as {
+      senderType?: string;
+      botOpenId?: string;
+      mentions?: Array<{ openId?: string; name?: string; isBot?: boolean }>;
+    };
+    expect(context.senderType).toBe('bot');
+    expect(context.botOpenId).toBe('ou_bot');
+    expect(context.mentions).toEqual([
+      { openId: 'ou_bot', name: 'Bridge', isBot: true },
+      { openId: 'ou_human', name: '张三', isBot: false },
+    ]);
+  });
+
+  it('marks a human sender via raw sender_type', async () => {
+    const h = await createHarness();
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(
+      message({
+        messageId: 'om_from_user',
+        content: '@Bridge 帮我看个问题',
+        rawSenderType: 'user',
+      }),
+    );
+    await waitFor(() => h.agent.runOptions.length === 1);
+
+    const context = readSection(h.agent.runOptions[0]?.prompt ?? '', 'bridge_context') as {
+      senderType?: string;
+    };
+    expect(context.senderType).toBe('user');
+  });
+
+  it('omits senderType when the raw event is unavailable', async () => {
+    const h = await createHarness();
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(
+      message({
+        messageId: 'om_no_raw',
+        content: '@Bridge 在吗',
+      }),
+    );
+    await waitFor(() => h.agent.runOptions.length === 1);
+
+    const context = readSection(h.agent.runOptions[0]?.prompt ?? '', 'bridge_context') as Record<
+      string,
+      unknown
+    >;
+    expect(context).not.toHaveProperty('senderType');
+    expect(context.botOpenId).toBe('ou_bot');
+  });
+
+  it('turns a mention-only message into an explicit wake-up ping', async () => {
+    const h = await createHarness();
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(
+      message({
+        messageId: 'om_empty_at',
+        content: '',
+        rawSenderType: 'user',
+      }),
+    );
+    await waitFor(() => h.agent.runOptions.length === 1);
+
+    const userInput = readSection(h.agent.runOptions[0]?.prompt ?? '', 'user_input') as {
+      text: string;
+    };
+    expect(userInput.text).toContain('唤醒');
+    expect(userInput.text).toContain('没有正文');
+  });
+
+  it('annotates each message with its sender when a batch merges multiple senders', async () => {
+    const h = await createHarness();
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(
+      message({
+        messageId: 'om_batch_user',
+        senderId: 'ou_human',
+        senderName: '张三',
+        content: '@Bridge 这个报错怎么回事',
+        rawSenderType: 'user',
+      }),
+    );
+    await h.channel.handlers.message?.(
+      message({
+        messageId: 'om_batch_bot',
+        senderId: 'ou_hermes',
+        senderName: 'HermesBot',
+        content: '我刚发布了 v1.2.3',
+        rawSenderType: 'app',
+      }),
+    );
+    await waitFor(() => h.agent.runOptions.length === 1);
+
+    const userInput = readSection(h.agent.runOptions[0]?.prompt ?? '', 'user_input') as {
+      text: string;
+    };
+    expect(userInput.text).toContain('[张三 (user)]:');
+    expect(userInput.text).toContain('[HermesBot (bot)]:');
+    expect(userInput.text).toContain('这个报错怎么回事');
+    expect(userInput.text).toContain('我刚发布了 v1.2.3');
+  });
+
+  it('keeps single-message batches free of sender annotations', async () => {
+    const h = await createHarness();
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(
+      message({
+        messageId: 'om_single',
+        content: '@Bridge 看下这个',
+        rawSenderType: 'user',
+      }),
+    );
+    await waitFor(() => h.agent.runOptions.length === 1);
+
+    const userInput = readSection(h.agent.runOptions[0]?.prompt ?? '', 'user_input') as {
+      text: string;
+    };
+    expect(userInput.text).not.toContain('[User (user)]:');
+    expect(userInput.text).toContain('看下这个');
+  });
+});
+
+async function createHarness(): Promise<{
+  tmp: TmpProfile;
+  channel: FakeLarkChannel & { handlers: MessageHandlerMap };
+  agent: FakeAgentAdapter;
+  sessions: SessionStore;
+  workspaces: WorkspaceStore;
+  profileConfig: ReturnType<typeof createDefaultProfileConfig>;
+  controls: ReturnType<typeof createControls>;
+}> {
+  const tmp = await createTmpProfile('bot-at-bot-');
+  const workspace = await realpath(tmp.workspace);
+  const baseProfileConfig = createDefaultProfileConfig({
+    agentKind: 'claude',
+    accounts: {
+      app: {
+        id: 'cli_test',
+        secret: 'secret',
+        tenant: 'feishu',
+      },
+    },
+    access: {
+      allowedChats: ['oc_chat'],
+      allowedUsers: ['ou_user'],
+    },
+  });
+  const profileConfig = {
+    ...baseProfileConfig,
+    workspaces: {
+      ...baseProfileConfig.workspaces,
+      default: workspace,
+    },
+  };
+  const sessions = new SessionStore(join(tmp.profile, 'sessions.json'));
+  const workspaces = new WorkspaceStore(join(tmp.profile, 'workspaces.json'));
+  const agent = new FakeAgentAdapter({
+    events: [{ type: 'done', terminationReason: 'normal' }],
+  });
+  const channel = createFakeLarkChannel();
+  sdkMock.channel = channel;
+  const controls = createControls(profileConfig);
+  cleanups.push(async () => {
+    await Promise.all([sessions.flush(), workspaces.flush()]);
+    await tmp.cleanup();
+  });
+  return {
+    tmp,
+    channel,
+    agent,
+    sessions,
+    workspaces,
+    profileConfig,
+    controls,
+  };
+}
+
+async function startTestBridge(h: {
+  profileConfig: ReturnType<typeof createDefaultProfileConfig>;
+  agent: FakeAgentAdapter;
+  sessions: SessionStore;
+  workspaces: WorkspaceStore;
+  controls: ReturnType<typeof createControls>;
+}): Promise<void> {
+  const bridge = await startChannel({
+    cfg: h.profileConfig,
+    agent: h.agent,
+    sessions: h.sessions,
+    workspaces: h.workspaces,
+    controls: h.controls,
+  });
+  cleanups.push(() => bridge.disconnect());
+}
+
+function createFakeLarkChannel(): FakeLarkChannel & { handlers: MessageHandlerMap } {
+  const handlers: MessageHandlerMap = {};
+  return {
+    handlers,
+    botIdentity: { openId: 'ou_bot', name: 'Bridge' },
+    rawClient: {
+      request: vi.fn(async () => ({ data: { items: [] } })),
+      application: {
+        v6: {
+          application: {
+            get: vi.fn(async () => ({
+              data: { app: { owner: { owner_id: 'ou_owner' } } },
+            })),
+          },
+        },
+      },
+      im: {
+        v1: {
+          message: {
+            get: vi.fn(async () => ({ data: { items: [] } })),
+          },
+          messageReaction: {
+            create: vi.fn(async () => ({ data: { reaction_id: 'reaction_1' } })),
+            delete: vi.fn(async () => ({})),
+          },
+        },
+      },
+    },
+    on(nextHandlers) {
+      Object.assign(handlers, nextHandlers);
+    },
+    async connect() {},
+    async disconnect() {},
+    async getChatMode() {
+      return 'group';
+    },
+    getConnectionStatus() {
+      return { state: 'connected', reconnectAttempts: 0 };
+    },
+    async send() {},
+    async stream(_chatId, input) {
+      if (isMarkdownStreamInput(input)) {
+        await input.markdown({ setContent: async () => {} });
+      }
+    },
+  };
+}
+
+function createControls(profileConfig: ReturnType<typeof createDefaultProfileConfig>) {
+  return {
+    profile: 'test',
+    profileConfig,
+    ownerRefreshState: 'unknown' as const,
+    async refreshOwner() {},
+    async restart() {},
+    async exit() {},
+    configPath: '/tmp/config.json',
+    cfg: profileConfig,
+    processId: 'proc_test',
+  };
+}
+
+function message(input: {
+  messageId: string;
+  content: string;
+  senderId?: string;
+  senderName?: string;
+  rawSenderType?: string;
+  mentions?: Array<{ key: string; openId?: string; name?: string; isBot?: boolean }>;
+}): NormalizedMessage {
+  return {
+    messageId: input.messageId,
+    chatId: 'oc_chat',
+    chatType: 'group',
+    senderId: input.senderId ?? 'ou_user',
+    senderName: input.senderName ?? 'User',
+    content: input.content,
+    rawContentType: 'text',
+    resources: [],
+    mentions: input.mentions ?? [
+      { key: '@_user_1', openId: 'ou_bot', name: 'Bridge', isBot: true },
+    ],
+    mentionAll: false,
+    mentionedBot: true,
+    createTime: 1760000001000,
+    ...(input.rawSenderType
+      ? {
+          raw: {
+            sender: {
+              sender_id: { open_id: input.senderId ?? 'ou_user' },
+              sender_type: input.rawSenderType,
+            },
+            message: { message_id: input.messageId },
+          },
+        }
+      : {}),
+  } as unknown as NormalizedMessage;
+}
+
+function readSection(prompt: string, tag: string): unknown {
+  const match = prompt.match(new RegExp(`<${tag}>\\n([\\s\\S]*?)\\n</${tag}>`));
+  if (!match) throw new Error(`missing section ${tag}`);
+  return JSON.parse(match[1] ?? 'null') as unknown;
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error('timed out waiting for async work');
+}
+
+interface MarkdownStreamInput {
+  markdown(ctrl: { setContent(markdown: string): Promise<void> }): Promise<void> | void;
+}
+
+function isMarkdownStreamInput(input: unknown): input is MarkdownStreamInput {
+  return Boolean(input && typeof input === 'object' && 'markdown' in input);
+}

--- a/tests/integration/comments/claude-comments.test.ts
+++ b/tests/integration/comments/claude-comments.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { CommentEvent } from '@larksuiteoapi/node-sdk';
+import type { AgentEvent } from '../../../src/agent/types.js';
 import { ActiveRuns } from '../../../src/bot/active-runs.js';
 import { handleCommentMention } from '../../../src/bot/comments.js';
 import { ProcessPool } from '../../../src/bot/process-pool.js';
@@ -147,6 +148,28 @@ describe('Claude cloud-doc comment regression', () => {
     expect(h.createdTopLevelReplies).toEqual(['bold italic code\nitem\nquote']);
   });
 
+  it('keeps pre-tool progress text out of cloud-doc comment replies', async () => {
+    const h = await createCommentHarness({
+      getResponse: commentGet({ replyId: 'reply-1', question: 'review this doc' }),
+      agentEvents: [
+        { type: 'text', delta: '我先把文档读出来再 review。' },
+        {
+          type: 'tool_use',
+          id: 'tool-1',
+          name: 'Bash',
+          input: { command: 'lark-cli docs +fetch --doc doc-token' },
+        },
+        { type: 'tool_result', id: 'tool-1', output: 'doc body', isError: false },
+        { type: 'text', delta: '最终评审结论。' },
+        { type: 'done', sessionId: 'comment-session', terminationReason: 'normal' },
+      ],
+    });
+
+    await handleCommentMention(h.deps(event()));
+
+    expect(h.inThreadReplies.at(-1)).toBe('最终评审结论。');
+  });
+
   it('skips unsupported, unmentioned, or empty comment events without running the agent', async () => {
     const h = await createCommentHarness({
       getResponse: commentGet({ replyId: 'reply-empty', question: '' }),
@@ -168,7 +191,8 @@ async function createCommentHarness(options: {
   getErrorCode?: number;
   listResponses?: unknown[];
   replyErrorCode?: number;
-  agentText: string;
+  agentText?: string;
+  agentEvents?: readonly AgentEvent[];
 }): Promise<{
   tmp: TmpProfile;
   channel: FakeCommentChannel;
@@ -232,13 +256,12 @@ async function createCommentHarness(options: {
     },
   };
 
-  const agent = new FakeAgentAdapter({
-    events: [
-      { type: 'system', sessionId: 'comment-session', cwd: tmp.workspace },
-      { type: 'text', delta: options.agentText },
-      { type: 'done', sessionId: 'comment-session', terminationReason: 'normal' },
-    ],
-  });
+  const agentEvents = options.agentEvents ?? [
+    { type: 'system', sessionId: 'comment-session', cwd: tmp.workspace },
+    { type: 'text', delta: options.agentText ?? '' },
+    { type: 'done', sessionId: 'comment-session', terminationReason: 'normal' },
+  ];
+  const agent = new FakeAgentAdapter({ events: agentEvents });
   const sessions = new SessionStore(`${tmp.profile}/sessions.json`);
   const sessionCatalog = new SessionCatalog(`${tmp.profile}/session-catalog.json`);
   const workspaces = new WorkspaceStore(`${tmp.profile}/workspaces.json`);

--- a/tests/integration/comments/comment-run-flow.test.ts
+++ b/tests/integration/comments/comment-run-flow.test.ts
@@ -99,6 +99,21 @@ describe('comment run flow', () => {
     expect(h.agent.runOptions[2]?.threadId).toBe('thread-two');
   });
 
+  it('keeps Codex pre-tool progress text out of every comment reply', async () => {
+    const h = await createHarness({
+      agentKind: 'codex',
+      agentEventRuns: [
+        codexRunWithProgress('thread-one', '我先读取文档再处理。', 'first final'),
+        codexRunWithProgress('thread-two', '我继续读取上下文。', 'second final'),
+      ],
+    });
+
+    await handleCommentMention(h.deps(event({ commentId: 'comment-1', replyId: 'reply-1' })));
+    await handleCommentMention(h.deps(event({ commentId: 'comment-1', replyId: 'reply-1' })));
+
+    expect(h.inThreadReplies).toEqual(['first final', 'second final']);
+  });
+
   it('does not reuse an existing Codex thread while another document comment run is active', async () => {
     const h = await createBlockingHarness({
       agentKind: 'codex',
@@ -176,6 +191,7 @@ describe('comment run flow', () => {
 async function createHarness(options: {
   agentKind?: 'claude' | 'codex';
   agentTexts?: string[];
+  agentEventRuns?: AgentEvent[][];
   sessionIds?: string[];
   threadIds?: string[];
   reactionFails?: boolean;
@@ -198,23 +214,25 @@ async function createHarness(options: {
   const agentTexts = options.agentTexts ?? ['answer one'];
   const sessionIds = options.sessionIds ?? ['session-one'];
   const threadIds = options.threadIds ?? ['thread-one'];
-  const eventRuns: AgentEvent[][] = agentTexts.map((text, index) => [
-    {
-      type: 'system',
-      ...(agentKind === 'codex'
-        ? { threadId: threadIds[index] ?? `thread-${index}` }
-        : { sessionId: sessionIds[index] ?? `session-${index}` }),
-      cwd: tmp.workspace,
-    },
-    { type: 'text', delta: text },
-    {
-      type: 'done',
-      ...(agentKind === 'codex'
-        ? { threadId: threadIds[index] ?? `thread-${index}` }
-        : { sessionId: sessionIds[index] ?? `session-${index}` }),
-      terminationReason: 'normal',
-    },
-  ]);
+  const eventRuns: AgentEvent[][] =
+    options.agentEventRuns ??
+    agentTexts.map((text, index) => [
+      {
+        type: 'system',
+        ...(agentKind === 'codex'
+          ? { threadId: threadIds[index] ?? `thread-${index}` }
+          : { sessionId: sessionIds[index] ?? `session-${index}` }),
+        cwd: tmp.workspace,
+      },
+      { type: 'text', delta: text },
+      {
+        type: 'done',
+        ...(agentKind === 'codex'
+          ? { threadId: threadIds[index] ?? `thread-${index}` }
+          : { sessionId: sessionIds[index] ?? `session-${index}` }),
+        terminationReason: 'normal',
+      },
+    ]);
   const agent = new FakeAgentAdapter({ events: eventRuns });
   const channel: FakeCommentChannel = {
     requests,
@@ -504,6 +522,22 @@ function profile(defaultWorkspace: string, agentKind: 'claude' | 'codex' = 'clau
   });
   config.workspaces.default = defaultWorkspace;
   return config;
+}
+
+function codexRunWithProgress(threadId: string, progress: string, finalAnswer: string): AgentEvent[] {
+  return [
+    { type: 'system', threadId },
+    { type: 'text', delta: progress },
+    {
+      type: 'tool_use',
+      id: `${threadId}-tool`,
+      name: 'command_execution',
+      input: { command: 'lark-cli docs +fetch --api-version v2 --doc doc-token --doc-format markdown' },
+    },
+    { type: 'tool_result', id: `${threadId}-tool`, output: 'doc body', isError: false },
+    { type: 'text', delta: finalAnswer },
+    { type: 'done', threadId, terminationReason: 'normal' },
+  ];
 }
 
 function docSessionScope(fileToken: string): string {

--- a/tests/unit/agent/adapter-system-prompt-wiring.test.ts
+++ b/tests/unit/agent/adapter-system-prompt-wiring.test.ts
@@ -1,0 +1,121 @@
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const spawnMock = vi.hoisted(() => ({
+  spawnProcess: vi.fn(),
+}));
+
+vi.mock('../../../src/platform/spawn', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/platform/spawn')>();
+  return { ...actual, spawnProcess: spawnMock.spawnProcess };
+});
+
+import {
+  buildBridgeSystemPrompt,
+  prefixBridgeSystemPrompt,
+} from '../../../src/agent/bridge-system-prompt';
+import { ClaudeAdapter } from '../../../src/agent/claude/adapter';
+import { CodexAdapter } from '../../../src/agent/codex/adapter';
+
+interface FakeChild extends EventEmitter {
+  pid: number;
+  stdin: PassThrough;
+  stdout: PassThrough;
+  stderr: PassThrough;
+  exitCode: number | null;
+  signalCode: NodeJS.Signals | null;
+  kill: ReturnType<typeof vi.fn>;
+}
+
+function fakeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.pid = 4242;
+  child.stdin = new PassThrough();
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.exitCode = 0;
+  child.signalCode = null;
+  child.kill = vi.fn();
+  return child;
+}
+
+beforeEach(() => {
+  spawnMock.spawnProcess.mockReset();
+});
+
+describe('ClaudeAdapter system prompt wiring', () => {
+  it('appends the identity-aware bridge system prompt after setBotIdentity', () => {
+    spawnMock.spawnProcess.mockReturnValue(fakeChild());
+    const adapter = new ClaudeAdapter();
+    adapter.setBotIdentity({ openId: 'ou_bot_self', name: 'Bridge' });
+
+    adapter.run({ runId: 'r1', prompt: 'hi', cwd: '/tmp' });
+
+    const args = spawnMock.spawnProcess.mock.calls[0]?.[1] as string[];
+    const flagIndex = args.indexOf('--append-system-prompt');
+    expect(flagIndex).toBeGreaterThan(-1);
+    expect(args[flagIndex + 1]).toBe(
+      buildBridgeSystemPrompt({ openId: 'ou_bot_self', name: 'Bridge' }),
+    );
+  });
+
+  it('falls back to the base system prompt when no identity was set', () => {
+    spawnMock.spawnProcess.mockReturnValue(fakeChild());
+    const adapter = new ClaudeAdapter();
+
+    adapter.run({ runId: 'r1', prompt: 'hi', cwd: '/tmp' });
+
+    const args = spawnMock.spawnProcess.mock.calls[0]?.[1] as string[];
+    const flagIndex = args.indexOf('--append-system-prompt');
+    expect(args[flagIndex + 1]).toBe(buildBridgeSystemPrompt(undefined));
+  });
+});
+
+describe('CodexAdapter system prompt wiring', () => {
+  function codexAdapter(): CodexAdapter {
+    return new CodexAdapter({
+      binary: '/usr/local/bin/codex',
+      binaryPin: {
+        binaryPath: '/usr/local/bin/codex',
+        realpath: '/usr/local/bin/codex',
+        version: '1.0.0',
+        sha256: 'deadbeef',
+      },
+      profileStateDir: '/tmp/codex-profile',
+    });
+  }
+
+  it('prefixes stdin with the identity-aware bridge system prompt after setBotIdentity', async () => {
+    const child = fakeChild();
+    spawnMock.spawnProcess.mockReturnValue(child);
+    const adapter = codexAdapter();
+    adapter.setBotIdentity({ openId: 'ou_bot_self', name: 'Bridge' });
+
+    adapter.run({ runId: 'r1', prompt: 'hi', cwd: '/tmp' });
+
+    const stdin = await readAll(child.stdin);
+    expect(stdin).toBe(
+      prefixBridgeSystemPrompt('hi', { openId: 'ou_bot_self', name: 'Bridge' }),
+    );
+  });
+
+  it('falls back to the base system prompt when no identity was set', async () => {
+    const child = fakeChild();
+    spawnMock.spawnProcess.mockReturnValue(child);
+    const adapter = codexAdapter();
+
+    adapter.run({ runId: 'r1', prompt: 'hi', cwd: '/tmp' });
+
+    const stdin = await readAll(child.stdin);
+    expect(stdin).toBe(prefixBridgeSystemPrompt('hi', undefined));
+  });
+});
+
+async function readAll(stream: PassThrough): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString('utf8');
+}

--- a/tests/unit/agent/bridge-system-prompt.test.ts
+++ b/tests/unit/agent/bridge-system-prompt.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BRIDGE_SYSTEM_PROMPT,
+  buildBridgeSystemPrompt,
+  prefixBridgeSystemPrompt,
+} from '../../../src/agent/bridge-system-prompt';
+
+describe('bridge system prompt bot collaboration rules', () => {
+  it('states that bots only receive messages via a real structured mention', () => {
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('只有被真实 @');
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('收不到');
+  });
+
+  it('scopes the mention requirement to bots, not human users', () => {
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('人类用户');
+  });
+
+  it('tells the agent not to mention other bots by default to avoid loops', () => {
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('默认不要 @ 其他 bot');
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('死循环');
+  });
+
+  it('allows mentioning a bot when the user explicitly asks for a handoff', () => {
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('用户明确要求');
+  });
+
+  it('points self-identification at the bridge_context botOpenId field', () => {
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('botOpenId');
+  });
+
+  it('documents the senderType and mentions context fields', () => {
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('senderType');
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('mentions');
+  });
+
+  it('tells the agent not to mimic the batch sender annotation format', () => {
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('[名字 (user|bot)]');
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('不要模仿');
+  });
+});
+
+describe('buildBridgeSystemPrompt', () => {
+  it('returns the base prompt unchanged when no identity is available', () => {
+    expect(buildBridgeSystemPrompt(undefined)).toBe(BRIDGE_SYSTEM_PROMPT);
+  });
+
+  it('appends a concrete identity line with open_id and name', () => {
+    const prompt = buildBridgeSystemPrompt({ openId: 'ou_bot_self', name: '尼莫' });
+    expect(prompt.startsWith(BRIDGE_SYSTEM_PROMPT)).toBe(true);
+    expect(prompt).toContain('ou_bot_self');
+    expect(prompt).toContain('尼莫');
+  });
+
+  it('appends the identity line even when the bot name is missing', () => {
+    const prompt = buildBridgeSystemPrompt({ openId: 'ou_bot_self' });
+    expect(prompt).toContain('ou_bot_self');
+  });
+});
+
+describe('prefixBridgeSystemPrompt', () => {
+  it('prefixes the identity-aware system prompt before the user message', () => {
+    const prompt = prefixBridgeSystemPrompt('hello world', { openId: 'ou_bot_self' });
+    expect(prompt).toContain('ou_bot_self');
+    expect(prompt.indexOf('ou_bot_self')).toBeLessThan(prompt.indexOf('## user_message'));
+    expect(prompt.endsWith('hello world')).toBe(true);
+  });
+
+  it('keeps working without an identity', () => {
+    const prompt = prefixBridgeSystemPrompt('hello world', undefined);
+    expect(prompt.startsWith(BRIDGE_SYSTEM_PROMPT)).toBe(true);
+    expect(prompt.endsWith('hello world')).toBe(true);
+  });
+});

--- a/tests/unit/comments/comment-parser.test.ts
+++ b/tests/unit/comments/comment-parser.test.ts
@@ -59,6 +59,8 @@ describe('comment parser', () => {
     expect(prompt).toContain('不要调用云文档评论或回复接口');
     expect(prompt).toContain('不要给评论添加或删除 reaction');
     expect(prompt).toContain('最终答案直接用纯文本交给 bridge');
+    expect(prompt).toContain('不要输出内部思考、内部分析、读取步骤、工具调用过程或工具日志');
+    expect(prompt).toContain('若用户要求解释依据，只说明用户可见的依据和结论');
     expect(prompt).not.toContain('`lark-cli docs +fetch --doc doc-token`');
   });
 


### PR DESCRIPTION
## Summary

This change includes two updates:

1. Fix internal process text leaking into cloud-doc comment replies
   - Clear accumulated reply text at `tool_use` / `tool_result` boundaries so pre-tool progress text is not included in the final comment reply.
   - Tighten the cloud-doc comment prompt to avoid exposing internal thinking, internal analysis, document-reading steps, tool-call process, or tool logs. If the user asks for an explanation, the agent should only cite user-visible evidence and conclusions.

2. Improve bot-at-bot context handling
   - Add `senderType`, `botOpenId`, and `mentions` to `bridge_context`.
   - Inject the bridge bot’s own open_id into the agent system prompt so the agent can identify itself.
   - Annotate each message segment with its sender when multiple messages are merged into one batch, reducing ambiguity between bot and human senders.
   - Document real structured @ mention requirements for bot handoff and discourage unnecessary bot-to-bot mention loops.

## Version

- `package.json`: `0.2.0` -> `0.2.1`

## Verification

- `pnpm test`
- `pnpm typecheck`
- `pnpm build`