### PR TITLE
Fix `(no content)` replies on Windows: bypass cmd.exe arg mangling for agent shims

### DIFF
--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -1,7 +1,12 @@
 import { createInterface } from 'node:readline';
 import type { Readable } from 'node:stream';
 import { log } from '../../core/logger';
-import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
+import {
+  mergeProcessEnv,
+  resolveWindowsCmdShim,
+  spawnProcess,
+  type SpawnedProcessByStdio,
+} from '../../platform/spawn';
 import { buildBridgeSystemPrompt } from '../bridge-system-prompt';
 import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel-env';
 import { checkAgentAvailability, type AgentAvailability } from '../preflight';
@@ -71,7 +76,13 @@ export class ClaudeAdapter implements AgentAdapter {
     if (opts.sessionId) args.push('--resume', opts.sessionId);
     if (opts.model) args.push('--model', opts.model);
 
-    const child = spawnProcess(this.binary, args, {
+    // On Windows, bypass cmd.exe by spawning node + the resolved entry script
+    // directly. See resolveWindowsCmdShim for the full rationale.
+    const shim = resolveWindowsCmdShim(this.binary);
+    const spawnBin = shim?.command ?? this.binary;
+    const spawnArgs = shim ? [...shim.prependArgs, ...args] : args;
+
+    const child = spawnProcess(spawnBin, spawnArgs, {
       cwd: opts.cwd,
       env: mergeProcessEnv(process.env, buildLarkChannelEnv(this.larkChannel)),
       stdio: ['ignore', 'pipe', 'pipe'],
@@ -83,6 +94,7 @@ export class ClaudeAdapter implements AgentAdapter {
       hasSession: Boolean(opts.sessionId),
       promptChars: opts.prompt.length,
       model: opts.model,
+      shim: shim ? 'win32-node' : null,
     });
 
     // Listeners MUST be attached synchronously here, before we return.

--- a/src/agent/codex/adapter.ts
+++ b/src/agent/codex/adapter.ts
@@ -3,7 +3,12 @@ import type { Readable, Writable } from 'node:stream';
 import { join } from 'node:path';
 import type { SandboxMode } from '../../config/profile-schema';
 import { log } from '../../core/logger';
-import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
+import {
+  mergeProcessEnv,
+  resolveWindowsCmdShim,
+  spawnProcess,
+  type SpawnedProcessByStdio,
+} from '../../platform/spawn';
 import { SpawnFailed } from '../../runtime/errors';
 import { prefixBridgeSystemPrompt } from '../bridge-system-prompt';
 import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel-env';
@@ -107,7 +112,14 @@ export class CodexAdapter implements AgentAdapter {
     } else if (!this.inheritCodexHome) {
       envOverrides.CODEX_HOME = join(this.profileStateDir, 'codex-home');
     }
-    const child = spawnProcess(this.binary, args, {
+
+    // On Windows, bypass cmd.exe by spawning node + the resolved entry script
+    // directly. See resolveWindowsCmdShim for the full rationale.
+    const shim = resolveWindowsCmdShim(this.binary);
+    const spawnBin = shim?.command ?? this.binary;
+    const spawnArgs = shim ? [...shim.prependArgs, ...args] : args;
+
+    const child = spawnProcess(spawnBin, spawnArgs, {
       cwd: opts.cwd,
       env: mergeProcessEnv(process.env, envOverrides),
       stdio: ['pipe', 'pipe', 'pipe'],
@@ -119,6 +131,7 @@ export class CodexAdapter implements AgentAdapter {
       hasThread: Boolean(opts.threadId),
       promptChars: opts.prompt.length,
       images: opts.images?.length ?? 0,
+      shim: shim ? 'win32-node' : null,
     });
 
     const stderrChunks: Buffer[] = [];

--- a/src/platform/spawn.ts
+++ b/src/platform/spawn.ts
@@ -5,6 +5,8 @@ import type {
   SpawnSyncOptions,
 } from 'node:child_process';
 import type { Readable, Writable } from 'node:stream';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, isAbsolute, join } from 'node:path';
 import crossSpawn from 'cross-spawn';
 
 export function spawnProcess(
@@ -37,6 +39,79 @@ export function mergeProcessEnv(
     if (value !== undefined) out[key] = value;
   }
   return out;
+}
+
+/**
+ * On Windows, npm-generated `.cmd` shims (claude.cmd, codex.cmd, ...) route
+ * every spawn through `cmd.exe`. cmd.exe's argument tokenizer mangles
+ * arguments that combine nested double-quotes with special characters like
+ * `< > & | { }` — see CVE-2024-1874 ("BatBadBut",
+ * https://flatt.tech/research/posts/batbadbut/).
+ *
+ * The bridge sends each prompt with a `<bridge_context>{...JSON...}</bridge_context>`
+ * header as a single `-p` argument. On Windows that argument plus every flag
+ * after it (`--output-format stream-json`, `--verbose`, `--append-system-prompt`,
+ * ...) is silently truncated by cmd.exe. The agent then falls back to its
+ * interactive default, prints a welcome banner, and exits cleanly because
+ * stdin is `'ignore'`d. The bridge sees a clean exit with zero stream-json
+ * events and renders an empty `(no content)` card.
+ *
+ * Workaround: when the binary resolves to a Windows `.cmd` shim, parse the
+ * shim to find the underlying JS entry point and spawn `node <entry>` directly.
+ * Node's CreateProcess argv encoding is reliable; we never go through cmd.exe.
+ *
+ * Returns `null` on non-Windows, when the shim can't be located, or when its
+ * format isn't recognized — callers should fall back to spawning the original
+ * command unchanged.
+ */
+export function resolveWindowsCmdShim(
+  command: string,
+): { command: string; prependArgs: string[] } | null {
+  if (process.platform !== 'win32') return null;
+
+  const cmdPath = isAbsolute(command) && /\.cmd$/i.test(command) && existsSync(command)
+    ? command
+    : findCmdShimInPath(command);
+  if (!cmdPath) return null;
+
+  let content: string;
+  try {
+    content = readFileSync(cmdPath, 'utf8');
+  } catch {
+    return null;
+  }
+
+  // npm / pnpm / yarn shims all eventually invoke `node "...\entry.js" %*`.
+  // Take the LAST quoted `.js` path — earlier matches may reference helpers
+  // (e.g. node.exe lookup), and the entry point is always the last reference.
+  const jsMatches = [...content.matchAll(/"([^"]+\.js)"/gi)];
+  if (jsMatches.length === 0) return null;
+  let jsPath = jsMatches[jsMatches.length - 1][1];
+
+  // npm shims use the `%dp0%` placeholder (the .cmd's dirname). Expand it.
+  jsPath = jsPath.replace(/%dp0%[\\/]?/gi, dirname(cmdPath) + '\\');
+  if (!isAbsolute(jsPath)) {
+    jsPath = join(dirname(cmdPath), jsPath);
+  }
+  if (!existsSync(jsPath)) return null;
+
+  return { command: process.execPath, prependArgs: [jsPath] };
+}
+
+function findCmdShimInPath(command: string): string | null {
+  if (/\.(cmd|bat|exe)$/i.test(command)) {
+    return findOnPath(command);
+  }
+  return findOnPath(`${command}.cmd`) ?? findOnPath(`${command}.bat`);
+}
+
+function findOnPath(filename: string): string | null {
+  const dirs = (process.env.PATH ?? '').split(';').filter(Boolean);
+  for (const dir of dirs) {
+    const full = join(dir, filename);
+    if (existsSync(full)) return full;
+  }
+  return null;
 }
 
 export type SpawnedProcessByStdio<


### PR DESCRIPTION
# Fix `(no content)` replies on Windows: bypass cmd.exe arg mangling for agent shims

## TL;DR

On Windows, every Lark message currently comes back as an empty `(no content)` card.
Root cause is **cmd.exe's argument tokenizer mangling the `-p` prompt** when `cross-spawn`
routes through the npm-generated `claude.cmd` / `codex.cmd` shims. This PR adds a small
helper that detects the `.cmd` shim, parses out its underlying `node ... entry.js` target,
and spawns Node directly — completely sidestepping cmd.exe.

Non-Windows paths are unchanged. On Windows, if anything about the shim is unrecognized,
the helper returns `null` and the caller falls back to the existing `cross-spawn` behavior,
so the change is strictly additive.

## Symptom

On Windows 11 with Node 20.x and a freshly installed `lark-channel-bridge` v0.3.0:

1. `lark-channel-bridge profile create --agent claude` → ok
2. `lark-channel-bridge run --profile claude` → ok, the bridge connects to Lark
3. Send any message in Feishu/Lark
4. The bot replies with **an empty bubble** (the `(no content)` card)

Bridge logs show `agent.spawn` followed shortly by `agent.exit` with `code: 0` and zero
stream-json events in between. The Claude CLI itself is functional in a terminal.

The same setup works on macOS / Linux without changes.

## Root cause

Reproduced with a minimal harness on Windows: write the exact `args` array the bridge
builds (`-p '<bridge_context>{...}</bridge_context>\n\nhi'`, `--output-format`,
`stream-json`, `--verbose`, `--permission-mode`, ..., `--append-system-prompt`, ...) and
spawn `claude` via `cross-spawn`. The CLI prints its **interactive welcome banner** and
exits cleanly — proving every `-p`-and-after argument was lost before `claude` parsed
its argv.

cross-spawn on Windows can't `CreateProcess` a `.cmd` file directly, so it rewrites the
spawn into `cmd.exe /d /s /c "claude.cmd" ...`. cmd.exe's tokenizer is the well-known
weak link here:

- It treats unquoted `<`, `>`, `&`, `|` as redirection / chaining metacharacters.
- It re-parses arguments that contain `"` (nested-quotes failure mode).
- This is the class of bugs grouped under **CVE-2024-1874 / "BatBadBut"** —
  https://flatt.tech/research/posts/batbadbut/.

The bridge's prompt argument is exactly the worst-case input: it has nested double
quotes (the JSON in `<bridge_context>`), `<` and `>` characters (the tag delimiters),
and often `&` or `|`. cmd.exe truncates at the first metacharacter it can't reconcile,
the rest of `argv` is dropped, the CLI sees an empty argv, prints the welcome banner,
and exits 0. Because stdin is `'ignore'`d, there is nothing to wait on, so it exits
fast and the bridge sees a clean `code: 0` with no events.

This is a Node/Windows-wide hazard, not a bug in the Claude or Codex CLI. Anyone
piping non-trivial prompts through a `.cmd` shim hits it.

## Fix

Add a `resolveWindowsCmdShim(command)` helper to `src/platform/spawn.ts`:

- On non-Windows, returns `null` immediately. **No behavior change off Windows.**
- On Windows, looks up the resolved `.cmd` shim on `PATH` (or accepts an absolute path).
- Reads the shim, finds the last quoted `*.js` reference in it, expands the `%dp0%`
  placeholder that npm uses, and verifies the file exists.
- Returns `{ command: process.execPath, prependArgs: [resolvedJsPath] }` on success,
  `null` on any failure (so the caller falls back to today's `cross-spawn` path).

The Claude and Codex adapters then do:

```ts
const shim = resolveWindowsCmdShim(this.binary);
const spawnBin = shim?.command ?? this.binary;
const spawnArgs = shim ? [...shim.prependArgs, ...args] : args;
const child = spawnProcess(spawnBin, spawnArgs, { ... });
```

That's it. Once the spawn target is `node.exe ...\cli.js`, Node's argv encoding is
reliable and there is no cmd.exe in the chain to mangle anything.

## Files changed

- `src/platform/spawn.ts` — new exported `resolveWindowsCmdShim` helper, with detailed
  JSDoc explaining the cmd.exe failure mode and pointing at the BatBadBut writeup.
- `src/agent/claude/adapter.ts` — call the helper before `spawnProcess`; add `shim`
  field to the spawn log line.
- `src/agent/codex/adapter.ts` — same treatment.

## How to verify

On Windows (where the bug reproduces):

1. Apply this PR.
2. `npm run build` (or whatever the project's bundle step is).
3. Reinstall the bridge globally and start `lark-channel-bridge run --profile <claude-profile>`.
4. Send any message in Feishu/Lark — the bot should now reply with real content.
5. Repeat with a Codex profile.
6. In the bridge log, the `agent.spawn` event should now include `"shim":"win32-node"`,
   confirming the helper kicked in.

On macOS / Linux:

1. Apply the PR, run the same flow.
2. The `agent.spawn` log shows `"shim":null` and behavior is unchanged.

## Scope / non-goals

- Fix is scoped to the two existing agent adapters. The helper is exported, so any
  future adapter can opt in with three lines.
- The helper deliberately does **not** alter `spawnProcess`/`spawnProcessSync`
  signatures or behavior — those are still vanilla `cross-spawn` wrappers. Other
  callers (e.g. the preflight `--version` checks) are short, fixed-shape commands
  that don't trigger the cmd.exe bug, so they don't need the workaround.
- The helper falls back to `null` (i.e. existing behavior) on every error path, so
  there's no regression risk if a future Node / npm version changes the shim format.

## References

- BatBadBut writeup (CVE-2024-1874): https://flatt.tech/research/posts/batbadbut/
- Node.js advisory: https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2
- cross-spawn Windows handling: https://github.com/moxystudio/node-cross-spawn#known-issues
