### PR TITLE
fix: Windows .cmd shim corrupts multi-line prompts causing no content

### DIFF
--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -2,6 +2,7 @@ import { createInterface } from 'node:readline';
 import type { Readable } from 'node:stream';
 import { log } from '../../core/logger';
 import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
+import { resolveWindowsBinary } from '../../platform/resolve-windows-binary';
 import { buildBridgeSystemPrompt } from '../bridge-system-prompt';
 import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel-env';
 import { checkAgentAvailability, type AgentAvailability } from '../preflight';
@@ -31,7 +32,7 @@ export class ClaudeAdapter implements AgentAdapter {
   private botIdentity: AgentBotIdentity | undefined;
 
   constructor(opts: ClaudeAdapterOptions = {}) {
-    this.binary = opts.binary ?? 'claude';
+    this.binary = resolveWindowsBinary(opts.binary ?? 'claude');
     this.larkChannel = opts.larkChannel;
   }
 

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -435,7 +435,10 @@ export function createRuntimeAgent(
       larkChannel,
     });
   }
-  return new ClaudeAdapter({ larkChannel });
+  return new ClaudeAdapter({
+    binary: process.env.LARK_CHANNEL_CLAUDE_BIN,
+    larkChannel,
+  });
 }
 
 function codexBinaryPin(codex: CodexConfig) {

--- a/src/platform/resolve-windows-binary.ts
+++ b/src/platform/resolve-windows-binary.ts
@@ -1,0 +1,37 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { platform } from 'node:os';
+
+/**
+ * On Windows, npm installs `.cmd` shims that wrap the real `.exe`.
+ * When cross-spawn runs a `.cmd` file, it wraps the invocation with
+ * `cmd.exe /d /s /c "..."`, which corrupts multi-line arguments
+ * (e.g. prompts containing `\n`). This causes downstream tools like
+ * Claude Code to receive garbled `--output-format` flags and fall
+ * back to plain-text output instead of structured JSON.
+ *
+ * This helper resolves a `.cmd` shim to its underlying `.exe` so that
+ * cross-spawn can execute the binary directly, bypassing cmd.exe.
+ */
+export function resolveWindowsBinary(binary: string): string {
+  if (platform() !== 'win32') return binary;
+
+  try {
+    const whereOutput = execFileSync('where', [binary], {
+      encoding: 'utf8',
+      timeout: 5000,
+      windowsHide: true,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    const cmdPath = whereOutput.trim().split(/\r?\n/)[0]?.trim();
+    if (!cmdPath || !cmdPath.toLowerCase().endsWith('.cmd')) return binary;
+
+    // npm .cmd shims contain the real .exe path in the last line:
+    // endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "path\to\exe" %*
+    const content = readFileSync(cmdPath, 'utf8');
+    const match = content.match(/"([^"]+\.exe)"/i);
+    return match ? match[1] : binary;
+  } catch {
+    return binary;
+  }
+}

--- a/tests/unit/platform/resolve-windows-binary.test.ts
+++ b/tests/unit/platform/resolve-windows-binary.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock node modules before importing
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+vi.mock('node:fs', () => ({
+  readFileSync: vi.fn(),
+}));
+vi.mock('node:os', () => ({
+  platform: vi.fn(),
+}));
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { platform } from 'node:os';
+import { resolveWindowsBinary } from '../../../src/platform/resolve-windows-binary';
+
+describe('resolveWindowsBinary', () => {
+  const mockExec = vi.mocked(execFileSync);
+  const mockRead = vi.mocked(readFileSync);
+  const mockPlatform = vi.mocked(platform);
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns binary unchanged on non-Windows', () => {
+    mockPlatform.mockReturnValue('linux');
+    expect(resolveWindowsBinary('claude')).toBe('claude');
+  });
+
+  it('returns binary unchanged when where finds no .cmd', () => {
+    mockPlatform.mockReturnValue('win32');
+    mockExec.mockReturnValue('C:\\Users\\test\\npm\\claude.exe\r\n');
+    expect(resolveWindowsBinary('claude')).toBe('claude');
+  });
+
+  it('resolves .cmd to .exe by parsing the shim', () => {
+    mockPlatform.mockReturnValue('win32');
+    mockExec.mockReturnValue('C:\\Users\\test\\npm\\claude.cmd\r\n');
+    mockRead.mockReturnValue(
+      '@ECHO off\r\n' +
+      'GOTO start\r\n' +
+      ':find_dp0\r\n' +
+      'SET dp0=%~dp0\r\n' +
+      'EXIT /b\r\n' +
+      ':start\r\n' +
+      'SETLOCAL\r\n' +
+      'CALL :find_dp0\r\n' +
+      'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "C:\\Users\\test\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe" %*\r\n',
+    );
+    expect(resolveWindowsBinary('claude')).toBe(
+      'C:\\Users\\test\\npm\\node_modules\\@anthropic-ai\\claude-code\\bin\\claude.exe',
+    );
+  });
+
+  it('returns original binary when .cmd parsing fails', () => {
+    mockPlatform.mockReturnValue('win32');
+    mockExec.mockReturnValue('C:\\Users\\test\\npm\\claude.cmd\r\n');
+    mockRead.mockReturnValue('invalid content without exe path');
+    expect(resolveWindowsBinary('claude')).toBe('claude');
+  });
+
+  it('returns original binary when where command fails', () => {
+    mockPlatform.mockReturnValue('win32');
+    mockExec.mockImplementation(() => {
+      throw new Error('not found');
+    });
+    expect(resolveWindowsBinary('claude')).toBe('claude');
+  });
+
+  it('returns custom binary unchanged', () => {
+    mockPlatform.mockReturnValue('win32');
+    expect(resolveWindowsBinary('/custom/path/claude.exe')).toBe('/custom/path/claude.exe');
+  });
+});


### PR DESCRIPTION
## Problem

On Windows, the bridge spawns Claude Code via `cross-spawn("claude", ...)`, which resolves to `claude.cmd` (npm's Windows shim). `cross-spawn` then wraps the invocation with `cmd.exe /d /s /c "..."`.

When the prompt contains **newlines** (e.g. `<bridge_context>\n...\n</bridge_context>`), `cmd.exe` corrupts the arguments. This causes Claude Code to receive a broken `--output-format stream-json` flag and fall back to **plain text** output. The bridge's JSON parser silently skips non-JSON lines, resulting in **"no content"** replies in Feishu.

This affects **all Windows users**. macOS/Linux users are unaffected.

### Reproduction

```js
// Plain text output (broken) - via .cmd shim
cross-spawn("claude", ["-p", "<bridge_context>\nhello\n</bridge_context>", "--output-format", "stream-json", ...])

// JSON output (correct) - via .exe directly  
cross-spawn("claude.exe", ["-p", "<bridge_context>\nhello\n</bridge_context>", "--output-format", "stream-json", ...])
```

## Fix

Three changes:

1. **`src/platform/resolve-windows-binary.ts`** (new) — On Windows, resolves a `.cmd` shim to its underlying `.exe` by:
   - Using `where` to find the `.cmd` path
   - Parsing the `.cmd` file to extract the actual `.exe` path (npm shims contain it in the last line)
   - Gracefully falling back to the original binary on any failure

2. **`src/agent/claude/adapter.ts`** — Import and call `resolveWindowsBinary()` in the `ClaudeAdapter` constructor so the binary is resolved to `.exe` before spawning.

3. **`src/cli/commands/start.ts`** — Wire `LARK_CHANNEL_CLAUDE_BIN` env var to the runtime `ClaudeAdapter` (currently it's only used during agent detection, not at runtime). This gives users a manual override.

## Related Issues

Fixes #69 (Windows: Claude CLI invocation completely broken — three cascading failures)
Fixes #49 (Failed to spawn claude: spawn claude ENOENT)

## Testing

- Added unit tests for `resolveWindowsBinary` with mocked modules
- Verified locally on Windows 11 that the fix resolves the "no content" issue