### PR TITLE
[codex] Add per-chat model and effort overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,8 @@ If a profile was created with the wrong agent kind, stop or unregister any match
 | `/ws use <name>` | Switch to a named workspace |
 | `/ws remove <name>` | Delete a named workspace |
 | `/resume` | Resume compatible history for the same agent, working directory, and permission mode |
+| `/model [model-id\|default]` | Set or clear the current chat's model override for the active agent |
+| `/effort [level\|default]` | Set or clear the current chat's effort override. Claude Code uses `--effort` (`low`, `medium`, `high`, `xhigh`, `max`); Codex uses `model_reasoning_effort` (`low`, `medium`, `high`, `xhigh`) |
 | `/status` | Show profile, agent, working directory, session, and run state |
 | `/config` | Adjust presentation preferences and view the access panel |
 | `/invite user @name` | Allow a user to use the bot in DMs |

--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -70,6 +70,7 @@ export class ClaudeAdapter implements AgentAdapter {
     ];
     if (opts.sessionId) args.push('--resume', opts.sessionId);
     if (opts.model) args.push('--model', opts.model);
+    if (opts.effort) args.push('--effort', opts.effort);
 
     const child = spawnProcess(this.binary, args, {
       cwd: opts.cwd,
@@ -83,6 +84,7 @@ export class ClaudeAdapter implements AgentAdapter {
       hasSession: Boolean(opts.sessionId),
       promptChars: opts.prompt.length,
       model: opts.model,
+      effort: opts.effort,
     });
 
     // Listeners MUST be attached synchronously here, before we return.

--- a/src/agent/codex/adapter.ts
+++ b/src/agent/codex/adapter.ts
@@ -132,6 +132,8 @@ export class CodexAdapter implements AgentAdapter {
       cwd: opts.cwd,
       sandbox: opts.sandbox ?? this.sandbox,
       threadId: opts.threadId,
+      model: opts.model,
+      effort: opts.effort,
       images: opts.images,
       ignoreUserConfig: this.ignoreUserConfig,
       ignoreRules: this.ignoreRules,
@@ -153,6 +155,8 @@ export class CodexAdapter implements AgentAdapter {
       cwd: opts.cwd,
       hasThread: Boolean(opts.threadId),
       promptChars: opts.prompt.length,
+      model: opts.model,
+      effort: opts.effort,
       images: opts.images?.length ?? 0,
     });
 

--- a/src/agent/codex/argv.ts
+++ b/src/agent/codex/argv.ts
@@ -4,6 +4,8 @@ export interface BuildCodexArgsInput {
   cwd: string;
   sandbox: SandboxMode;
   threadId?: string;
+  model?: string;
+  effort?: string;
   images?: readonly string[];
   ignoreUserConfig?: boolean;
   ignoreRules?: boolean;
@@ -27,6 +29,10 @@ export function buildCodexArgs(input: BuildCodexArgsInput): string[] {
     'shell_environment_policy.inherit="all"',
     ...(input.ignoreUserConfig === true ? ['--ignore-user-config'] : []),
     ...(input.ignoreRules === false ? [] : ['--ignore-rules']),
+    ...(input.model ? ['--model', input.model] : []),
+    ...(input.effort
+      ? ['-c', `model_reasoning_effort=${tomlString(input.effort)}`]
+      : []),
     '--skip-git-repo-check',
     '-C',
     input.cwd,
@@ -54,4 +60,8 @@ export function buildCodexArgs(input: BuildCodexArgsInput): string[] {
     ...(imageFlags.length > 0 ? ['--'] : []),
     '-',
   ];
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value);
 }

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -34,6 +34,7 @@ export interface AgentRunOptions {
   sessionId?: string;
   threadId?: string;
   model?: string;
+  effort?: string;
   images?: readonly string[];
   sandbox?: CodexSandboxMode;
   permissionMode?: ClaudePermissionMode;

--- a/src/bot/run-flow.ts
+++ b/src/bot/run-flow.ts
@@ -143,6 +143,8 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
       policy,
       sessionId,
       threadId,
+      model: input.sessions.getModel(input.scopeId),
+      effort: input.sessions.getEffort(input.scopeId),
       images:
         input.capability.agentId === 'codex'
           ? policy.attachments

--- a/src/card/templates.ts
+++ b/src/card/templates.ts
@@ -68,6 +68,8 @@ export interface StatusInfo {
   emptySessionText?: string;
   sessionStale: boolean;
   agentName: string;
+  model?: string;
+  effort?: string;
   runtimeAccess: {
     label: string;
     value: string;
@@ -102,6 +104,8 @@ export function statusCard(info: StatusInfo): object {
     `📁 **cwd**: ${cwdLine}`,
     `🔗 **session**: ${sessionLine}`,
     `🤖 **agent**: ${escapeMd(info.agentName)}`,
+    `🧠 **model**: ${info.model ? `\`${escapeCode(info.model)}\`` : '(默认)'}`,
+    `⚙️ **effort**: ${info.effort ? `\`${escapeCode(info.effort)}\`` : '(默认)'}`,
     `🛡 **${escapeMd(info.runtimeAccess.label)}**: ${escapeMd(info.runtimeAccess.value)}`,
     `🏃 **active run**: ${info.activeRun ? 'yes' : 'no'}`,
     ...(info.activeCommentScopes && info.activeCommentScopes.length > 0
@@ -169,8 +173,14 @@ export function resumeCard(cwd: string, entries: ResumeEntry[]): object {
   return shell('🔁 恢复历史会话', elements);
 }
 
-export function helpCard(agentName = 'Agent'): object {
+export function helpCard(agentName = 'Agent', agentKind: 'claude' | 'codex' = 'claude'): object {
   const escapedAgentName = escapeMd(agentName);
+  const modelLine = agentKind === 'codex'
+    ? '- `/model [model-id|default]` — 当前 chat 的 Codex 模型覆盖（传给 `--model`）'
+    : '- `/model [model-id|default]` — 当前 chat 的 Claude 模型覆盖（传给 `--model`）';
+  const effortLine = agentKind === 'codex'
+    ? '- `/effort [low|medium|high|xhigh|default]` — 当前 chat 的 Codex 推理投入覆盖（写入 `model_reasoning_effort`）'
+    : '- `/effort [low|medium|high|xhigh|max|default]` — 当前 chat 的 Claude Code 原生 effort 覆盖（传给 `--effort`）';
   return shell('💡 使用帮助', [
     divMd(
       [
@@ -179,6 +189,8 @@ export function helpCard(agentName = 'Agent'): object {
         '- `/new` `/reset` — 清空当前 chat 的会话',
         '- `/new chat [name]` — 新建群+新会话，自动拉你进群',
         '- `/resume [N]` — 列出并恢复历史会话（最多 N 条）',
+        modelLine,
+        effortLine,
         '- `/cd <path>` — 切换工作目录（会重置 session）',
         '- `/ws list|save <name>|use <name>|remove <name>` — 工作目录',
         '- `/account` — 查看当前应用；`/account change` 换 appId/secret 并重连',

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -152,6 +152,8 @@ const handlers: Record<string, Handler> = {
   '/cd': handleCd,
   '/ws': handleWs,
   '/resume': handleResume,
+  '/model': handleModel,
+  '/effort': handleEffort,
   '/status': handleStatus,
   '/help': handleHelp,
   '/account': handleAccount,
@@ -300,6 +302,11 @@ async function handleNew(args: string, ctx: CommandContext): Promise<void> {
     return handleNewChat(rawName, ctx);
   }
 
+  const wasRunning = resetCurrentScopeSession(ctx);
+  await reply(ctx, wasRunning ? '已中断当前任务并开始新会话。' : '已开始新会话。');
+}
+
+function resetCurrentScopeSession(ctx: CommandContext): boolean {
   const wasRunning = ctx.activeRuns.interrupt(ctx.scope);
   if (ctx.sessionCatalog && ctx.sessionCatalogIdentity) {
     ctx.sessionCatalog.archiveActive({
@@ -308,7 +315,7 @@ async function handleNew(args: string, ctx: CommandContext): Promise<void> {
     });
   }
   ctx.sessions.clear(ctx.scope);
-  await reply(ctx, wasRunning ? '已中断当前任务并开始新会话。' : '已开始新会话。');
+  return wasRunning;
 }
 
 async function handleNewChat(rawName: string, ctx: CommandContext): Promise<void> {
@@ -348,6 +355,87 @@ async function handleNewChat(rawName: string, ctx: CommandContext): Promise<void
     ctx,
     `✓ 已创建群 **${created.name}**，去新群里继续。`,
   );
+}
+
+const MODEL_ARG_RE = /^[A-Za-z0-9][A-Za-z0-9._:@/+,-]*$/;
+const CLAUDE_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh', 'max'] as const;
+const CODEX_EFFORT_LEVELS = ['low', 'medium', 'high', 'xhigh'] as const;
+const CLEAR_SETTING_ARGS = new Set(['default', 'reset', 'clear', 'off']);
+
+async function handleModel(args: string, ctx: CommandContext): Promise<void> {
+  const input = args.trim();
+  const current = ctx.sessions.getModel(ctx.scope);
+  if (!input) {
+    await reply(
+      ctx,
+      `当前 model：${current ? `\`${current}\`` : '(默认)'}\n用法：\`/model <model-id>\` 或 \`/model default\`。`,
+    );
+    return;
+  }
+  const normalized = input.toLowerCase();
+  if (CLEAR_SETTING_ARGS.has(normalized)) {
+    const changed = ctx.sessions.clearModelOverride(ctx.scope);
+    if (changed) resetCurrentScopeSession(ctx);
+    await reply(ctx, changed ? '✓ 已清除当前会话的 model 覆盖，并开始新会话。' : '当前会话没有 model 覆盖。');
+    return;
+  }
+  if (!MODEL_ARG_RE.test(input)) {
+    await reply(ctx, 'model 只能包含字母、数字、`.`、`-`、`_`、`:`、`/`、`@`、`+`、`,`。');
+    return;
+  }
+  ctx.sessions.setModel(ctx.scope, input);
+  resetCurrentScopeSession(ctx);
+  await reply(ctx, `✓ 当前会话 model 已设为 \`${input}\`，下一条消息会用新模型启动。`);
+}
+
+async function handleEffort(args: string, ctx: CommandContext): Promise<void> {
+  const input = args.trim().toLowerCase();
+  const current = ctx.sessions.getEffort(ctx.scope);
+  const backend = effortBackendDescription(ctx);
+  const usage = effortUsage(ctx);
+  if (!input) {
+    await reply(
+      ctx,
+      `当前 effort：${current ? `\`${current}\`` : '(默认)'}\n用法：${usage}。\n当前后端：${backend}。`,
+    );
+    return;
+  }
+  if (CLEAR_SETTING_ARGS.has(input)) {
+    const changed = ctx.sessions.clearEffortOverride(ctx.scope);
+    if (changed) resetCurrentScopeSession(ctx);
+    await reply(ctx, changed ? '✓ 已清除当前会话的 effort 覆盖，并开始新会话。' : '当前会话没有 effort 覆盖。');
+    return;
+  }
+  if (!effortLevels(ctx).includes(input)) {
+    const note = ctx.controls.profileConfig.agentKind === 'claude' && input === 'ultracode'
+      ? '\n`ultracode` 是 xhigh + workflows 的组合模式，不是 Claude Code `--effort` 的合法值。'
+      : '';
+    await reply(ctx, `${backend} 可选值：${formatEffortLevels(ctx)}。${note}`);
+    return;
+  }
+  ctx.sessions.setEffort(ctx.scope, input);
+  resetCurrentScopeSession(ctx);
+  await reply(ctx, `✓ 当前会话 effort 已设为 \`${input}\`（${backend}），下一条消息会用新设置启动。`);
+}
+
+function effortLevels(ctx: CommandContext): readonly string[] {
+  return ctx.controls.profileConfig.agentKind === 'codex'
+    ? CODEX_EFFORT_LEVELS
+    : CLAUDE_EFFORT_LEVELS;
+}
+
+function formatEffortLevels(ctx: CommandContext): string {
+  return effortLevels(ctx).map((level) => `\`${level}\``).join('、');
+}
+
+function effortUsage(ctx: CommandContext): string {
+  return `\`/effort ${effortLevels(ctx).join('|')}\` 或 \`/effort default\``;
+}
+
+function effortBackendDescription(ctx: CommandContext): string {
+  return ctx.controls.profileConfig.agentKind === 'codex'
+    ? 'Codex `model_reasoning_effort`'
+    : 'Claude Code `--effort`';
 }
 
 async function handleCd(args: string, ctx: CommandContext): Promise<void> {
@@ -761,6 +849,8 @@ async function handleStatus(_args: string, ctx: CommandContext): Promise<void> {
     emptySessionText: isCodex ? '(未建立)' : undefined,
     sessionStale: !isCodex && Boolean(cwd && sess && sess.cwd !== cwd),
     agentName: ctx.agent.displayName,
+    model: ctx.sessions.getModel(ctx.scope),
+    effort: ctx.sessions.getEffort(ctx.scope),
     runtimeAccess: runtimeAccessStatus(ctx.controls.profileConfig),
     activeRun: Boolean(ctx.activeRuns.get(ctx.scope)),
     activeCommentScopes: ctx.activeRuns.scopes().filter((scope) => scope.startsWith('comment:')),
@@ -1272,7 +1362,7 @@ function formatDoctorEchoStatus(echoText: string, state: RunState): string {
 }
 
 async function handleHelp(_args: string, ctx: CommandContext): Promise<void> {
-  const card = helpCard(ctx.agent.displayName);
+  const card = helpCard(ctx.agent.displayName, ctx.controls.profileConfig.agentKind);
   await ctx.channel.send(ctx.msg.chatId, { card }, { replyTo: ctx.msg.messageId });
 }
 

--- a/src/runtime/run-executor.ts
+++ b/src/runtime/run-executor.ts
@@ -21,6 +21,7 @@ export interface SubmitRunInput {
   sessionId?: string;
   threadId?: string;
   model?: string;
+  effort?: string;
   images?: readonly string[];
   stopGraceMs?: number;
   nowait?: boolean;
@@ -100,6 +101,7 @@ export class RunExecutor {
       sessionId: input.sessionId,
       threadId: input.threadId,
       model: input.model,
+      effort: input.effort,
       images: input.images,
       sandbox: input.policy.sandbox,
       permissionMode: input.policy.permissionMode,

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -14,6 +14,10 @@ export interface SessionEntry {
    * scope, undefined = follow global default. Session resets preserve this
    * scope preference while removing the resumable session id/cwd. */
   idleTimeoutMinutes?: number;
+  /** Per-scope model override passed to the local CLI on the next run. */
+  model?: string;
+  /** Per-scope effort override passed to the local CLI on the next run. */
+  effort?: string;
 }
 
 type SessionMap = Record<string, SessionEntry>;
@@ -43,13 +47,23 @@ export class SessionStore {
         const cwd = typeof entry.cwd === 'string' ? entry.cwd : undefined;
         const idleTimeoutMinutes =
           typeof entry.idleTimeoutMinutes === 'number' ? entry.idleTimeoutMinutes : undefined;
+        const model = typeof entry.model === 'string' && entry.model.trim()
+          ? entry.model.trim()
+          : undefined;
+        const effort = typeof entry.effort === 'string' && entry.effort.trim()
+          ? entry.effort.trim()
+          : undefined;
         const hasSession = sessionId !== undefined && cwd !== undefined;
-        if (!hasSession && idleTimeoutMinutes === undefined) continue;
+        if (!hasSession && idleTimeoutMinutes === undefined && model === undefined && effort === undefined) {
+          continue;
+        }
         this.data[chatId] = {
           ...(sessionId !== undefined ? { sessionId } : {}),
           ...(cwd !== undefined ? { cwd } : {}),
           updatedAt: entry.updatedAt,
           ...(idleTimeoutMinutes !== undefined ? { idleTimeoutMinutes } : {}),
+          ...(model !== undefined ? { model } : {}),
+          ...(effort !== undefined ? { effort } : {}),
         };
       }
     } catch (err) {
@@ -85,6 +99,8 @@ export class SessionStore {
       ...(prev?.idleTimeoutMinutes !== undefined
         ? { idleTimeoutMinutes: prev.idleTimeoutMinutes }
         : {}),
+      ...(prev?.model !== undefined ? { model: prev.model } : {}),
+      ...(prev?.effort !== undefined ? { effort: prev.effort } : {}),
     };
     this.schedulePersist();
   }
@@ -92,15 +108,79 @@ export class SessionStore {
   clear(chatId: string): void {
     const prev = this.data[chatId];
     if (!prev) return;
-    if (prev.idleTimeoutMinutes !== undefined) {
+    if (
+      prev.idleTimeoutMinutes !== undefined ||
+      prev.model !== undefined ||
+      prev.effort !== undefined
+    ) {
       this.data[chatId] = {
-        idleTimeoutMinutes: prev.idleTimeoutMinutes,
         updatedAt: Date.now(),
+        ...(prev.idleTimeoutMinutes !== undefined ? { idleTimeoutMinutes: prev.idleTimeoutMinutes } : {}),
+        ...(prev.model !== undefined ? { model: prev.model } : {}),
+        ...(prev.effort !== undefined ? { effort: prev.effort } : {}),
       };
     } else {
       delete this.data[chatId];
     }
     this.schedulePersist();
+  }
+
+  getModel(chatId: string): string | undefined {
+    return this.data[chatId]?.model;
+  }
+
+  setModel(chatId: string, model: string): void {
+    const value = model.trim();
+    if (!value) {
+      this.clearModelOverride(chatId);
+      return;
+    }
+    const prev = this.data[chatId];
+    this.data[chatId] = {
+      ...(prev ?? { updatedAt: Date.now() }),
+      model: value,
+      updatedAt: Date.now(),
+    };
+    this.schedulePersist();
+  }
+
+  clearModelOverride(chatId: string): boolean {
+    const prev = this.data[chatId];
+    if (!prev || prev.model === undefined) return false;
+    const { model: _, ...rest } = prev;
+    this.data[chatId] = { ...rest, updatedAt: Date.now() };
+    this.pruneEmptyPreferenceOnlyEntry(chatId);
+    this.schedulePersist();
+    return true;
+  }
+
+  getEffort(chatId: string): string | undefined {
+    return this.data[chatId]?.effort;
+  }
+
+  setEffort(chatId: string, effort: string): void {
+    const value = effort.trim();
+    if (!value) {
+      this.clearEffortOverride(chatId);
+      return;
+    }
+    const prev = this.data[chatId];
+    this.data[chatId] = {
+      ...(prev ?? { updatedAt: Date.now() }),
+      effort: value,
+      updatedAt: Date.now(),
+    };
+    this.schedulePersist();
+  }
+
+  clearEffortOverride(chatId: string): boolean {
+    const prev = this.data[chatId];
+    if (!prev || prev.effort === undefined) return false;
+    const { effort: _, ...rest } = prev;
+    this.data[chatId] = { ...rest, updatedAt: Date.now() };
+    this.pruneEmptyPreferenceOnlyEntry(chatId);
+    this.schedulePersist();
+    return true;
   }
 
   /** Per-scope idle-timeout override. `undefined` means no override set. */
@@ -126,6 +206,7 @@ export class SessionStore {
     if (!prev || prev.idleTimeoutMinutes === undefined) return false;
     const { idleTimeoutMinutes: _, ...rest } = prev;
     this.data[chatId] = { ...rest, updatedAt: Date.now() };
+    this.pruneEmptyPreferenceOnlyEntry(chatId);
     this.schedulePersist();
     return true;
   }
@@ -144,5 +225,19 @@ export class SessionStore {
       .catch((err: unknown) => {
         log.fail('session', err, { step: 'persist' });
       });
+  }
+
+  private pruneEmptyPreferenceOnlyEntry(chatId: string): void {
+    const entry = this.data[chatId];
+    if (!entry) return;
+    if (
+      entry.sessionId === undefined &&
+      entry.cwd === undefined &&
+      entry.idleTimeoutMinutes === undefined &&
+      entry.model === undefined &&
+      entry.effort === undefined
+    ) {
+      delete this.data[chatId];
+    }
   }
 }

--- a/tests/integration/bot/im-run-flow.test.ts
+++ b/tests/integration/bot/im-run-flow.test.ts
@@ -50,6 +50,8 @@ describe('IM run flow', () => {
     const workspaceRealpath = await realpath(h.tmp.workspace);
     h.workspaces.setCwd('chat-1', h.tmp.workspace);
     h.sessions.set('chat-1', 'sess-1', workspaceRealpath);
+    h.sessions.setModel('chat-1', 'sonnet');
+    h.sessions.setEffort('chat-1', 'high');
 
     const result = await startRunFlow({
       scopeId: 'chat-1',
@@ -73,6 +75,8 @@ describe('IM run flow', () => {
       runId: 'run-1',
       cwd: workspaceRealpath,
       sessionId: 'sess-1',
+      model: 'sonnet',
+      effort: 'high',
     });
   });
 

--- a/tests/integration/commands/commands-v1.test.ts
+++ b/tests/integration/commands/commands-v1.test.ts
@@ -31,6 +31,10 @@ interface Harness {
   run(content: string, overrides?: RunOverrides): Promise<boolean>;
 }
 
+interface HarnessOptions {
+  agentKind?: 'claude' | 'codex';
+}
+
 const cleanups: Array<() => Promise<void>> = [];
 
 describe('Bridge command contracts', () => {
@@ -238,6 +242,76 @@ describe('Bridge command contracts', () => {
     expect(status).toContain(jsonStringFragment(await realpath(h.tmp.workspace)));
   });
 
+  it('sets and clears per-scope model and effort overrides', async () => {
+    const h = await createHarness();
+
+    await expect(h.run('/model sonnet')).resolves.toBe(true);
+    expect(lastMarkdown(h.channel)).toContain('model 已设为 `sonnet`');
+    expect(h.sessions.getModel('chat-1')).toBe('sonnet');
+
+    await expect(h.run('/effort high')).resolves.toBe(true);
+    expect(lastMarkdown(h.channel)).toContain('effort 已设为 `high`');
+    expect(h.sessions.getEffort('chat-1')).toBe('high');
+
+    await expect(h.run('/model')).resolves.toBe(true);
+    expect(lastMarkdown(h.channel)).toContain('`sonnet`');
+
+    await expect(h.run('/effort')).resolves.toBe(true);
+    expect(lastMarkdown(h.channel)).toContain('`high`');
+
+    await expect(h.run('/model default')).resolves.toBe(true);
+    expect(h.sessions.getModel('chat-1')).toBeUndefined();
+
+    await expect(h.run('/effort default')).resolves.toBe(true);
+    expect(h.sessions.getEffort('chat-1')).toBeUndefined();
+  });
+
+  it('uses agent-specific effort levels and help text', async () => {
+    const claude = await createHarness({ agentKind: 'claude' });
+
+    await expect(claude.run('/effort max')).resolves.toBe(true);
+    expect(claude.sessions.getEffort('chat-1')).toBe('max');
+
+    await expect(claude.run('/effort ultracode')).resolves.toBe(true);
+    expect(lastMarkdown(claude.channel)).toContain('不是 Claude Code `--effort` 的合法值');
+    expect(claude.sessions.getEffort('chat-1')).toBe('max');
+
+    await expect(claude.run('/help')).resolves.toBe(true);
+    const claudeHelp = JSON.stringify(lastContent(claude.channel));
+    expect(claudeHelp).toContain('Claude Code 原生 effort');
+    expect(claudeHelp).toContain('--effort');
+    expect(claudeHelp).not.toContain('model_reasoning_effort');
+
+    const codex = await createHarness({ agentKind: 'codex' });
+
+    await expect(codex.run('/effort xhigh')).resolves.toBe(true);
+    expect(codex.sessions.getEffort('chat-1')).toBe('xhigh');
+
+    await expect(codex.run('/effort max')).resolves.toBe(true);
+    expect(lastMarkdown(codex.channel)).toContain('Codex `model_reasoning_effort` 可选值');
+    expect(codex.sessions.getEffort('chat-1')).toBe('xhigh');
+
+    await expect(codex.run('/help')).resolves.toBe(true);
+    const codexHelp = JSON.stringify(lastContent(codex.channel));
+    expect(codexHelp).toContain('model_reasoning_effort');
+    expect(codexHelp).toContain('/effort [low|medium|high|xhigh|default]');
+    expect(codexHelp).not.toContain('/effort [low|medium|high|xhigh|max|default]');
+  });
+
+  it('shows per-scope model and effort overrides in /status', async () => {
+    const h = await createHarness();
+    h.sessions.setModel('chat-1', 'sonnet');
+    h.sessions.setEffort('chat-1', 'high');
+
+    await expect(h.run('/status')).resolves.toBe(true);
+
+    const status = JSON.stringify(lastContent(h.channel));
+    expect(status).toContain('**model**');
+    expect(status).toContain('sonnet');
+    expect(status).toContain('**effort**');
+    expect(status).toContain('high');
+  });
+
   it('shows workspace paths in group-visible /status replies', async () => {
     const h = await createHarness();
 
@@ -313,7 +387,7 @@ describe('Bridge command contracts', () => {
   });
 });
 
-async function createHarness(): Promise<Harness> {
+async function createHarness(options: HarnessOptions = {}): Promise<Harness> {
   const tmp = await createTmpProfile('commands-v1-');
   const channel = createFakeChannel();
   const sessions = new SessionStore(join(tmp.profile, 'sessions.json'));
@@ -321,11 +395,12 @@ async function createHarness(): Promise<Harness> {
   const activeRuns = new ActiveRuns();
   const agent = createFakeAgent();
   const workspaceRealpath = await realpath(tmp.workspace);
-  const profileConfig = appConfig(workspaceRealpath);
+  const agentKind = options.agentKind ?? 'claude';
+  const profileConfig = appConfig(workspaceRealpath, agentKind);
   const configPath = join(tmp.root, 'config.json');
-  await saveRootConfig(createRootConfig('claude', profileConfig), configPath);
+  await saveRootConfig(createRootConfig(agentKind, profileConfig), configPath);
   const controls = {
-    profile: 'claude',
+    profile: agentKind,
     profileConfig,
     botOwnerId: 'ou-owner',
     ownerRefreshState: 'ok',
@@ -368,13 +443,14 @@ async function createHarness(): Promise<Harness> {
   return { tmp, channel, sessions, workspaces, activeRuns, agent, controls, run };
 }
 
-function appConfig(defaultWorkspace: string): ProfileConfig {
+function appConfig(defaultWorkspace: string, agentKind: 'claude' | 'codex' = 'claude'): ProfileConfig {
   const config = createDefaultProfileConfig({
-    agentKind: 'claude',
+    agentKind,
     accounts: { app: { id: 'app-id', secret: 'secret', tenant: 'feishu' } },
     access: { admins: ['ou-admin'] },
     sandbox: { defaultMode: 'read-only', maxMode: 'workspace-write' },
     preferences: { maxConcurrentRuns: 2 },
+    ...(agentKind === 'codex' ? { codex: { binaryPath: 'codex' } } : {}),
   });
   config.workspaces.default = defaultWorkspace;
   return config;

--- a/tests/process/claude-adapter.test.ts
+++ b/tests/process/claude-adapter.test.ts
@@ -100,7 +100,7 @@ describe('ClaudeAdapter process contract', () => {
     });
   });
 
-  it('passes resume and model after the base CLI contract', async () => {
+  it('passes resume, model, and effort after the base CLI contract', async () => {
     const fake = await createFakeClaude({
       lines: [{ type: 'result', session_id: 'sess-resumed' }],
     });
@@ -112,6 +112,7 @@ describe('ClaudeAdapter process contract', () => {
       cwd: fake.dir,
       sessionId: 'sess-old',
       model: 'sonnet',
+      effort: 'high',
     });
 
     expect(await collect(run.events)).toEqual([
@@ -119,7 +120,14 @@ describe('ClaudeAdapter process contract', () => {
     ]);
     const record = await readRecord(fake.recordPath);
 
-    expect(record.argv.slice(-4)).toEqual(['--resume', 'sess-old', '--model', 'sonnet']);
+    expect(record.argv.slice(-6)).toEqual([
+      '--resume',
+      'sess-old',
+      '--model',
+      'sonnet',
+      '--effort',
+      'high',
+    ]);
     expect(record.argv[6]).toBe('bypassPermissions');
   });
 

--- a/tests/process/codex-adapter.test.ts
+++ b/tests/process/codex-adapter.test.ts
@@ -147,7 +147,7 @@ describe('CodexAdapter process contract', () => {
     expect(record.env.CODEX_HOME).toBeUndefined();
   });
 
-  it('passes image paths and resume thread through the Codex argv contract', async () => {
+  it('passes image paths, resume thread, model, and effort through the Codex argv contract', async () => {
     const fake = await createFakeCodex({
       lines: [{ type: 'turn.completed' }],
     });
@@ -164,6 +164,8 @@ describe('CodexAdapter process contract', () => {
       prompt: 'continue',
       cwd,
       threadId: 'thread-old',
+      model: 'gpt-5.5',
+      effort: 'xhigh',
       images: [image],
     });
 
@@ -176,6 +178,8 @@ describe('CodexAdapter process contract', () => {
         cwd,
         sandbox: 'workspace-write',
         threadId: 'thread-old',
+        model: 'gpt-5.5',
+        effort: 'xhigh',
         images: [image],
       }),
     );

--- a/tests/unit/agent/codex-argv.test.ts
+++ b/tests/unit/agent/codex-argv.test.ts
@@ -118,4 +118,32 @@ describe('Codex argv contract', () => {
     ).toContain('--ignore-user-config');
   });
 
+  it('passes model and effort overrides as Codex CLI flags', () => {
+    expect(
+      buildCodexArgs({
+        cwd: '/repo',
+        sandbox: 'danger-full-access',
+        model: 'gpt-5.5',
+        effort: 'xhigh',
+      }),
+    ).toEqual([
+      'exec',
+      '--json',
+      '--sandbox',
+      'danger-full-access',
+      '-c',
+      'approval_policy="never"',
+      '-c',
+      'shell_environment_policy.inherit="all"',
+      '--ignore-rules',
+      '--model',
+      'gpt-5.5',
+      '-c',
+      'model_reasoning_effort="xhigh"',
+      '--skip-git-repo-check',
+      '-C',
+      '/repo',
+      '-',
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
- add /model and /effort commands that persist per chat scope and reset the active session when changed
- pass model/effort overrides through to Claude Code and Codex using each agent's native mechanism
- show model/effort in /status and document agent-specific effort levels in help/README

## Notes
- Claude Code receives --model and --effort; supported effort levels are low/medium/high/xhigh/max.
- Codex receives --model plus -c model_reasoning_effort=...; current bundled Codex catalog supports low/medium/high/xhigh.
- ultracode is not treated as a Claude --effort value because the local Claude CLI rejects it; it can be modeled later as a separate workflow/mode command.

## Tests
- npm run typecheck
- npm test
- npm run build
