### PR TITLE
feat: support non-TTY bootstrap — emit QR URL to stderr for agent environments

### DIFF
--- a/src/bot/wizard.ts
+++ b/src/bot/wizard.ts
@@ -8,6 +8,15 @@ export async function runRegistrationWizard(): Promise<AppConfig> {
   const result = await registerApp({
     source: 'lark-channel-bridge',
     onQRCodeReady: (info) => {
+      if (!process.stdout.isTTY) {
+        console.error(
+          JSON.stringify({
+            type: 'qr_ready',
+            url: info.url,
+            expire_in: info.expireIn,
+          }),
+        );
+      }
       console.log('请用飞书 App 扫描以下二维码完成应用创建：\n');
       qrcode.generate(info.url, { small: true });
       const mins = Math.max(1, Math.round(info.expireIn / 60));

--- a/src/runtime/profile-runtime.ts
+++ b/src/runtime/profile-runtime.ts
@@ -429,11 +429,8 @@ async function migrateV1ToV2WithActiveBridgeHandling(
 async function resolveBootstrapAppConfig(opts: ResolveProfileRuntimeOptions): Promise<AppConfig> {
   if (!opts.appId) {
     if (!isInteractiveTerminal()) {
-      throw new Error(
-        '当前没有配置，非交互模式无法完成扫码创建应用。' +
-          '请先在终端运行 `lark-channel-bridge run` 完成首次初始化，' +
-          '或传入 --app-id 和 --app-secret。',
-      );
+      // Agent environments can surface the wizard URL from stderr and keep polling.
+      return runRegistrationWizard();
     }
     return runRegistrationWizard();
   }


### PR DESCRIPTION
## Problem

When running `lark-channel-bridge` from agent environments (Hermes, Claude Code, CI pipelines), `process.stdout.isTTY` is `false`. The current code throws immediately in `resolveBootstrapAppConfig`:

```ts
if (!isInteractiveTerminal()) {
  throw new Error('当前没有配置，非交互模式无法完成扫码创建应用...')
}
```

This makes first-run app registration impossible without a physical terminal session — a blocker for agent-driven deployments.

## Solution

Two minimal changes, no new dependencies:

**`src/runtime/profile-runtime.ts`** — remove the throw, fall through to `runRegistrationWizard()`  
**`src/bot/wizard.ts`** — in `onQRCodeReady`, write a JSON line to stderr when stdout is not a TTY:

```json
{"type":"qr_ready","url":"https://...","expire_in":300}
```

The agent reads this JSON from stderr, forwards the URL to the user (e.g. as a chat message), and waits. Once the user scans, the wizard completes and returns the `AppConfig` as normal.

This mirrors the pattern used by `lark-cli auth login` in headless environments.

## Behaviour

| Scenario | Before | After |
|---|---|---|
| TTY terminal | Interactive wizard with QR in terminal | Unchanged |
| Non-TTY (agent/CI) | ❌ Throws immediately | ✅ Wizard runs; QR URL emitted to stderr as JSON |

## Testing

- `pnpm build` passes
- TTY interactive flow unchanged (guarded with `!process.stdout.isTTY`)
- Change is 11 lines added, 5 removed