### PR TITLE
feat(channel): make REST request timeout configurable via LARK_CHANNEL_STREAM_TIMEOUT_MS

### DIFF
--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -233,7 +233,7 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
     handshakeTimeoutMs: 8_000,
     // Per-request REST timeout — without a cap a slow API can hang the
     // event-handling thread.
-    httpTimeoutMs: 30_000,
+    httpTimeoutMs: (() => { const v = Number(process.env.LARK_CHANNEL_STREAM_TIMEOUT_MS); return Number.isFinite(v) && v > 0 ? v : 30_000; })(),
     // Route WS + REST through HTTPS_PROXY / HTTP_PROXY when set (no-op otherwise).
     respectProxyEnv: true,
   };


### PR DESCRIPTION
## Problem

The bridge's REST API timeout is hardcoded at 30 seconds (`httpTimeoutMs: 30_000` in `src/bot/channel.ts`). When Claude Code uses extended thinking or processes large contexts, the stream easily exceeds this limit. The bridge then reports `stream.fail` with "timeout of 30000ms exceeded" and drops the response — even though Claude is still processing successfully.

## Change

Make `httpTimeoutMs` configurable via the environment variable `LARK_CHANNEL_STREAM_TIMEOUT_MS` (default `30000` to keep backward compatibility):

```ts
httpTimeoutMs: (() => {
  const v = Number(process.env.LARK_CHANNEL_STREAM_TIMEOUT_MS);
  return Number.isFinite(v) && v > 0 ? v : 30_000;
})(),
```

Operators can now set `LARK_CHANNEL_STREAM_TIMEOUT_MS=120000` (2 min) for long-thinking workloads without modifying the bridge code.

## Testing

- `pnpm build` — ESM + DTS pass clean
- Tested on the existing v0.2.2 dist with the same env var pattern