### PR TITLE
Retry agent run on transient auth/403

### DIFF
--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -56,7 +56,12 @@ export class ClaudeAdapter implements AgentAdapter {
     if (!opts.cwd) {
       throw new Error('cwd is required for ClaudeAdapter.run');
     }
+    return createRetryingRun(opts, () => this.spawnAttempt(opts));
+  }
 
+  // One spawn of the claude CLI. The public run() wraps this with transparent
+  // retry on transient auth/403 failures — see createRetryingRun.
+  private spawnAttempt(opts: AgentRunOptions): AgentRun {
     const args = [
       '-p',
       opts.prompt,
@@ -166,6 +171,145 @@ export class ClaudeAdapter implements AgentAdapter {
       },
     };
   }
+}
+
+// At most 3 re-spawns after the initial attempt, backing off before each.
+const MAX_AUTH_RETRIES = 3;
+const AUTH_RETRY_BACKOFF_MS = [1000, 2000, 4000];
+
+/**
+ * A 403 "Request not allowed" / 401 from the API is usually a *permanent*
+ * rejection (geo-block, revoked creds) — retrying won't fix that. But it can
+ * also be a transient blip (a flaky proxy hop, a momentary edge rejection),
+ * and that's the only case retry helps. So we retry ONLY this error class,
+ * bounded and backed off; every other failure is reported immediately.
+ */
+export function isTransientAuthError(message: string): boolean {
+  return /failed to authenticate|authentication failed|authentication_failed|request not allowed|unauthorized|\b40[13]\b/i.test(
+    message,
+  );
+}
+
+// Events that represent real model output. Once any of these has streamed we
+// must NOT retry — the words are already on the user's screen, we can't unsend
+// them. (The synthetic auth-error text is suppressed in translateEvent, so it
+// never counts as real content here.)
+function isRealContent(evt: AgentEvent): boolean {
+  return (
+    evt.type === 'text' ||
+    evt.type === 'thinking' ||
+    evt.type === 'tool_use' ||
+    evt.type === 'tool_result'
+  );
+}
+
+/**
+ * Wrap single-shot spawns with transparent retry on transient auth/403.
+ *
+ * Each attempt's events are buffered until we either (a) see real output — at
+ * which point we commit: flush the buffer and stream the rest live, never
+ * retrying again — or (b) the attempt ends. If it ended with a transient auth
+ * error before any output, we discard the buffered events, back off, and
+ * re-spawn (up to MAX_AUTH_RETRIES). Any non-auth error, an auth error after
+ * output already streamed, or a clean done is passed through untouched.
+ *
+ * The first attempt is spawned eagerly so run() returns a live process
+ * synchronously, matching the non-retrying contract callers depend on.
+ */
+function createRetryingRun(opts: AgentRunOptions, spawn: () => AgentRun): AgentRun {
+  let current = spawn();
+  let stopped = false;
+  let abortBackoff: (() => void) | undefined;
+
+  async function* stream(): AsyncGenerator<AgentEvent> {
+    let attempt = 1;
+    while (true) {
+      const inner = current;
+      const buffer: AgentEvent[] = [];
+      let committed = false;
+      let terminalError: Extract<AgentEvent, { type: 'error' }> | null = null;
+
+      for await (const evt of inner.events) {
+        if (committed) {
+          yield evt;
+          continue;
+        }
+        if (isRealContent(evt)) {
+          committed = true;
+          for (const buffered of buffer) yield buffered;
+          buffer.length = 0;
+          yield evt;
+          continue;
+        }
+        if (evt.type === 'error') {
+          // Terminal. Stop draining here so we don't also consume the trailing
+          // "exited with code N" event the stream emits after an error result.
+          terminalError = evt;
+          break;
+        }
+        // system / usage / done — buffer until we know whether to retry.
+        buffer.push(evt);
+        if (evt.type === 'done') break;
+      }
+
+      if (committed) return;
+
+      const retriable =
+        terminalError !== null &&
+        !stopped &&
+        attempt <= MAX_AUTH_RETRIES &&
+        isTransientAuthError(terminalError.message);
+
+      if (!retriable) {
+        for (const buffered of buffer) yield buffered;
+        if (terminalError) yield terminalError;
+        return;
+      }
+
+      log.warn('agent', 'auth-retry', {
+        attempt,
+        maxRetries: MAX_AUTH_RETRIES,
+        backoffMs: AUTH_RETRY_BACKOFF_MS[attempt - 1] ?? 0,
+        reason: terminalError!.message.slice(0, 200),
+      });
+
+      // Reap the dead child before re-spawning so we don't stack processes.
+      if (!(await inner.waitForExit(2000))) await inner.stop().catch(() => {});
+
+      const delay =
+        AUTH_RETRY_BACKOFF_MS[attempt - 1] ??
+        AUTH_RETRY_BACKOFF_MS[AUTH_RETRY_BACKOFF_MS.length - 1]!;
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, delay);
+        abortBackoff = () => {
+          clearTimeout(timer);
+          resolve();
+        };
+      });
+      abortBackoff = undefined;
+      if (stopped) return;
+
+      current = spawn();
+      if (stopped) {
+        await current.stop().catch(() => {});
+        return;
+      }
+      attempt++;
+    }
+  }
+
+  return {
+    runId: opts.runId,
+    events: stream(),
+    async stop() {
+      stopped = true;
+      abortBackoff?.();
+      await current.stop();
+    },
+    waitForExit(timeoutMs: number): Promise<boolean> {
+      return current.waitForExit(timeoutMs);
+    },
+  };
 }
 
 async function* createEventStream(

--- a/src/agent/claude/stream-json.ts
+++ b/src/agent/claude/stream-json.ts
@@ -18,13 +18,22 @@ interface ClaudeRawEvent {
   session_id?: string;
   cwd?: string;
   model?: string;
-  message?: { content?: ContentBlock[] };
+  message?: { content?: ContentBlock[]; model?: string };
   usage?: {
     input_tokens?: number;
     output_tokens?: number;
     cache_read_input_tokens?: number;
   };
   total_cost_usd?: number;
+  // `result` events carry the run outcome. On an API/auth failure the CLI
+  // still exits via a result line with is_error set (subtype stays "success"),
+  // the failing HTTP status in api_error_status, and the message in `result`.
+  is_error?: boolean;
+  api_error_status?: number;
+  result?: string;
+  // Top-level marker on a synthetic assistant turn that wraps an API error
+  // (e.g. "authentication_failed"). Its message.model is "<synthetic>".
+  error?: string;
 }
 
 export function* translateEvent(raw: unknown): Generator<AgentEvent> {
@@ -42,6 +51,12 @@ export function* translateEvent(raw: unknown): Generator<AgentEvent> {
   }
 
   if (evt.type === 'assistant' && evt.message?.content) {
+    // A synthetic assistant turn carrying an API error (e.g. 403 auth) arrives
+    // with a top-level `error` ("authentication_failed") and model
+    // "<synthetic>". Its only "content" is the error string — don't stream it
+    // as a normal reply. The trailing `result` event (is_error) carries the
+    // failure to the bridge instead, so it surfaces exactly once.
+    if (evt.error) return;
     for (const block of evt.message.content) {
       if (block.type === 'text' && typeof block.text === 'string' && block.text) {
         yield { type: 'text', delta: block.text };
@@ -80,6 +95,19 @@ export function* translateEvent(raw: unknown): Generator<AgentEvent> {
         costUsd: evt.total_cost_usd,
       };
     }
+    // is_error means the run failed (API/auth error, exceeded turns, etc.).
+    // subtype is unreliable here — a 403 still reports subtype "success" — so
+    // key off is_error and surface a real error event instead of a clean done.
+    if (evt.is_error) {
+      yield { type: 'error', message: resultErrorMessage(evt), terminationReason: 'failed' };
+      return;
+    }
     yield { type: 'done', sessionId: evt.session_id, terminationReason: 'normal' };
   }
+}
+
+function resultErrorMessage(evt: ClaudeRawEvent): string {
+  if (typeof evt.result === 'string' && evt.result.trim()) return evt.result.trim();
+  if (typeof evt.api_error_status === 'number') return `claude API error ${evt.api_error_status}`;
+  return 'claude reported an error';
 }

--- a/tests/process/claude-adapter.test.ts
+++ b/tests/process/claude-adapter.test.ts
@@ -209,6 +209,166 @@ describe('ClaudeAdapter process contract', () => {
   });
 });
 
+// How the claude CLI surfaces a 403: a synthetic assistant turn (its only
+// "content" is the error string) followed by a result line with is_error set,
+// then exit 1. Captured from a real `claude -p` run against a 403 endpoint.
+const AUTH_403_SCENARIO = {
+  lines: [
+    { type: 'system', subtype: 'init', session_id: 'sess-fail', model: '<synthetic>' },
+    {
+      type: 'assistant',
+      message: {
+        model: '<synthetic>',
+        content: [{ type: 'text', text: 'Failed to authenticate. API Error: 403 Request not allowed' }],
+      },
+      error: 'authentication_failed',
+    },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: true,
+      api_error_status: 403,
+      result: 'Failed to authenticate. API Error: 403 Request not allowed',
+      session_id: 'sess-fail',
+    },
+  ],
+  exitCode: 1,
+};
+
+const SUCCESS_SCENARIO = {
+  lines: [
+    { type: 'system', subtype: 'init', session_id: 'sess-ok', model: 'claude-sonnet' },
+    { type: 'assistant', message: { content: [{ type: 'text', text: 'hello after retry' }] } },
+    {
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      session_id: 'sess-ok',
+      usage: { input_tokens: 3, output_tokens: 4 },
+    },
+  ],
+  exitCode: 0,
+};
+
+describe('ClaudeAdapter transient auth/403 retry', () => {
+  const cleanup: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      cleanup.splice(0).map((dir) =>
+        rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 25 }),
+      ),
+    );
+  });
+
+  it('retries a transient auth/403 failure and streams the next attempt cleanly', async () => {
+    const fake = await createCountingClaude([AUTH_403_SCENARIO, SUCCESS_SCENARIO]);
+    cleanup.push(fake.dir);
+
+    const run = new ClaudeAdapter({ binary: fake.path }).run({
+      runId: 'run-retry',
+      prompt: 'hi',
+      cwd: fake.dir,
+    });
+    const events = await collect(run.events);
+
+    // The 403 must never reach the user — no error, no auth text leaked.
+    expect(events.some((e) => e.type === 'error')).toBe(false);
+    expect(events.some((e) => e.type === 'text' && e.delta.includes('authenticate'))).toBe(false);
+    expect(events.find((e) => e.type === 'text')).toEqual({
+      type: 'text',
+      delta: 'hello after retry',
+    });
+    expect(events.at(-1)).toEqual({ type: 'done', sessionId: 'sess-ok', terminationReason: 'normal' });
+
+    const invocations = await readInvocations(fake.invocationsPath);
+    expect(invocations).toHaveLength(2);
+    // The retry re-runs the caller's request fresh; it must not resume the
+    // failed attempt's throwaway session.
+    expect(invocations[1]!.argv).not.toContain('--resume');
+  }, 15_000);
+
+  it('does not retry a non-auth API error', async () => {
+    const fake = await createCountingClaude([
+      {
+        lines: [
+          { type: 'system', subtype: 'init', session_id: 's', model: 'm' },
+          {
+            type: 'result',
+            subtype: 'success',
+            is_error: true,
+            api_error_status: 500,
+            result: 'API Error: 500 Internal server error',
+            session_id: 's',
+          },
+        ],
+        exitCode: 1,
+      },
+    ]);
+    cleanup.push(fake.dir);
+
+    const events = await collect(
+      new ClaudeAdapter({ binary: fake.path }).run({ runId: 'run-500', prompt: 'hi', cwd: fake.dir })
+        .events,
+    );
+
+    expect(events.find((e) => e.type === 'error')).toMatchObject({
+      type: 'error',
+      message: 'API Error: 500 Internal server error',
+      terminationReason: 'failed',
+    });
+    expect(await readInvocations(fake.invocationsPath)).toHaveLength(1);
+  });
+
+  it('does not retry once real content has streamed, even on an auth error', async () => {
+    const fake = await createCountingClaude([
+      {
+        lines: [
+          { type: 'system', subtype: 'init', session_id: 's', model: 'm' },
+          { type: 'assistant', message: { content: [{ type: 'text', text: 'partial answer' }] } },
+          {
+            type: 'result',
+            subtype: 'success',
+            is_error: true,
+            api_error_status: 403,
+            result: 'Failed to authenticate. API Error: 403 Request not allowed',
+            session_id: 's',
+          },
+        ],
+        exitCode: 1,
+      },
+    ]);
+    cleanup.push(fake.dir);
+
+    const events = await collect(
+      new ClaudeAdapter({ binary: fake.path }).run({ runId: 'run-partial', prompt: 'hi', cwd: fake.dir })
+        .events,
+    );
+
+    expect(events.find((e) => e.type === 'text')).toEqual({ type: 'text', delta: 'partial answer' });
+    expect(events.some((e) => e.type === 'error')).toBe(true);
+    expect(await readInvocations(fake.invocationsPath)).toHaveLength(1);
+  });
+
+  it('surfaces the auth error to the user after exhausting retries', async () => {
+    const fake = await createCountingClaude([AUTH_403_SCENARIO]); // every attempt fails
+    cleanup.push(fake.dir);
+
+    const events = await collect(
+      new ClaudeAdapter({ binary: fake.path }).run({ runId: 'run-exhaust', prompt: 'hi', cwd: fake.dir })
+        .events,
+    );
+
+    expect(events.find((e) => e.type === 'error')).toMatchObject({
+      type: 'error',
+      message: 'Failed to authenticate. API Error: 403 Request not allowed',
+      terminationReason: 'failed',
+    });
+    // 1 initial attempt + MAX_AUTH_RETRIES (3) re-spawns.
+    expect(await readInvocations(fake.invocationsPath)).toHaveLength(4);
+  }, 20_000);
+});
+
 async function collect(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
   const out: AgentEvent[] = [];
   for await (const event of events) out.push(event);
@@ -273,4 +433,56 @@ async function readRecord(path: string): Promise<{
       LARKSUITE_CLI_CONFIG_DIR?: string;
     };
   };
+}
+
+interface Scenario {
+  lines: unknown[];
+  stderr?: string;
+  exitCode?: number;
+}
+
+// A fake claude that behaves differently on each spawn: invocation N runs
+// scenario N (the last scenario repeats once the list is exhausted), and every
+// spawn appends its argv to a JSONL file so tests can assert how many times —
+// and with what args — claude was re-run.
+async function createCountingClaude(scenarios: Scenario[]): Promise<{
+  path: string;
+  dir: string;
+  invocationsPath: string;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), 'claude-retry-test-'));
+  const path = join(dir, 'fake-claude.mjs');
+  const countPath = join(dir, 'count.json');
+  const invocationsPath = join(dir, 'invocations.jsonl');
+  await writeFile(
+    path,
+    [
+      '#!/usr/bin/env node',
+      'import { readFileSync, writeFileSync, appendFileSync } from "node:fs";',
+      `const countPath = ${JSON.stringify(countPath)};`,
+      `const invocationsPath = ${JSON.stringify(invocationsPath)};`,
+      `const scenarios = ${JSON.stringify(scenarios)};`,
+      'let n = 0;',
+      'try { n = JSON.parse(readFileSync(countPath, "utf8")).n; } catch {}',
+      'n += 1;',
+      'writeFileSync(countPath, JSON.stringify({ n }));',
+      'appendFileSync(invocationsPath, JSON.stringify({ attempt: n, argv: process.argv.slice(2) }) + "\\n");',
+      'const scenario = scenarios[Math.min(n - 1, scenarios.length - 1)];',
+      'for (const line of scenario.lines) console.log(JSON.stringify(line));',
+      'if (scenario.stderr) process.stderr.write(scenario.stderr);',
+      'process.exit(scenario.exitCode ?? 0);',
+    ].join('\n'),
+    'utf8',
+  );
+  await chmod(path, 0o755);
+  return { path, dir, invocationsPath };
+}
+
+async function readInvocations(path: string): Promise<{ attempt: number; argv: string[] }[]> {
+  const raw = await readFile(path, 'utf8');
+  return raw
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => JSON.parse(line) as { attempt: number; argv: string[] });
 }

--- a/tests/unit/agent/claude-stream-json.test.ts
+++ b/tests/unit/agent/claude-stream-json.test.ts
@@ -83,6 +83,46 @@ describe('Claude stream-json translator', () => {
     expect([...translateEvent({ type: 'result', session_id: 'sess-2' })][0]).not.toHaveProperty('threadId');
   });
 
+  it('emits an error (not done) when a result reports is_error', () => {
+    expect([
+      ...translateEvent({
+        type: 'result',
+        subtype: 'success',
+        is_error: true,
+        api_error_status: 403,
+        result: 'Failed to authenticate. API Error: 403 Request not allowed',
+        session_id: 'sess-403',
+        usage: { input_tokens: 0, output_tokens: 0 },
+      }),
+    ]).toEqual([
+      { type: 'usage', inputTokens: 0, outputTokens: 0, cachedInputTokens: undefined, costUsd: undefined },
+      {
+        type: 'error',
+        message: 'Failed to authenticate. API Error: 403 Request not allowed',
+        terminationReason: 'failed',
+      },
+    ]);
+  });
+
+  it('falls back to api_error_status when an errored result has no text', () => {
+    expect([...translateEvent({ type: 'result', is_error: true, api_error_status: 500 })]).toEqual([
+      { type: 'error', message: 'claude API error 500', terminationReason: 'failed' },
+    ]);
+  });
+
+  it('suppresses a synthetic auth-error assistant turn so it is not streamed as a reply', () => {
+    expect([
+      ...translateEvent({
+        type: 'assistant',
+        error: 'authentication_failed',
+        message: {
+          model: '<synthetic>',
+          content: [{ type: 'text', text: 'Failed to authenticate. API Error: 403 Request not allowed' }],
+        },
+      }),
+    ]).toEqual([]);
+  });
+
   it('ignores unknown, empty, and incomplete raw events', () => {
     expect([...translateEvent(null)]).toEqual([]);
     expect([...translateEvent({ type: 'assistant', message: { content: [{ type: 'text', text: '' }] } })]).toEqual([]);


### PR DESCRIPTION
## What

Make the Claude agent run **transparently retry transient auth/403 failures** instead of immediately dumping an error card on the user.

When the API returns `403 Request not allowed` (or `401`), the `claude -p` CLI surfaces it through `stream-json` as:

1. a `system` init event,
2. a **synthetic** assistant turn — `message.model: "<synthetic>"`, top-level `"error": "authentication_failed"`, whose only content is the text `"Failed to authenticate. API Error: 403 Request not allowed"`,
3. a `result` line with `subtype: "success"` **but** `is_error: true`, `api_error_status: 403`, and the message in `result`,
4. process exit code `1`.

(Captured from a real `claude -p hi --output-format stream-json --verbose` run against a 403 endpoint, on CLI `2.1.162`.)

Two latent problems with the current behavior:

- The synthetic error text is translated as a normal `text` event, so the bridge **streams the raw auth error to the user as if it were a reply**.
- `translateEvent` treats *any* `result` event as a clean `done` (it ignores `is_error`), so an errored run was reported as a normal completion — and `subtype` can't be used to detect it (a 403 still reports `subtype: "success"`).

## Changes

**`stream-json.ts`**
- Emit a real `error` event when `result.is_error` is set (message = `result` text, falling back to `api_error_status`). Keys off `is_error`, not `subtype`.
- Suppress the synthetic auth-error assistant turn (top-level `error` present) so it isn't streamed as a reply — the `result` event now carries the failure exactly once.

**`adapter.ts`**
- Wrap each spawn with a transparent retry layer. Each attempt's events are **buffered until real output streams** (then we commit, flush the buffer, and stream the rest live — never retrying once words are on screen), or until the attempt ends. If it ended with a transient auth error **before any output**, discard the buffered events, back off, and re-spawn.
- Auth classifier (`isTransientAuthError`): `failed to authenticate | authentication failed | authentication_failed | request not allowed | unauthorized | \b40[13]\b`. Only this class retries; everything else is reported immediately.
- Bounded: **3 retries** with **1s / 2s / 4s** backoff. The retry re-runs the caller's original request (it does **not** resume the failed attempt's throwaway session). `stop()` / `waitForExit()` delegate to the current attempt and abort an in-flight backoff.

Silent by design (a `log.warn('agent', 'auth-retry', …)` per retry) — no new `AgentEvent` type, no card/renderer changes. A user-facing "retrying…" indicator would be an easy follow-up if wanted.

## Tradeoffs (by design)

- A `403 Request not allowed` is **usually a permanent rejection** (geo-block, revoked/region-locked creds), which no amount of retrying fixes. Retry only rescues genuinely transient blips — so it's **bounded (3), backed off, and auth-only**. After the retries are exhausted the original error is surfaced to the user as before.
- **Never retries once any real output (text/thinking/tool_use/tool_result) has streamed** — we can't unsend words already shown.
- Non-auth failures (e.g. `500`, overloaded, crashes) are passed through immediately, unchanged.

## Tests

- `tests/process/claude-adapter.test.ts` — end-to-end through `ClaudeAdapter` with a counting fake binary:
  - transient 403 → retry → 2nd attempt streams cleanly (no error/auth-text leaked; 2 spawns; retry doesn't `--resume`);
  - non-auth `500` result → no retry (1 spawn);
  - auth error *after* real content streamed → no retry (1 spawn);
  - always-403 → error surfaces after exhausting retries (1 + 3 = 4 spawns).
- `tests/unit/agent/claude-stream-json.test.ts` — `result.is_error` → `error`; `api_error_status` fallback message; synthetic auth turn suppressed.

`pnpm typecheck`, `pnpm test` (494 passed), and `pnpm build` all green.

> Note: branched from this repo's `main` (not the fork's `main`, which was a few commits behind) so it applies cleanly here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
