### PR TITLE
feat: add `profile repin <name>` to refresh codex binary pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ lark-channel-bridge profile list
 lark-channel-bridge profile use <name>
 lark-channel-bridge profile remove <name>
 lark-channel-bridge profile remove <name> --purge --yes
+lark-channel-bridge profile repin <name>
 lark-channel-bridge profile export <name> [--output ./profile.json] [--force]
 lark-channel-bridge profile export <name> --include-secrets --yes
 ```
@@ -295,7 +296,7 @@ Cloud-doc comments do not need a separate workspace binding or document allowlis
 
 ## Codex CLI verification
 
-Codex profiles store a binary pin with `binaryPath`, `realpath`, `version`, and `sha256`. The bridge verifies the pin before every Codex run and refuses to continue if the binary changes. Arbitrary `codex.flags` are not exposed; bridge-owned Codex argv is fixed.
+Codex profiles store a binary pin with `binaryPath`, `realpath`, `version`, and `sha256`. The bridge verifies the pin before every Codex run and refuses to continue if the binary changes. Arbitrary `codex.flags` are not exposed; bridge-owned Codex argv is fixed. When you intentionally upgrade Codex, run `profile repin <name>` to refresh the pin from the current binary; the command prints which fields changed and requires no flags.
 
 ## Testing and CI
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -124,6 +124,7 @@ lark-channel-bridge profile list
 lark-channel-bridge profile use <name>
 lark-channel-bridge profile remove <name>
 lark-channel-bridge profile remove <name> --purge --yes
+lark-channel-bridge profile repin <name>
 lark-channel-bridge profile export <name> [--output ./profile.json] [--force]
 lark-channel-bridge profile export <name> --include-secrets --yes
 ```
@@ -295,7 +296,7 @@ grep '"event":"enter"' ~/.lark-channel/profiles/<profile>/logs/bridge-$(date +%Y
 
 ## Codex CLI 安全校验
 
-Codex profile 会记录 binary pin，包括 `binaryPath`、`realpath`、`version` 和 `sha256`。bridge 每次 Codex run 前都会复核 pin；二进制被替换时会拒绝继续运行。bridge 不开放任意 `codex.flags` 配置，Codex argv 由 bridge 固定生成。
+Codex profile 会记录 binary pin，包括 `binaryPath`、`realpath`、`version` 和 `sha256`。bridge 每次 Codex run 前都会复核 pin；二进制被替换时会拒绝继续运行。bridge 不开放任意 `codex.flags` 配置，Codex argv 由 bridge 固定生成。主动升级 Codex 之后，跑 `profile repin <name>` 用磁盘上现行 binary 刷新 pin；命令会打印发生变化的字段，无需额外参数。
 
 ## 测试与 CI
 

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
+import { createCodexBinaryPin } from '../../agent/codex/binary';
 import { resolveAppPaths } from '../../config/app-paths';
 import { paths } from '../../config/paths';
 import {
@@ -15,7 +16,7 @@ import {
   withConfigFileLock,
   writeActiveProfile,
 } from '../../config/profile-store';
-import type { RootConfig } from '../../config/profile-schema';
+import type { CodexConfig, RootConfig } from '../../config/profile-schema';
 import { resolveAppSecret } from '../../config/secret-resolver';
 import { writeFileAtomic } from '../../platform/atomic-write';
 import { acquireProfileRuntimeLock, checkRuntimeLock } from '../../runtime/locks';
@@ -47,6 +48,8 @@ export interface ProfileExportOptions extends ProfileCommandOptions {
   includeSecrets?: boolean;
   yes?: boolean;
 }
+
+export interface ProfileRepinOptions extends ProfileCommandOptions {}
 
 export async function runProfileList(opts: ProfileCommandOptions = {}): Promise<void> {
   const rootDir = opts.rootDir ?? paths.rootDir;
@@ -273,4 +276,75 @@ export async function runProfileExport(
 
 function cloneJson<T>(value: T): T {
   return JSON.parse(JSON.stringify(value)) as T;
+}
+
+export async function runProfileRepin(
+  name: string,
+  opts: ProfileRepinOptions = {},
+): Promise<void> {
+  const rootDir = opts.rootDir ?? paths.rootDir;
+  const configFile = resolveAppPaths({ rootDir }).configFile;
+  await withConfigFileLock(configFile, async () => {
+    const root = await loadRootConfig(configFile);
+    if (!root) throw new Error('config not initialized');
+    const profile = root.profiles[name];
+    if (!profile) throw new Error(`profile not found: ${name}`);
+    if (profile.agentKind !== 'codex') {
+      throw new Error(
+        `profile ${name} is not a codex profile (agentKind: ${profile.agentKind}); ` +
+          `only codex profiles have binary pins`,
+      );
+    }
+    const oldCodex = profile.codex;
+    const binaryPath =
+      oldCodex?.binaryPath ?? process.env.LARK_CHANNEL_CODEX_BIN ?? 'codex';
+    const newPin = await createCodexBinaryPin(binaryPath);
+
+    const diffLines = diffCodexPin(oldCodex, newPin);
+    if (diffLines.length === 0) {
+      console.log('(no changes)');
+      return;
+    }
+    for (const line of diffLines) console.log(line);
+
+    const updatedCodex: CodexConfig = {
+      ...(oldCodex ?? {}),
+      binaryPath: newPin.binaryPath,
+      realpath: newPin.realpath,
+      version: newPin.version,
+      sha256: newPin.sha256,
+      ...(newPin.owner !== undefined ? { owner: newPin.owner } : {}),
+      ...(newPin.mode !== undefined ? { mode: newPin.mode } : {}),
+    };
+    profile.codex = updatedCodex;
+    await saveRootConfig(root, configFile);
+    console.log(`✓ codex pin updated for profile "${name}". Restart daemon to pick up the new pin.`);
+  });
+}
+
+function diffCodexPin(
+  oldCodex: CodexConfig | undefined,
+  newPin: { binaryPath: string; realpath: string; version: string; sha256: string; owner?: number; mode?: number },
+): string[] {
+  const fields: Array<'binaryPath' | 'realpath' | 'version' | 'sha256' | 'owner' | 'mode'> = [
+    'binaryPath',
+    'realpath',
+    'version',
+    'sha256',
+    'owner',
+    'mode',
+  ];
+  const lines: string[] = [];
+  for (const field of fields) {
+    const oldVal = oldCodex?.[field];
+    const newVal = newPin[field];
+    if (oldVal === newVal) continue;
+    const fmt = (value: string | number | undefined): string => {
+      if (value === undefined) return '(unset)';
+      if (field === 'sha256' && typeof value === 'string') return `${value.slice(0, 8)}...`;
+      return String(value);
+    };
+    lines.push(`  ${field}: ${fmt(oldVal)} → ${fmt(newVal)}`);
+  }
+  return lines;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,7 @@ import {
   runProfileExport,
   runProfileList,
   runProfileRemove,
+  runProfileRepin,
   runProfileUse,
 } from './commands/profile';
 import {
@@ -111,6 +112,13 @@ profile
   .option('--yes', 'confirm destructive profile deletion')
   .action(async (name: string, opts: { purge?: boolean; yes?: boolean }) => {
     await runProfileRemove(name, { purge: opts.purge, yes: opts.yes });
+  });
+
+profile
+  .command('repin <name>')
+  .description('Refresh the codex binary pin from the current binary on disk')
+  .action(async (name: string) => {
+    await runProfileRepin(name);
   });
 
 profile

--- a/tests/integration/cli/profile-repin.test.ts
+++ b/tests/integration/cli/profile-repin.test.ts
@@ -1,0 +1,177 @@
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { runProfileRepin } from '../../../src/cli/commands/profile';
+import {
+  createDefaultProfileConfig,
+  type RootConfig,
+} from '../../../src/config/profile-schema';
+import { writeVersionExecutable } from '../../helpers/fake-executable';
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('profile repin command', () => {
+  it('refreshes pin fields from the current codex binary when version has drifted', async () => {
+    const root = await makeRoot();
+    const binary = await writeVersionExecutable(root, 'codex', 'codex-cli 0.136.0');
+    await writeCodexProfile(root, 'codex', {
+      binaryPath: binary,
+      realpath: binary,
+      version: 'codex-cli 0.133.0',
+      sha256: 'aa3c64b122c9d06bf48eaf988f5970aa69556d69506c3118cf07d10b2401b48a',
+      owner: 501,
+      mode: 0o755,
+    });
+
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    };
+    try {
+      await runProfileRepin('codex', { rootDir: root });
+    } finally {
+      console.log = originalLog;
+    }
+
+    const saved = JSON.parse(await readFile(join(root, 'config.json'), 'utf8')) as RootConfig;
+    const newPin = saved.profiles.codex?.codex;
+    expect(newPin?.version).toBe('codex-cli 0.136.0');
+    expect(newPin?.sha256).not.toBe(
+      'aa3c64b122c9d06bf48eaf988f5970aa69556d69506c3118cf07d10b2401b48a',
+    );
+    expect(newPin?.sha256).toMatch(/^[0-9a-f]{64}$/);
+    expect(newPin?.binaryPath).toBe(binary);
+
+    const combined = logs.join('\n');
+    expect(combined).toContain('version');
+    expect(combined).toContain('codex-cli 0.133.0');
+    expect(combined).toContain('codex-cli 0.136.0');
+  });
+
+  it('prints (no changes) and leaves config untouched when the pin already matches disk', async () => {
+    const root = await makeRoot();
+    const binary = await writeVersionExecutable(root, 'codex', 'codex-cli 0.136.0');
+    const resolved = await realpath(binary);
+    const actualSha = await sha256OfFile(binary);
+    const { stat } = await import('node:fs/promises');
+    const info = await stat(binary);
+    await writeCodexProfile(root, 'codex', {
+      binaryPath: binary,
+      realpath: resolved,
+      version: 'codex-cli 0.136.0',
+      sha256: actualSha,
+      owner: info.uid,
+      mode: info.mode & 0o7777,
+    });
+
+    const before = await readFile(join(root, 'config.json'), 'utf8');
+    const logs: string[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    };
+    try {
+      await runProfileRepin('codex', { rootDir: root });
+    } finally {
+      console.log = originalLog;
+    }
+    const after = await readFile(join(root, 'config.json'), 'utf8');
+    expect(after).toBe(before);
+    expect(logs.join('\n')).toContain('(no changes)');
+  });
+
+  it('refuses to repin a non-codex profile with a clear error', async () => {
+    const root = await makeRoot();
+    await writeClaudeProfile(root, 'claude');
+
+    await expect(runProfileRepin('claude', { rootDir: root })).rejects.toThrow(
+      /not a codex profile/,
+    );
+  });
+
+  it('throws profile not found when the profile name is unknown', async () => {
+    const root = await makeRoot();
+    await writeClaudeProfile(root, 'claude');
+
+    await expect(runProfileRepin('nope', { rootDir: root })).rejects.toThrow(
+      /profile not found: nope/,
+    );
+  });
+});
+
+async function makeRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'bridge-profile-repin-'));
+  roots.push(root);
+  return root;
+}
+
+async function writeCodexProfile(
+  root: string,
+  name: string,
+  codexPin: {
+    binaryPath: string;
+    realpath: string;
+    version: string;
+    sha256: string;
+    owner?: number;
+    mode?: number;
+  },
+): Promise<void> {
+  const profile = createDefaultProfileConfig({
+    agentKind: 'codex',
+    accounts: {
+      app: {
+        id: `cli_${name}`,
+        secret: '${APP_SECRET}',
+        tenant: 'feishu',
+      },
+    },
+    codex: codexPin,
+  });
+  const config: RootConfig = {
+    schemaVersion: 2,
+    activeProfile: name,
+    preferences: {},
+    profiles: { [name]: profile },
+  };
+  await writeJson(join(root, 'config.json'), config);
+  await mkdir(join(root, 'profiles', name), { recursive: true });
+}
+
+async function writeClaudeProfile(root: string, name: string): Promise<void> {
+  const profile = createDefaultProfileConfig({
+    agentKind: 'claude',
+    accounts: {
+      app: {
+        id: `cli_${name}`,
+        secret: '${APP_SECRET}',
+        tenant: 'feishu',
+      },
+    },
+  });
+  const config: RootConfig = {
+    schemaVersion: 2,
+    activeProfile: name,
+    preferences: {},
+    profiles: { [name]: profile },
+  };
+  await writeJson(join(root, 'config.json'), config);
+  await mkdir(join(root, 'profiles', name), { recursive: true });
+}
+
+async function writeJson(path: string, value: unknown): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}
+
+async function sha256OfFile(path: string): Promise<string> {
+  const { createHash } = await import('node:crypto');
+  const { readFile: read } = await import('node:fs/promises');
+  return createHash('sha256').update(await read(path)).digest('hex');
+}

--- a/tests/unit/cli/index-registration.test.ts
+++ b/tests/unit/cli/index-registration.test.ts
@@ -16,4 +16,11 @@ describe('CLI command registration', () => {
     const appSecretOptions = source.match(/--app-secret <secret>/g) ?? [];
     expect(appSecretOptions.length).toBeGreaterThanOrEqual(3);
   });
+
+  it('registers the profile repin command', async () => {
+    const source = await readFile(join(process.cwd(), 'src', 'cli', 'index.ts'), 'utf8');
+
+    expect(source).toMatch(/\.command\(['"]repin <name>['"]\)/);
+    expect(source).toContain('runProfileRepin');
+  });
 });


### PR DESCRIPTION
## Why

Codex profiles store a binary pin (`realpath`, `version`, `sha256`, `owner`, `mode`) that `verifyCodexBinaryPin` checks before every codex run (`src/agent/codex/binary.ts:48-62`). Any drift on any of those fields → bridge throws `codex binary verification failed` → the bot in Lark silently stops responding (only visible in `profiles/<name>/logs/daemon/daemon-stderr.log` as `flush.fail err=codex binary verification failed`).

This drift is **routine** in practice — every time the user upgrades codex (`npm update -g @openai/codex`) the `version` + `sha256` necessarily change. Upgrading `lark-channel-bridge` itself can also transitively bump `@openai/codex` (we hit this going 0.1.33 → 0.2.1 — codex went from 0.133.0 to 0.136.0 in the same `npm i`, the post-create pin captured the stale version, and codex was bricked until we hand-edited `config.json`).

Today there is no CLI path to recover — users must edit `~/.lark-channel/config.json` directly, which requires knowing which 5 fields the pin checks and how to recompute the SHA. That is a poor failure mode for a security feature whose entire value depends on users being able to consciously re-trust upgrades.

## What

A new `profile repin <name>` command that:

- Reads the current binary on disk via the existing `createCodexBinaryPin()` helper (no new pin logic introduced)
- Prints a field-level diff (`version: codex-cli 0.133.0 → codex-cli 0.136.0`, sha256 truncated to first 8 chars for readability)
- Atomically writes the fresh pin back via the existing `withConfigFileLock` + `saveRootConfig` path
- Preserves non-pin codex settings (`inheritCodexHome`, `ignoreUserConfig`, `ignoreRules`, `codexHome`)
- No new flags

```
$ lark-channel-bridge profile repin codex
  version: codex-cli 0.133.0 → codex-cli 0.136.0
  sha256: deadbeef... → aa3c64b1...
✓ codex pin updated for profile "codex". Restart daemon to pick up the new pin.
```

No-op path stays quiet and does not touch the file:

```
$ lark-channel-bridge profile repin codex
(no changes)
```

Validation matches the rest of the `profile` namespace:

- `profile not found: <name>` when the name is unknown
- `profile <name> is not a codex profile (agentKind: claude); only codex profiles have binary pins` when called on a claude profile

## Security note

This does not weaken pin verification — `verifyCodexBinaryPin` still runs on every codex execution. `repin` only changes *when* the user explicitly re-establishes trust: it converts "hand-edit a JSON file" into "run one command and read the diff". The act of running the command IS the trust event.

## Alternatives considered & dropped (YAGNI)

- `--dry-run`: the diff output already shows what would change; users can `Ctrl+C` if surprised
- `--yes` / auto-confirm: user is already explicit by running the command
- Daemon auto-restart: keeping it as a separate user step matches the existing `start/stop/restart` contract
- Bulk repin across profiles: only codex has a pin today, so the scope is one

These can be added later if anyone asks.

## Out of scope

There is a related question — *why* did `profile create` capture version `0.133.0` immediately after `npm i -g lark-channel-bridge@latest`, when `codex --version` at that moment was already `0.136.0`? We suspect a race between npm's post-install of bridge and codex's own package metadata, but I didn't dig further. Happy to open a separate issue once this lands.

## Test plan

- 4 new integration tests at `tests/integration/cli/profile-repin.test.ts`:
  - drift → diff printed, config rewritten
  - identical pin → `(no changes)` printed, file byte-identical
  - claude profile → throws with the helpful message
  - missing profile name → throws `profile not found: <name>`
- 1 new CLI-registration smoke test at `tests/unit/cli/index-registration.test.ts`
- Full suite: 492 passing (was 487), `pnpm typecheck` clean, `pnpm build` clean
- End-to-end manually verified on my machine against the real failure I hit upgrading from 0.1.33 → 0.2.1