### PR TITLE
fix: clean up stale runtime locks when the holder process is dead

### DIFF
--- a/src/cli/commands/ps.ts
+++ b/src/cli/commands/ps.ts
@@ -1,4 +1,4 @@
-import { readAndPrune, resolveTarget, isAlive } from '../../runtime/registry';
+import { readAndPrune, resolveTarget, isAlive, unregister } from '../../runtime/registry';
 import type { ProcessEntry } from '../../runtime/registry';
 
 /**
@@ -51,6 +51,13 @@ export async function runKillCli(target: string | undefined): Promise<void> {
     process.exit(1);
   }
 
+  if (result === 'not-running') {
+    // Hard-killed processes (crash, Stop-Process, task-scheduler kill) never
+    // unregister themselves; drop the ghost entry so `ps` stops listing it.
+    await unregister(entry.id);
+    console.log(`✓ bot ${entry.id} 的进程已不存在,已清理注册表残留。`);
+    return;
+  }
   if (result === 'killed') {
     console.log(`✓ 已强制关闭 bot ${entry.id}。`);
     return;
@@ -58,13 +65,18 @@ export async function runKillCli(target: string | undefined): Promise<void> {
   console.log(`✓ 已关闭 bot ${entry.id}。`);
 }
 
-export type StopProcessEntryResult = 'terminated' | 'killed';
+export type StopProcessEntryResult = 'terminated' | 'killed' | 'not-running';
 
 export async function stopProcessEntry(
   entry: Pick<ProcessEntry, 'pid'> & { id?: string },
   timeoutMs = 2000,
 ): Promise<StopProcessEntryResult> {
-  process.kill(entry.pid, 'SIGTERM');
+  try {
+    process.kill(entry.pid, 'SIGTERM');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ESRCH') return 'not-running';
+    throw err;
+  }
 
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -12,8 +12,8 @@ import {
   materializeEnvSecretForService,
   resolveProfileRuntime,
 } from '../../runtime/profile-runtime';
-import { readAndPrune, type ProcessEntry } from '../../runtime/registry';
-import { checkRuntimeLock, type RuntimeLockMeta } from '../../runtime/locks';
+import { isAlive, readAndPrune, type ProcessEntry } from '../../runtime/registry';
+import { checkRuntimeLock, cleanupStaleRuntimeLock, type RuntimeLockMeta } from '../../runtime/locks';
 import { preFlightChecks } from '../preflight';
 import { promptAndStopActiveBridgeMigrationConflict } from './migrate';
 import { stopProcessEntry, type StopProcessEntryResult } from './ps';
@@ -144,6 +144,15 @@ async function assertLockNotHeldByAnotherRuntime(
     console.error(
       `  holder: profile=${lock.meta.profile}${app} agent=${lock.meta.agentKind} pid=${lock.meta.pid} startedAt=${lock.meta.startedAt}`,
     );
+
+    // Dead holder = stale lock left by a crash / hard kill. Nothing to stop;
+    // clean it up and re-check instead of aborting (the non-interactive abort
+    // below would otherwise wedge service start until manual lock surgery).
+    if (!isAlive(lock.meta.pid)) {
+      console.log(`  holder pid ${lock.meta.pid} 已不存在,自动清理陈旧锁后重试…`);
+      await cleanupStaleRuntimeLock(target);
+      continue;
+    }
 
     if (!opts.confirmStopRuntimeLockProcess && (!process.stdin.isTTY || !process.stdout.isTTY)) {
       console.error(

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -27,6 +27,7 @@ import { promptAndStopActiveBridgeMigrationConflict } from './migrate';
 import { stopProcessEntry, type StopProcessEntryResult } from './ps';
 import {
   cleanupTmpFiles,
+  isAlive,
   register,
   sameAppLiveOthers,
   unregisterSync,
@@ -35,6 +36,7 @@ import {
 } from '../../runtime/registry';
 import {
   acquireAppRuntimeLock,
+  cleanupStaleRuntimeLock,
   RuntimeLockConflictError,
   withProfileAndAppLocks,
   type AcquiredRuntimeLock,
@@ -506,6 +508,16 @@ async function handleRuntimeLockConflict(
   } else {
     console.error(`  lock: ${err.target}`);
     return 'unhandled';
+  }
+
+  // Holder process is gone (crash / hard kill): the lock is stale, there is
+  // nothing to stop and nobody to ask about. Clean up and retry instead of
+  // demanding confirmation — in non-interactive runs (task scheduler,
+  // systemd, watchdogs) the confirmation path would abort the start.
+  if (!isAlive(err.meta.pid)) {
+    console.log(`  holder pid ${err.meta.pid} 已不存在,自动清理陈旧锁后重试…`);
+    await cleanupStaleRuntimeLock(err.target);
+    return 'retry';
   }
 
   const confirmed = opts.confirmStopRuntimeLockProcess

--- a/src/runtime/locks.ts
+++ b/src/runtime/locks.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, rm, unlink, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import * as lockfile from 'proper-lockfile';
 import type { AppPaths } from '../config/app-paths';
@@ -96,6 +96,19 @@ export async function acquireProfileRuntimeLock(
 
 export function runtimeLockMetaFile(target: string): string {
   return `${target}.meta.json`;
+}
+
+/**
+ * Remove lockfile artifacts left behind by a dead holder. A hard kill
+ * (crash, Stop-Process, task-scheduler termination — common on Windows)
+ * leaves the `.lock` dir in place, and proper-lockfile only reclaims it
+ * after the stale window, which turns every crash into a confusing
+ * "already running" failure on the next `start`. Only call this after
+ * confirming the holder process is gone.
+ */
+export async function cleanupStaleRuntimeLock(target: string): Promise<void> {
+  await rm(`${target}.lock`, { recursive: true, force: true });
+  await rm(runtimeLockMetaFile(target), { force: true });
 }
 
 export async function readRuntimeLockMeta(target: string): Promise<RuntimeLockMeta | undefined> {

--- a/tests/integration/cli/start-codex-legacy-config.test.ts
+++ b/tests/integration/cli/start-codex-legacy-config.test.ts
@@ -38,7 +38,9 @@ describe('Codex startup compatibility with legacy binary metadata', () => {
       target: join(h.root, 'registry', 'locks', 'profile', 'codex.lock'),
       profile: 'codex',
       agentKind: 'codex',
-      pid: 12345,
+      // Must be a live pid: dead holders now short-circuit into stale-lock
+      // cleanup and retry instead of asking for confirmation.
+      pid: process.pid,
       startedAt: '2026-06-04T09:00:00.000Z',
     };
     mocks.withProfileAndAppLocks.mockRejectedValueOnce(
@@ -66,7 +68,8 @@ describe('Codex startup compatibility with legacy binary metadata', () => {
       target: join(h.root, 'registry', 'locks', 'profile', 'codex.lock'),
       profile: 'codex',
       agentKind: 'codex',
-      pid: 12345,
+      // Live pid for the same reason as above.
+      pid: process.pid,
       startedAt: '2026-06-04T09:00:00.000Z',
     };
     mocks.withProfileAndAppLocks.mockRejectedValueOnce(

--- a/tests/unit/cli/service-profile.test.ts
+++ b/tests/unit/cli/service-profile.test.ts
@@ -26,10 +26,15 @@ vi.mock('../../../src/runtime/profile-runtime', () => ({
 
 vi.mock('../../../src/runtime/registry', () => ({
   readAndPrune: mocks.readAndPrune,
+  // Lock holders in these tests are simulated processes; treat them as live
+  // so the confirm/stop flows under test are exercised (dead holders now
+  // short-circuit into stale-lock cleanup).
+  isAlive: () => true,
 }));
 
 vi.mock('../../../src/runtime/locks', () => ({
   checkRuntimeLock: mocks.checkRuntimeLock,
+  cleanupStaleRuntimeLock: vi.fn(),
 }));
 
 vi.mock('../../../src/cli/commands/ps', () => ({

--- a/tests/unit/cli/start-runtime-lock-conflict.test.ts
+++ b/tests/unit/cli/start-runtime-lock-conflict.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'node:child_process';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RuntimeLockConflictError, type RuntimeLockMeta } from '../../../src/runtime/locks';
 
@@ -102,7 +103,9 @@ describe('run runtime lock conflict handling', () => {
       target: '/tmp/lark-channel-home/registry/locks/profile/codex.lock',
       profile: 'codex',
       agentKind: 'codex',
-      pid: 83130,
+      // Must be a live pid: dead holders now short-circuit into stale-lock
+      // cleanup without confirmation. The test runner itself is always live.
+      pid: process.pid,
       startedAt: '2026-05-28T12:50:39.072Z',
     };
     mocks.withProfileAndAppLocks
@@ -129,5 +132,37 @@ describe('run runtime lock conflict handling', () => {
     expect(stopped).toEqual([holder]);
     expect(exit).not.toHaveBeenCalled();
     exit.mockRestore();
+  });
+
+  it('cleans up the stale lock and retries without confirmation when the holder is dead', async () => {
+    // A just-exited child gives us a pid that is guaranteed dead.
+    const deadPid = spawnSync(process.execPath, ['-e', 'process.exit(0)']).pid ?? 0;
+    const holder: RuntimeLockMeta = {
+      kind: 'profile',
+      target: '/tmp/lark-channel-home/registry/locks/profile/codex.lock',
+      profile: 'codex',
+      agentKind: 'codex',
+      pid: deadPid,
+      startedAt: '2026-05-28T12:50:39.072Z',
+    };
+    mocks.withProfileAndAppLocks
+      .mockRejectedValueOnce(new RuntimeLockConflictError('profile', holder.target, holder, new Error('locked')))
+      .mockResolvedValueOnce(undefined);
+    const confirm = vi.fn(async () => true);
+    const stop = vi.fn(async () => 'terminated' as const);
+
+    await expect(
+      runStart({
+        profile: 'codex',
+        skipCheckLarkCli: true,
+        confirmStopRuntimeLockProcess: confirm,
+        stopRuntimeLockProcess: stop,
+      }),
+    ).resolves.toBeUndefined();
+
+    // Dead holder: no one to confirm with, nothing to stop — just retry.
+    expect(mocks.withProfileAndAppLocks).toHaveBeenCalledTimes(2);
+    expect(confirm).not.toHaveBeenCalled();
+    expect(stop).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Problem

A crash or hard kill (the normal failure mode under Windows Task Scheduler, but equally reachable via `kill -9` anywhere) leaves the proper-lockfile artifacts and lock meta behind. Then:

- the next `start` refuses with "already running" and asks to stop a process that no longer exists
- non-interactive starts (task scheduler, systemd, watchdog scripts) abort outright
- `kill <bot id>` fails with `ESRCH`
- `ps` keeps listing the ghost entry

The only way out today is manually deleting the lock directories.

## Fix

- **start/service**: before asking the user to stop the lock holder, liveness-check the holder pid. Dead holder → remove the stale lock artifacts and retry silently; there is nothing to confirm or stop.
- **stopProcessEntry**: `ESRCH` on the initial signal reports `not-running` instead of throwing.
- **kill CLI**: a not-running target drops the ghost registry entry so `ps` stops listing it.

PID-reuse false positives err on the safe side: an "alive" answer keeps today's confirm-and-stop behavior.

## Verification

- Windows 11: hard-killed the daemon, re-ran `start` non-interactively — it now self-heals instead of wedging
- Tests added for the dead-holder path; existing conflict tests updated to use a live pid (they previously used arbitrary numbers that only passed by accident)
- Full suite: 514 tests pass; `pnpm typecheck` and `pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
