### PR TITLE
fix: respect LARK_CHANNEL_CLAUDE_BIN at runtime

### DIFF
--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -434,7 +434,10 @@ export function createRuntimeAgent(
       larkChannel,
     });
   }
-  return new ClaudeAdapter({ larkChannel });
+  return new ClaudeAdapter({
+    binary: process.env.LARK_CHANNEL_CLAUDE_BIN ?? 'claude',
+    larkChannel,
+  });
 }
 
 /**


### PR DESCRIPTION
## 问题

设置 `LARK_CHANNEL_CLAUDE_BIN` 环境变量后并不生效——实际启动 agent 时仍然使用硬编码的 `claude`。

根因：`createRuntimeAgent` 构造 `ClaudeAdapter` 时没有传 `binary`，于是落到 adapter 内部默认值 `'claude'`（`adapter.ts:34`）。该环境变量此前只在 **agent 检测** 阶段被读取（`agent-detection.ts:49`），所以检测能认出，真正运行时却被忽略。

## 改动

在 `createRuntimeAgent` 里把环境变量透传给 `ClaudeAdapter`，与 `LARK_CHANNEL_CODEX_BIN` 流入 codex 路径（`profile-runtime.ts:91`）的方式保持一致。同时用 `??` 与检测逻辑写法统一。

```ts
return new ClaudeAdapter({
  binary: process.env.LARK_CHANNEL_CLAUDE_BIN ?? 'claude',
  larkChannel,
});
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)