### PR TITLE
Add registry-backed card callbacks

### DIFF
--- a/src/agent/bridge-system-prompt.ts
+++ b/src/agent/bridge-system-prompt.ts
@@ -67,12 +67,12 @@ export const BRIDGE_SYSTEM_PROMPT = `# lark-channel-bridge 运行约定
    \`lark-cli im send-card --chat-id <chat_id> --card '<json>'\`
 2. 卡片用 CardKit 2.0 schema（\`schema: "2.0"\`）。
 3. **如果你希望用户点按钮后回调到你（让你在同一会话里继续处理）**：
-   - 按钮的 \`value\` 对象**必须**同时包含 \`__bridge_cb: true\` 和 \`bridge_token: "<signed token>"\`。
-   - \`bridge_token\` 必须由 bridge-aware 的 lark-cli 回调签名能力生成；不要猜测、伪造、复用或手写 token。
-   - 如果当前 lark-cli 不能生成 \`bridge_token\`，不要发送回调按钮。改成普通展示卡，让用户用文字回复选择。
+   - 先运行 \`lark-channel-bridge callback create --action agent_callback\`，从 JSON 输出里取 \`callback_id\`。
+   - 按钮的 \`value\` 对象**必须**同时包含 \`__bridge_cb: true\` 和 \`callback_id: \"<id>\"\`。
+   - \`callback_id\` 是当前 run / chat / 操作者 / 权限策略绑定的一次性 id；不要猜测、复用或手写 id。
    - 同时可以塞任意其它字段，作为你需要在回调时记住的状态（比如 \`choice\`、\`ticket_id\`）。
-4. 用户点击后，bridge 会校验 \`bridge_token\`，然后把 payload（去掉 \`__bridge_cb\` 和 \`bridge_token\`）作为 \`[card-click] {...}\` 消息发回给你；你的 session 自动续上，能看到自己上轮发了什么卡。
-5. **如果只是展示卡（不需要回调）**，不要加 \`__bridge_cb\` 或 \`bridge_token\`，否则点击会被当成回调并要求签名。
+4. 用户点击后，bridge 会校验并消费 \`callback_id\`，然后把 payload（去掉 \`__bridge_cb\` 和 \`callback_id\`）作为 \`[card-click] {...}\` 消息发回给你；你的 session 自动续上，能看到自己上轮发了什么卡。
+5. **如果只是展示卡（不需要回调）**，不要加 \`__bridge_cb\` 或 \`callback_id\`，否则点击会被当成回调并要求登记。
 
 示例 button：
 \`\`\`json
@@ -83,7 +83,7 @@ export const BRIDGE_SYSTEM_PROMPT = `# lark-channel-bridge 运行约定
     "type": "callback",
     "value": {
       "__bridge_cb": true,
-      "bridge_token": "SIGNED_TOKEN_FROM_LARK_CLI",
+      "callback_id": "CALLBACK_ID_FROM_BRIDGE",
       "choice": "a"
     }
   }]

--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -73,7 +73,13 @@ export class ClaudeAdapter implements AgentAdapter {
 
     const child = spawnProcess(this.binary, args, {
       cwd: opts.cwd,
-      env: mergeProcessEnv(process.env, buildLarkChannelEnv(this.larkChannel)),
+      env: mergeProcessEnv(
+        process.env,
+        buildLarkChannelEnv(
+          this.larkChannel,
+          opts.callbackContext ? { runId: opts.runId, ...opts.callbackContext } : undefined,
+        ),
+      ),
       stdio: ['ignore', 'pipe', 'pipe'],
     }) as ClaudeChild;
 

--- a/src/agent/codex/adapter.ts
+++ b/src/agent/codex/adapter.ts
@@ -101,7 +101,10 @@ export class CodexAdapter implements AgentAdapter {
       ignoreUserConfig: this.ignoreUserConfig,
       ignoreRules: this.ignoreRules,
     });
-    const envOverrides: NodeJS.ProcessEnv = buildLarkChannelEnv(this.larkChannel);
+    const envOverrides: NodeJS.ProcessEnv = buildLarkChannelEnv(
+      this.larkChannel,
+      opts.callbackContext ? { runId: opts.runId, ...opts.callbackContext } : undefined,
+    );
     if (this.codexHome) {
       envOverrides.CODEX_HOME = this.codexHome;
     } else if (!this.inheritCodexHome) {

--- a/src/agent/lark-channel-env.ts
+++ b/src/agent/lark-channel-env.ts
@@ -8,7 +8,18 @@ export interface LarkChannelEnvContext {
   larkCliSourceConfigFile?: string;
 }
 
-export function buildLarkChannelEnv(context?: LarkChannelEnvContext): NodeJS.ProcessEnv {
+export interface LarkChannelCallbackEnvContext {
+  runId: string;
+  scope: string;
+  chatId: string;
+  operatorOpenId: string;
+  policyFingerprint: string;
+}
+
+export function buildLarkChannelEnv(
+  context?: LarkChannelEnvContext,
+  callback?: LarkChannelCallbackEnvContext,
+): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
     LARK_CHANNEL: '1',
   };
@@ -26,6 +37,14 @@ export function buildLarkChannelEnv(context?: LarkChannelEnvContext): NodeJS.Pro
 
   const larkCliConfigDir = nonEmpty(context?.larkCliConfigDir);
   if (larkCliConfigDir) env.LARKSUITE_CLI_CONFIG_DIR = larkCliConfigDir;
+
+  if (callback) {
+    env.LARK_CHANNEL_RUN_ID = callback.runId;
+    env.LARK_CHANNEL_SCOPE = callback.scope;
+    env.LARK_CHANNEL_CHAT_ID = callback.chatId;
+    env.LARK_CHANNEL_OPERATOR_OPEN_ID = callback.operatorOpenId;
+    env.LARK_CHANNEL_POLICY_FINGERPRINT = callback.policyFingerprint;
+  }
 
   return env;
 }

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -45,6 +45,12 @@ export interface AgentRunOptions {
    * are adapter-specific.
   */
   stopGraceMs?: number;
+  callbackContext?: {
+    scope: string;
+    chatId: string;
+    operatorOpenId: string;
+    policyFingerprint: string;
+  };
 }
 
 export interface AgentRun {

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -16,6 +16,7 @@ import type { AgentAdapter, AgentEvent } from '../agent/types';
 import { handleCardAction } from '../card/dispatcher';
 import { CallbackAuth } from '../card/callback-auth';
 import { CallbackNonceStore } from '../card/callback-store';
+import { CallbackRegistryStore } from '../card/callback-registry';
 import { renderCard } from '../card/run-renderer';
 import {
   finalizeIfRunning,
@@ -188,7 +189,10 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
   const callbackNonceStore = deps.appPaths?.mediaDir
     ? new CallbackNonceStore(join(dirname(deps.appPaths.mediaDir), 'callback-nonces.json'))
     : undefined;
-  await callbackNonceStore?.load();
+  const callbackRegistry = deps.appPaths?.mediaDir
+    ? new CallbackRegistryStore(join(dirname(deps.appPaths.mediaDir), 'callback-registry.json'))
+    : undefined;
+  await Promise.all([callbackNonceStore?.load(), callbackRegistry?.load()]);
   const callbackAuth = callbackNonceStore
     ? new CallbackAuth({
         keys: [{ version: 1, secret: appSecret }],
@@ -318,6 +322,7 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
           pending,
           chatModeCache,
           callbackAuth,
+          callbackRegistry,
           callbackPolicyFingerprintForScope: (scope) => activePolicyFingerprints.get(scope),
         });
       }).catch((err) => log.fail('cardAction', err));
@@ -427,6 +432,7 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
         sessions.flush(),
         sessionCatalog?.flush(),
         callbackNonceStore?.flush(),
+        callbackRegistry?.flush(),
         workspaces.flush(),
       ]);
       if (stopAllResult.status === 'rejected') {

--- a/src/bot/run-flow.ts
+++ b/src/bot/run-flow.ts
@@ -151,6 +151,16 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
               .filter((path): path is string => Boolean(path))
           : undefined,
       stopGraceMs: input.stopGraceMs,
+      ...(input.scope.chatId
+        ? {
+            callbackContext: {
+              scope: input.scopeId,
+              chatId: input.scope.chatId,
+              operatorOpenId: input.scope.actorId,
+              policyFingerprint: policy.policyFingerprint,
+            },
+          }
+        : {}),
       observability: input.observability,
     });
   } catch (err) {

--- a/src/card/callback-registry.ts
+++ b/src/card/callback-registry.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { log } from '../core/logger';
+import { writeFileAtomic } from '../platform/atomic-write';
+
+export interface CallbackRegistrationInput {
+  runId: string;
+  scope: string;
+  chatId: string;
+  operatorOpenId: string;
+  action: string;
+  policyFingerprint: string;
+  ttlMs: number;
+}
+
+export interface CallbackRegistration {
+  id: string;
+  runId: string;
+  scope: string;
+  chatId: string;
+  operatorOpenId: string;
+  action: string;
+  policyFingerprint: string;
+  expiresAt: number;
+  state: 'active' | 'used' | 'revoked';
+}
+
+export type CallbackRegistryVerifyResult =
+  | { ok: true; registration: CallbackRegistration }
+  | {
+      ok: false;
+      reason:
+        | 'missing'
+        | 'expired'
+        | 'context-mismatch'
+        | 'used'
+        | 'revoked'
+        | 'malformed';
+    };
+
+export interface CallbackRegistryExpected {
+  scope: string;
+  chatId: string;
+  operatorOpenId: string;
+  action: string;
+}
+
+export class CallbackRegistryStore {
+  private readonly path: string;
+  private readonly now: () => number;
+  private readonly createId: () => string;
+  private registrations = new Map<string, CallbackRegistration>();
+  private saving: Promise<void> = Promise.resolve();
+
+  constructor(path: string, opts: { now?: () => number; createId?: () => string } = {}) {
+    this.path = path;
+    this.now = opts.now ?? Date.now;
+    this.createId = opts.createId ?? (() => randomUUID());
+  }
+
+  async load(): Promise<void> {
+    try {
+      const raw = JSON.parse(await readFile(this.path, 'utf8')) as unknown;
+      if (!raw || typeof raw !== 'object') return;
+      this.registrations.clear();
+      for (const [id, value] of Object.entries(raw as Record<string, unknown>)) {
+        const registration = parseRegistration(id, value);
+        if (registration) this.registrations.set(id, registration);
+      }
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return;
+      log.fail('callback-registry', err, { step: 'load' });
+    }
+  }
+
+  async register(input: CallbackRegistrationInput): Promise<CallbackRegistration> {
+    await this.load();
+    const id = this.createId();
+    const registration: CallbackRegistration = {
+      id,
+      runId: input.runId,
+      scope: input.scope,
+      chatId: input.chatId,
+      operatorOpenId: input.operatorOpenId,
+      action: input.action,
+      policyFingerprint: input.policyFingerprint,
+      expiresAt: this.now() + input.ttlMs,
+      state: 'active',
+    };
+    this.registrations.set(id, registration);
+    this.pruneExpired();
+    await this.persist();
+    return registration;
+  }
+
+  async consume(
+    id: string,
+    expected: CallbackRegistryExpected,
+  ): Promise<CallbackRegistryVerifyResult> {
+    if (!id || id.length > 200) return { ok: false, reason: 'malformed' };
+    await this.load();
+    const registration = this.registrations.get(id);
+    if (!registration) return { ok: false, reason: 'missing' };
+    if (registration.state === 'used') return { ok: false, reason: 'used' };
+    if (registration.state === 'revoked') return { ok: false, reason: 'revoked' };
+    if (registration.expiresAt <= this.now()) {
+      registration.state = 'revoked';
+      await this.persist();
+      return { ok: false, reason: 'expired' };
+    }
+    if (!matchesExpected(registration, expected)) {
+      return { ok: false, reason: 'context-mismatch' };
+    }
+    registration.state = 'used';
+    await this.persist();
+    return { ok: true, registration };
+  }
+
+  async flush(): Promise<void> {
+    await this.saving;
+  }
+
+  private pruneExpired(): void {
+    const cutoff = this.now();
+    for (const [id, registration] of this.registrations.entries()) {
+      if (registration.expiresAt <= cutoff && registration.state !== 'active') {
+        this.registrations.delete(id);
+      }
+    }
+  }
+
+  private async persist(): Promise<void> {
+    this.saving = this.saving
+      .then(async () => {
+        await writeFileAtomic(
+          this.path,
+          `${JSON.stringify(Object.fromEntries(this.registrations), null, 2)}\n`,
+          { mode: 0o600 },
+        );
+      })
+      .catch((err: unknown) => {
+        log.fail('callback-registry', err, { step: 'persist' });
+      });
+    await this.saving;
+  }
+}
+
+function matchesExpected(
+  registration: CallbackRegistration,
+  expected: CallbackRegistryExpected,
+): boolean {
+  return (
+    registration.scope === expected.scope &&
+    registration.chatId === expected.chatId &&
+    registration.operatorOpenId === expected.operatorOpenId &&
+    registration.action === expected.action
+  );
+}
+
+function parseRegistration(id: string, value: unknown): CallbackRegistration | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const raw = value as Partial<CallbackRegistration>;
+  if (
+    typeof raw.runId !== 'string' ||
+    typeof raw.scope !== 'string' ||
+    typeof raw.chatId !== 'string' ||
+    typeof raw.operatorOpenId !== 'string' ||
+    typeof raw.action !== 'string' ||
+    typeof raw.policyFingerprint !== 'string' ||
+    typeof raw.expiresAt !== 'number' ||
+    (raw.state !== 'active' && raw.state !== 'used' && raw.state !== 'revoked')
+  ) {
+    return undefined;
+  }
+  return {
+    id,
+    runId: raw.runId,
+    scope: raw.scope,
+    chatId: raw.chatId,
+    operatorOpenId: raw.operatorOpenId,
+    action: raw.action,
+    policyFingerprint: raw.policyFingerprint,
+    expiresAt: raw.expiresAt,
+    state: raw.state,
+  };
+}

--- a/src/card/dispatcher.ts
+++ b/src/card/dispatcher.ts
@@ -5,6 +5,7 @@ import type { ChatModeCache } from '../bot/chat-mode-cache';
 import type { PendingQueue } from '../bot/pending-queue';
 import type { ProcessPool } from '../bot/process-pool';
 import type { CallbackAuth } from './callback-auth';
+import type { CallbackRegistryStore } from './callback-registry';
 import { runCommandHandler, type CommandContext, type Controls } from '../commands';
 import { log } from '../core/logger';
 import { canUseDm, canUseGroup } from '../policy/access';
@@ -37,6 +38,7 @@ export interface CardDispatchDeps {
   pending: PendingQueue;
   chatModeCache: ChatModeCache;
   callbackAuth?: CallbackAuth;
+  callbackRegistry?: CallbackRegistryStore;
   callbackPolicyFingerprint?: string;
   callbackPolicyFingerprintForScope?: (scope: string) => string | undefined;
 }
@@ -127,12 +129,13 @@ export async function handleCardAction(deps: CardDispatchDeps): Promise<void> {
     return;
   }
 
-  // Agent-driven callback: the button was rendered by an agent via lark-cli,
-  // with `__bridge_cb` set on the value. Forward the click back into the
-  // scope's pending queue so the agent resumes its session and sees the click
-  // as a follow-up message, with full context of what it sent.
+  // Agent-driven callback. Prefer registry-backed callback_id; keep bridge_token for existing cards.
   if (BRIDGE_CALLBACK_MARKER in payload) {
-    if (!verifyBridgeToken(deps, payload, scope, 'agent_callback')) return;
+    const callbackId = typeof payload.callback_id === 'string' ? payload.callback_id : '';
+    const verified = callbackId
+      ? await verifyBridgeCallbackId(deps, callbackId, scope, 'agent_callback')
+      : verifyBridgeToken(deps, payload, scope, 'agent_callback');
+    if (!verified) return;
     forwardToAgent(deps, payload, formValue, scope, threadId, mode);
     return;
   }
@@ -192,6 +195,7 @@ function forwardToAgent(
   const {
     [BRIDGE_CALLBACK_MARKER]: _marker,
     bridge_token: _token,
+    callback_id: _callbackId,
     ...agentPayload
   } = payload;
   const merged = formValue ? { ...agentPayload, form_value: formValue } : agentPayload;
@@ -215,6 +219,35 @@ function forwardToAgent(
     createTime: Date.now(),
   };
   deps.pending.push(scope, synthetic);
+}
+
+async function verifyBridgeCallbackId(
+  deps: CardDispatchDeps,
+  callbackId: string,
+  scope: string,
+  action: string,
+): Promise<boolean> {
+  if (!deps.callbackRegistry) {
+    log.info('cardAction', 'skip-callback-registry-missing', { scope, action });
+    log.warn('callback', 'denied', { scope, action, reason: 'missing-registry' });
+    return false;
+  }
+  const result = await deps.callbackRegistry.consume(callbackId, {
+    scope,
+    chatId: deps.evt.chatId,
+    operatorOpenId: deps.evt.operator.openId,
+    action,
+  });
+  if (!result.ok) {
+    log.info('cardAction', 'skip-callback-registry-failed', {
+      scope,
+      action,
+      reason: result.reason,
+    });
+    log.warn('callback', 'denied', { scope, action, reason: result.reason });
+    return false;
+  }
+  return true;
 }
 
 function verifyBridgeToken(

--- a/src/cli/commands/callback.ts
+++ b/src/cli/commands/callback.ts
@@ -1,0 +1,60 @@
+import { resolveAppPaths } from '../../config/app-paths';
+import { CallbackRegistryStore } from '../../card/callback-registry';
+
+export async function runCallbackCreate(opts: {
+  action?: string;
+  ttlSeconds?: string;
+  profile?: string;
+}): Promise<void> {
+  const runId = requiredEnv('LARK_CHANNEL_RUN_ID');
+  const scope = requiredEnv('LARK_CHANNEL_SCOPE');
+  const chatId = requiredEnv('LARK_CHANNEL_CHAT_ID');
+  const operatorOpenId = requiredEnv('LARK_CHANNEL_OPERATOR_OPEN_ID');
+  const policyFingerprint = requiredEnv('LARK_CHANNEL_POLICY_FINGERPRINT');
+  const action = nonEmpty(opts.action) ?? 'agent_callback';
+  const ttlMs = parseTtlMs(opts.ttlSeconds);
+  const paths = resolveAppPaths({
+    rootDir: process.env.LARK_CHANNEL_HOME,
+    profile: opts.profile ?? process.env.LARK_CHANNEL_PROFILE,
+  });
+  const store = new CallbackRegistryStore(`${paths.profileDir}/callback-registry.json`);
+  const registration = await store.register({
+    runId,
+    scope,
+    chatId,
+    operatorOpenId,
+    action,
+    policyFingerprint,
+    ttlMs,
+  });
+  process.stdout.write(
+    `${JSON.stringify({
+      callback_id: registration.id,
+      action: registration.action,
+      expires_at: new Date(registration.expiresAt).toISOString(),
+    })}\n`,
+  );
+}
+
+function requiredEnv(name: string): string {
+  const value = nonEmpty(process.env[name]);
+  if (!value) {
+    throw new Error(`${name} is required; run this command inside an active lark-channel agent run`);
+  }
+  return value;
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function parseTtlMs(raw: string | undefined): number {
+  const value = nonEmpty(raw);
+  if (!value) return 24 * 60 * 60 * 1000;
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds) || seconds <= 0 || seconds > 7 * 24 * 60 * 60) {
+    throw new Error('--ttl-seconds must be between 1 and 604800');
+  }
+  return Math.floor(seconds * 1000);
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,6 +24,7 @@ import {
   runServiceUnregister,
 } from './commands/service';
 import { runStart } from './commands/start';
+import { runCallbackCreate } from './commands/callback';
 
 const program = new Command();
 
@@ -202,6 +203,20 @@ program
   .option('--profile <name>', 'profile name (defaults to active profile)')
   .action(async (opts: { profile?: string }) => {
     await runServiceUnregister({ profile: opts.profile });
+  });
+
+const callback = program
+  .command('callback')
+  .description('Create bridge callback ids for interactive cards inside agent runs');
+
+callback
+  .command('create')
+  .description('Create a one-time callback_id for a CardKit button value')
+  .option('--action <name>', 'callback action name (default agent_callback)')
+  .option('--ttl-seconds <seconds>', 'callback lifetime, default 86400')
+  .option('--profile <name>', 'profile name (defaults to LARK_CHANNEL_PROFILE)')
+  .action(async (opts: { action?: string; ttlSeconds?: string; profile?: string }) => {
+    await runCallbackCreate(opts);
   });
 
 const secrets = program

--- a/src/runtime/run-executor.ts
+++ b/src/runtime/run-executor.ts
@@ -23,6 +23,12 @@ export interface SubmitRunInput {
   model?: string;
   images?: readonly string[];
   stopGraceMs?: number;
+  callbackContext?: {
+    scope: string;
+    chatId: string;
+    operatorOpenId: string;
+    policyFingerprint: string;
+  };
   nowait?: boolean;
   observability?: {
     profile: string;
@@ -104,6 +110,7 @@ export class RunExecutor {
       sandbox: input.policy.sandbox,
       permissionMode: input.policy.permissionMode,
       stopGraceMs: input.stopGraceMs,
+      callbackContext: input.callbackContext,
     };
     let run: AgentRun;
     try {

--- a/tests/integration/card/callback-dispatch.test.ts
+++ b/tests/integration/card/callback-dispatch.test.ts
@@ -5,6 +5,7 @@ import type { ChatModeCache } from '../../../src/bot/chat-mode-cache.js';
 import { PendingQueue } from '../../../src/bot/pending-queue.js';
 import { CallbackAuth } from '../../../src/card/callback-auth.js';
 import { CallbackNonceStore } from '../../../src/card/callback-store.js';
+import { CallbackRegistryStore } from '../../../src/card/callback-registry.js';
 import { handleCardAction } from '../../../src/card/dispatcher.js';
 import type { Controls } from '../../../src/commands/index.js';
 import { createDefaultProfileConfig } from '../../../src/config/profile-schema.js';
@@ -63,6 +64,31 @@ describe('signed card callback dispatch', () => {
     expect(queued).toHaveLength(1);
     expect(queued[0]?.content).toBe('[card-click] {"choice":"a","form_value":{"note":"from form"}}');
     expect(queued[0]?.chatType).toBe('group');
+  });
+
+  it('forwards registry callback ids once without leaking callback fields', async () => {
+    const h = await createHarness();
+    const callbackId = await h.callbackId();
+
+    await h.dispatch(
+      {
+        __bridge_cb: true,
+        callback_id: callbackId,
+        choice: 'a',
+      },
+      { note: 'from form' },
+    );
+
+    const queued = h.pending.cancel('oc_group');
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.content).toBe('[card-click] {"choice":"a","form_value":{"note":"from form"}}');
+
+    await h.dispatch({
+      __bridge_cb: true,
+      callback_id: callbackId,
+      choice: 'replay',
+    });
+    expect(h.pending.cancel('oc_group')).toHaveLength(0);
   });
 
   it('drops legacy Claude callback markers before command dispatch', async () => {
@@ -125,6 +151,8 @@ type Harness = {
   controls: Controls;
   pending: PendingQueue;
   auth: CallbackAuth;
+  registry: CallbackRegistryStore;
+  callbackId(): Promise<string>;
   dispatch(value: Record<string, unknown>, formValue?: Record<string, unknown>): Promise<void>;
   token(
     action: string,
@@ -143,6 +171,10 @@ async function createHarness(
   const agent = new FakeAgentAdapter();
   const pending = new PendingQueue(60_000, () => {});
   const store = new CallbackNonceStore(`${tmp.profile}/callback-nonces.json`);
+  const registry = new CallbackRegistryStore(`${tmp.profile}/callback-registry.json`, {
+    now: () => 1000,
+    createId: () => `cb-${Math.random().toString(36).slice(2)}`,
+  });
   const controls = {
     profile: 'claude',
     profileConfig: createDefaultProfileConfig({
@@ -175,7 +207,7 @@ async function createHarness(
   } as unknown as ChatModeCache;
   cleanups.push(async () => {
     pending.cancelAll();
-    await Promise.all([sessions.flush(), workspaces.flush(), store.flush()]);
+    await Promise.all([sessions.flush(), workspaces.flush(), store.flush(), registry.flush()]);
     await tmp.cleanup();
   });
 
@@ -189,6 +221,19 @@ async function createHarness(
     controls,
     pending,
     auth,
+    registry,
+    callbackId: async () => {
+      const registered = await registry.register({
+        runId: 'run-active',
+        scope: 'oc_group',
+        chatId: 'oc_group',
+        operatorOpenId: 'ou_operator',
+        action: 'agent_callback',
+        policyFingerprint: 'fp-1',
+        ttlMs: 60_000,
+      });
+      return registered.id;
+    },
     token: (action, overrides = {}) => {
       nonce = overrides.nonce ?? `nonce-${action}`;
       return auth.sign({
@@ -213,6 +258,7 @@ async function createHarness(
         pending,
         chatModeCache,
         ...(opts.callbackAuth === false ? {} : { callbackAuth: auth }),
+        callbackRegistry: registry,
         callbackPolicyFingerprint: 'fp-1',
       }),
   };


### PR DESCRIPTION
## Summary
- add a profile-local callback registry for one-time interactive card callback ids
- expose lark-channel-bridge callback create for agents to mint callback_id values without lark-cli signing support
- route cardAction callbacks through callback_id validation while preserving bridge_token compatibility

## Validation
- npm run build
- npm run typecheck
- user verified the interactive card flow manually