### PR TITLE
Send workspace artifacts from agent replies

### DIFF
--- a/src/agent/bridge-system-prompt.ts
+++ b/src/agent/bridge-system-prompt.ts
@@ -128,6 +128,14 @@ bridge 会给你的子进程注入当前运行 profile 的环境变量:
 7. 如果用户中途想取消，他们会发 \`/stop\`——那时被 kill 是预期行为，不用兜底。
 `;
 
+export const BRIDGE_OUTBOUND_MEDIA_PROMPT = `
+## 输出图片和文件
+
+如果你为用户生成或修改了图片，请把图片保存在当前 workspace 下，并在最终回复里必须用 markdown 图片语法引用它，例如 \`![alt](relative/path.png)\`。bridge 会在你的文字回复结束后自动上传并发送这些 workspace 内的 png/jpg/jpeg/gif/webp 图片。普通路径文本不会触发上传。
+
+如果你需要把本地非图片文件发给用户，请先把文件保存或复制到当前 workspace 下，然后在最终回复里必须使用显式附件链接：\`[name](bridge-file:relative/path.ext)\`。bridge 只会上传这种 \`bridge-file:\` 链接指向的 workspace 内文件；普通 markdown 链接和普通路径文本不会触发上传。
+`;
+
 /**
  * Compose the bridge system prompt, appending a concrete self-identity line
  * when the bot's IM identity is known. Falls back to the base prompt (which
@@ -135,9 +143,10 @@ bridge 会给你的子进程注入当前运行 profile 的环境变量:
  * e.g. before the channel handshake completes.
  */
 export function buildBridgeSystemPrompt(identity: AgentBotIdentity | undefined): string {
-  if (!identity?.openId) return BRIDGE_SYSTEM_PROMPT;
+  const basePrompt = `${BRIDGE_SYSTEM_PROMPT}${BRIDGE_OUTBOUND_MEDIA_PROMPT}`;
+  if (!identity?.openId) return basePrompt;
   const nameSuffix = identity.name ? `，名字是「${identity.name}」` : '';
-  return `${BRIDGE_SYSTEM_PROMPT}\n## 你的身份\n\n你的 open_id 是 \`${identity.openId}\`${nameSuffix}。消息内容或 mentions 里出现这个 open_id 都是指你自己。\n`;
+  return `${basePrompt}\n## 你的身份\n\n你的 open_id 是 \`${identity.openId}\`${nameSuffix}。消息内容或 mentions 里出现这个 open_id 都是指你自己。\n`;
 }
 
 export function prefixBridgeSystemPrompt(

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -56,6 +56,7 @@ import { handleCommentMention } from './comments';
 import { recordRunSessionEvent, startRunFlow } from './run-flow';
 import { commandSessionCatalogIdentity } from './session-catalog-identity';
 import { startKeepalive } from './keepalive';
+import { sendOutboundArtifacts } from './outbound-artifacts';
 import { PendingQueue } from './pending-queue';
 import { ProcessPool } from './process-pool';
 import { fetchQuotedContext, type QuotedContext } from './quote';
@@ -845,6 +846,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
           );
         },
       });
+      await sendOutboundArtifacts(channel, chatId, filterForPrefs(await renderDone), cwd, sendOpts);
     } else if (replyMode === 'markdown') {
       let latestState: RunState = initialState;
       let producerStarted = false;
@@ -886,6 +888,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
           }
         },
       });
+      await sendOutboundArtifacts(channel, chatId, filterForPrefs(await renderDone), cwd, sendOpts);
     } else {
       // text mode: drain the agent stream without sending anything during
       // the run, then post the final rendered text once as a plain markdown
@@ -902,6 +905,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
       if (body.trim()) {
         await channel.send(chatId, { markdown: body }, sendOpts);
       }
+      await sendOutboundArtifacts(channel, chatId, filterForPrefs(finalState), cwd, sendOpts);
     }
   } catch (err) {
     log.fail('stream', err);
@@ -1084,6 +1088,7 @@ async function awaitRenderAwareStream(input: {
       mode: input.mode,
       graceMs: STREAM_TERMINAL_GRACE_MS,
     });
+    await runFallbackReply(input.mode, first.state, input.fallback);
     void streamResult.then((result) => {
       if (!result.ok) {
         log.fail('stream', result.err, { mode: input.mode, step: 'stream-terminal-late' });
@@ -1091,7 +1096,10 @@ async function awaitRenderAwareStream(input: {
     });
     return;
   }
-  if (!terminal.ok) throw terminal.err;
+  if (!terminal.ok) {
+    log.fail('stream', terminal.err, { mode: input.mode, step: 'stream-terminal' });
+    await runFallbackReply(input.mode, first.state, input.fallback);
+  }
 }
 
 async function runFallbackReply(

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -2,6 +2,7 @@ import type {
   LarkChannel,
   LarkChannelOptions,
   NormalizedMessage,
+  SendOptions,
 } from '@larksuite/channel';
 import { createLarkChannel } from '@larksuite/channel';
 import { dirname, join } from 'node:path';
@@ -56,7 +57,7 @@ import { handleCommentMention } from './comments';
 import { recordRunSessionEvent, startRunFlow } from './run-flow';
 import { commandSessionCatalogIdentity } from './session-catalog-identity';
 import { startKeepalive } from './keepalive';
-import { sendOutboundArtifacts } from './outbound-artifacts';
+import { sanitizeOutboundArtifactReferences, sendOutboundArtifacts } from './outbound-artifacts';
 import { PendingQueue } from './pending-queue';
 import { ProcessPool } from './process-pool';
 import { fetchQuotedContext, type QuotedContext } from './quote';
@@ -776,6 +777,8 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     if (getShowToolCalls(controls.cfg)) return state;
     return { ...state, blocks: state.blocks.filter((b) => b.kind !== 'tool') };
   };
+  const displayForPrefs = (state: RunState): RunState =>
+    sanitizeOutboundArtifactReferences(filterForPrefs(state));
   const cardRenderOptions = callbackAuth
     ? {
         signCallback: (action: string) =>
@@ -814,7 +817,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         async (state) => {
           latestState = state;
           if (cardCtrl) {
-            await cardCtrl.update(renderCard(filterForPrefs(state), cardRenderOptions));
+            await cardCtrl.update(renderCard(displayForPrefs(state), cardRenderOptions));
           }
         },
       );
@@ -826,7 +829,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
             producer: async (ctrl) => {
               producerStarted = true;
               cardCtrl = ctrl;
-              await ctrl.update(renderCard(filterForPrefs(latestState), cardRenderOptions));
+              await ctrl.update(renderCard(displayForPrefs(latestState), cardRenderOptions));
               await renderDone;
             },
           },
@@ -841,12 +844,12 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         fallback: async (state) => {
           await channel.send(
             chatId,
-            { card: renderCard(filterForPrefs(state), cardRenderOptions) },
+            { card: renderCard(displayForPrefs(state), cardRenderOptions) },
             sendOpts,
           );
         },
       });
-      await sendOutboundArtifacts(channel, chatId, filterForPrefs(await renderDone), cwd, sendOpts);
+      scheduleOutboundArtifacts(channel, chatId, filterForPrefs(await renderDone), cwd, sendOpts);
     } else if (replyMode === 'markdown') {
       let latestState: RunState = initialState;
       let producerStarted = false;
@@ -860,7 +863,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         async (state) => {
           latestState = state;
           if (markdownCtrl) {
-            await markdownCtrl.setContent(renderText(filterForPrefs(state)));
+            await markdownCtrl.setContent(renderText(displayForPrefs(state)));
           }
         },
       );
@@ -870,7 +873,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
           markdown: async (ctrl) => {
             producerStarted = true;
             markdownCtrl = ctrl;
-            await ctrl.setContent(renderText(filterForPrefs(latestState)));
+            await ctrl.setContent(renderText(displayForPrefs(latestState)));
             await renderDone;
           },
         },
@@ -882,13 +885,13 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         renderDone,
         producerStarted: () => producerStarted,
         fallback: async (state) => {
-          const body = renderText(filterForPrefs(state));
+          const body = renderText(displayForPrefs(state));
           if (body.trim()) {
             await channel.send(chatId, { markdown: body }, sendOpts);
           }
         },
       });
-      await sendOutboundArtifacts(channel, chatId, filterForPrefs(await renderDone), cwd, sendOpts);
+      scheduleOutboundArtifacts(channel, chatId, filterForPrefs(await renderDone), cwd, sendOpts);
     } else {
       // text mode: drain the agent stream without sending anything during
       // the run, then post the final rendered text once as a plain markdown
@@ -901,11 +904,11 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         recordSession,
         async () => {},
       );
-      const body = renderText(filterForPrefs(finalState));
+      const body = renderText(displayForPrefs(finalState));
       if (body.trim()) {
         await channel.send(chatId, { markdown: body }, sendOpts);
       }
-      await sendOutboundArtifacts(channel, chatId, filterForPrefs(finalState), cwd, sendOpts);
+      scheduleOutboundArtifacts(channel, chatId, filterForPrefs(finalState), cwd, sendOpts);
     }
   } catch (err) {
     log.fail('stream', err);
@@ -913,6 +916,18 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     activePolicyFingerprints.delete(scope);
     scheduleWorkingReactionCleanup(channel, lastMsg.messageId, reactionPromise);
   }
+}
+
+function scheduleOutboundArtifacts(
+  channel: LarkChannel,
+  chatId: string,
+  state: RunState,
+  cwd: string,
+  sendOpts: SendOptions,
+): void {
+  void sendOutboundArtifacts(channel, chatId, state, cwd, sendOpts).catch((err) => {
+    log.fail('media', err, { step: 'outbound-artifacts' });
+  });
 }
 
 /**

--- a/src/bot/outbound-artifacts.ts
+++ b/src/bot/outbound-artifacts.ts
@@ -1,0 +1,198 @@
+import type { LarkChannel, SendOptions } from '@larksuite/channel';
+import { realpath, stat } from 'node:fs/promises';
+import { basename, extname, isAbsolute, resolve } from 'node:path';
+import type { RunState } from '../card/run-state';
+import { log } from '../core/logger';
+
+const OUTBOUND_IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp']);
+const OUTBOUND_IMAGE_MAX_COUNT = 6;
+const OUTBOUND_IMAGE_MAX_BYTES = 25 * 1024 * 1024;
+const OUTBOUND_FILE_MAX_COUNT = 6;
+const OUTBOUND_FILE_MAX_BYTES = 25 * 1024 * 1024;
+const OUTBOUND_FILE_SCHEME = 'bridge-file:';
+
+export async function sendOutboundArtifacts(
+  channel: LarkChannel,
+  chatId: string,
+  state: RunState,
+  cwd: string,
+  sendOpts: SendOptions,
+): Promise<void> {
+  await sendOutboundImages(channel, chatId, state, cwd, sendOpts);
+  await sendOutboundFiles(channel, chatId, state, cwd, sendOpts);
+}
+
+async function sendOutboundImages(
+  channel: LarkChannel,
+  chatId: string,
+  state: RunState,
+  cwd: string,
+  sendOpts: SendOptions,
+): Promise<void> {
+  if (state.terminal === 'running') return;
+  const candidates = extractOutboundImageCandidates(state);
+  if (candidates.length === 0) return;
+  const images = await resolveOutboundImageCandidates(candidates, cwd);
+  if (images.length === 0) return;
+  await allowOutboundDir(channel, cwd);
+
+  for (const imagePath of images) {
+    try {
+      await channel.send(chatId, { image: { source: imagePath } }, sendOpts);
+      log.info('media', 'outbound-image-sent', { path: imagePath });
+    } catch (err) {
+      log.fail('media', err, { step: 'outbound-image-send', path: imagePath });
+    }
+  }
+}
+
+async function sendOutboundFiles(
+  channel: LarkChannel,
+  chatId: string,
+  state: RunState,
+  cwd: string,
+  sendOpts: SendOptions,
+): Promise<void> {
+  if (state.terminal === 'running') return;
+  const candidates = extractOutboundFileCandidates(state);
+  if (candidates.length === 0) return;
+  const files = await resolveOutboundFileCandidates(candidates, cwd);
+  if (files.length === 0) return;
+  await allowOutboundDir(channel, cwd);
+
+  for (const filePath of files) {
+    try {
+      await channel.send(chatId, { file: { source: filePath, fileName: basename(filePath) } }, sendOpts);
+      log.info('media', 'outbound-file-sent', { path: filePath });
+    } catch (err) {
+      log.fail('media', err, { step: 'outbound-file-send', path: filePath });
+    }
+  }
+}
+
+export function extractOutboundImageCandidates(state: RunState): string[] {
+  const out: string[] = [];
+  for (const block of state.blocks) {
+    if (block.kind !== 'text') continue;
+    out.push(...extractImagePathsFromText(block.content));
+  }
+  return uniqueStrings(out).slice(0, OUTBOUND_IMAGE_MAX_COUNT * 3);
+}
+
+export function extractOutboundFileCandidates(state: RunState): string[] {
+  const out: string[] = [];
+  for (const block of state.blocks) {
+    if (block.kind !== 'text') continue;
+    out.push(...extractFilePathsFromText(block.content));
+  }
+  return uniqueStrings(out).slice(0, OUTBOUND_FILE_MAX_COUNT * 3);
+}
+
+function extractImagePathsFromText(text: string): string[] {
+  const out: string[] = [];
+  const markdownImage = /!\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+  for (const match of text.matchAll(markdownImage)) {
+    const raw = cleanImagePathCandidate(match[1]);
+    if (raw) out.push(raw);
+  }
+  return out;
+}
+
+function extractFilePathsFromText(text: string): string[] {
+  const out: string[] = [];
+  const markdownLink = /(?<!!)\[[^\]]+]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
+  for (const match of text.matchAll(markdownLink)) {
+    const raw = cleanFilePathCandidate(match[1]);
+    if (raw) out.push(raw);
+  }
+  return out;
+}
+
+function cleanImagePathCandidate(value: string | undefined): string | undefined {
+  if (!value || /^https?:\/\//i.test(value)) return undefined;
+  let s = value.trim();
+  if (s.startsWith('file://')) {
+    try {
+      s = decodeURIComponent(new URL(s).pathname);
+    } catch {
+      return undefined;
+    }
+  }
+  s = s.replace(/[),.;，。；]+$/g, '');
+  return s && OUTBOUND_IMAGE_EXTENSIONS.has(extname(s).toLowerCase()) ? s : undefined;
+}
+
+function cleanFilePathCandidate(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  let s = value.trim();
+  if (!s.startsWith(OUTBOUND_FILE_SCHEME)) return undefined;
+  s = s.slice(OUTBOUND_FILE_SCHEME.length);
+  s = s.replace(/[),.;，。；]+$/g, '');
+  if (!s || OUTBOUND_IMAGE_EXTENSIONS.has(extname(s).toLowerCase())) return undefined;
+  return s;
+}
+
+export async function resolveOutboundImageCandidates(
+  candidates: readonly string[],
+  cwd: string,
+): Promise<string[]> {
+  const cwdReal = await realpath(cwd).catch(() => cwd);
+  const out: string[] = [];
+  for (const candidate of candidates) {
+    if (out.length >= OUTBOUND_IMAGE_MAX_COUNT) break;
+    const abs = isAbsolute(candidate) ? candidate : resolve(cwdReal, candidate);
+    let real: string;
+    try {
+      real = await realpath(abs);
+    } catch {
+      continue;
+    }
+    if (!isPathInside(real, cwdReal)) continue;
+    if (!OUTBOUND_IMAGE_EXTENSIONS.has(extname(real).toLowerCase())) continue;
+    const info = await stat(real).catch(() => undefined);
+    if (!info?.isFile() || info.size <= 0 || info.size > OUTBOUND_IMAGE_MAX_BYTES) continue;
+    out.push(real);
+  }
+  return uniqueStrings(out);
+}
+
+export async function resolveOutboundFileCandidates(
+  candidates: readonly string[],
+  cwd: string,
+): Promise<string[]> {
+  const cwdReal = await realpath(cwd).catch(() => cwd);
+  const out: string[] = [];
+  for (const candidate of candidates) {
+    if (out.length >= OUTBOUND_FILE_MAX_COUNT) break;
+    const abs = isAbsolute(candidate) ? candidate : resolve(cwdReal, candidate);
+    let real: string;
+    try {
+      real = await realpath(abs);
+    } catch {
+      continue;
+    }
+    if (!isPathInside(real, cwdReal)) continue;
+    if (OUTBOUND_IMAGE_EXTENSIONS.has(extname(real).toLowerCase())) continue;
+    const info = await stat(real).catch(() => undefined);
+    if (!info?.isFile() || info.size <= 0 || info.size > OUTBOUND_FILE_MAX_BYTES) continue;
+    out.push(real);
+  }
+  return uniqueStrings(out);
+}
+
+function isPathInside(path: string, root: string): boolean {
+  return path === root || path.startsWith(root.endsWith('/') ? root : `${root}/`);
+}
+
+async function allowOutboundDir(channel: LarkChannel, cwd: string): Promise<void> {
+  const sender = (channel as unknown as { sender?: { config?: { allowedFileDirs?: unknown } } }).sender;
+  const cfg = sender?.config;
+  if (!cfg || typeof cfg !== 'object') return;
+  const cwdReal = await realpath(cwd).catch(() => cwd);
+  const existing = Array.isArray(cfg.allowedFileDirs) ? cfg.allowedFileDirs : [];
+  cfg.allowedFileDirs = uniqueStrings([...existing, cwdReal]);
+}
+
+function uniqueStrings(values: readonly unknown[]): string[] {
+  return [...new Set(values.filter((value): value is string => typeof value === 'string' && value.length > 0))];
+}

--- a/src/bot/outbound-artifacts.ts
+++ b/src/bot/outbound-artifacts.ts
@@ -10,6 +10,11 @@ const OUTBOUND_IMAGE_MAX_BYTES = 25 * 1024 * 1024;
 const OUTBOUND_FILE_MAX_COUNT = 6;
 const OUTBOUND_FILE_MAX_BYTES = 25 * 1024 * 1024;
 const OUTBOUND_FILE_SCHEME = 'bridge-file:';
+const OUTBOUND_SEND_TIMEOUT_MS = 30_000;
+
+export interface SendOutboundArtifactsOptions {
+  sendTimeoutMs?: number;
+}
 
 export async function sendOutboundArtifacts(
   channel: LarkChannel,
@@ -17,9 +22,10 @@ export async function sendOutboundArtifacts(
   state: RunState,
   cwd: string,
   sendOpts: SendOptions,
+  options: SendOutboundArtifactsOptions = {},
 ): Promise<void> {
-  await sendOutboundImages(channel, chatId, state, cwd, sendOpts);
-  await sendOutboundFiles(channel, chatId, state, cwd, sendOpts);
+  await sendOutboundImages(channel, chatId, state, cwd, sendOpts, options);
+  await sendOutboundFiles(channel, chatId, state, cwd, sendOpts, options);
 }
 
 async function sendOutboundImages(
@@ -28,6 +34,7 @@ async function sendOutboundImages(
   state: RunState,
   cwd: string,
   sendOpts: SendOptions,
+  options: SendOutboundArtifactsOptions,
 ): Promise<void> {
   if (state.terminal === 'running') return;
   const candidates = extractOutboundImageCandidates(state);
@@ -38,7 +45,11 @@ async function sendOutboundImages(
 
   for (const imagePath of images) {
     try {
-      await channel.send(chatId, { image: { source: imagePath } }, sendOpts);
+      await withTimeout(
+        channel.send(chatId, { image: { source: imagePath } }, sendOpts),
+        options.sendTimeoutMs ?? OUTBOUND_SEND_TIMEOUT_MS,
+        'outbound image send timed out',
+      );
       log.info('media', 'outbound-image-sent', { path: imagePath });
     } catch (err) {
       log.fail('media', err, { step: 'outbound-image-send', path: imagePath });
@@ -52,6 +63,7 @@ async function sendOutboundFiles(
   state: RunState,
   cwd: string,
   sendOpts: SendOptions,
+  options: SendOutboundArtifactsOptions,
 ): Promise<void> {
   if (state.terminal === 'running') return;
   const candidates = extractOutboundFileCandidates(state);
@@ -62,7 +74,11 @@ async function sendOutboundFiles(
 
   for (const filePath of files) {
     try {
-      await channel.send(chatId, { file: { source: filePath, fileName: basename(filePath) } }, sendOpts);
+      await withTimeout(
+        channel.send(chatId, { file: { source: filePath, fileName: basename(filePath) } }, sendOpts),
+        options.sendTimeoutMs ?? OUTBOUND_SEND_TIMEOUT_MS,
+        'outbound file send timed out',
+      );
       log.info('media', 'outbound-file-sent', { path: filePath });
     } catch (err) {
       log.fail('media', err, { step: 'outbound-file-send', path: filePath });
@@ -88,6 +104,17 @@ export function extractOutboundFileCandidates(state: RunState): string[] {
   return uniqueStrings(out).slice(0, OUTBOUND_FILE_MAX_COUNT * 3);
 }
 
+export function sanitizeOutboundArtifactReferences(state: RunState): RunState {
+  return {
+    ...state,
+    blocks: state.blocks.map((block) =>
+      block.kind === 'text'
+        ? { ...block, content: sanitizeOutboundArtifactText(block.content) }
+        : block,
+    ),
+  };
+}
+
 function extractImagePathsFromText(text: string): string[] {
   const out: string[] = [];
   const markdownImage = /!\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g;
@@ -106,6 +133,21 @@ function extractFilePathsFromText(text: string): string[] {
     if (raw) out.push(raw);
   }
   return out;
+}
+
+function sanitizeOutboundArtifactText(text: string): string {
+  return text
+    .replace(/!\[([^\]]*)]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g, (match, alt, href) => {
+      const candidate = cleanImagePathCandidate(href);
+      if (!candidate) return match;
+      const label = String(alt || basename(candidate) || 'image').trim();
+      return `图片已作为附件发送：${label}`;
+    })
+    .replace(/(?<!!)\[([^\]]+)]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g, (match, label, href) => {
+      const candidate = cleanFilePathCandidate(href);
+      if (!candidate) return match;
+      return `文件已作为附件发送：${String(label || basename(candidate) || 'file').trim()}`;
+    });
 }
 
 function cleanImagePathCandidate(value: string | undefined): string | undefined {
@@ -195,4 +237,16 @@ async function allowOutboundDir(channel: LarkChannel, cwd: string): Promise<void
 
 function uniqueStrings(values: readonly unknown[]): string[] {
   return [...new Set(values.filter((value): value is string => typeof value === 'string' && value.length > 0))];
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return promise;
+  let timer: NodeJS.Timeout | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  promise.catch(() => undefined);
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
 }

--- a/tests/integration/bot/markdown-stream-startup-failure.test.ts
+++ b/tests/integration/bot/markdown-stream-startup-failure.test.ts
@@ -156,6 +156,30 @@ describe('markdown stream startup failures', () => {
       ),
     );
   }, 10_000);
+
+  it('falls back when the stream does not finish after the agent reaches terminal state', async () => {
+    let streamProducerStarted = false;
+    const h = await createHarness({
+      stream: async (_chatId, input) => {
+        const producer = (input as {
+          markdown?: (ctrl: { setContent(markdown: string): Promise<void> }) => Promise<void>;
+        }).markdown;
+        if (producer) {
+          streamProducerStarted = true;
+          void producer({ setContent: vi.fn(async () => {}) });
+        }
+        await new Promise<void>(() => {});
+      },
+    });
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(message('om_first', 'first'));
+    await waitFor(() => streamProducerStarted);
+    await waitFor(() => h.channel.sent.length > 0, 4500);
+
+    expect(lastMarkdown(h.channel)).toContain('agent 失败');
+    expect(lastMarkdown(h.channel)).toContain('codex exited with code 1');
+  }, 10_000);
 });
 
 async function createHarness(options: {

--- a/tests/unit/agent/bridge-system-prompt.test.ts
+++ b/tests/unit/agent/bridge-system-prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  BRIDGE_OUTBOUND_MEDIA_PROMPT,
   BRIDGE_SYSTEM_PROMPT,
   buildBridgeSystemPrompt,
   prefixBridgeSystemPrompt,
@@ -40,8 +41,10 @@ describe('bridge system prompt bot collaboration rules', () => {
 });
 
 describe('buildBridgeSystemPrompt', () => {
-  it('returns the base prompt unchanged when no identity is available', () => {
-    expect(buildBridgeSystemPrompt(undefined)).toBe(BRIDGE_SYSTEM_PROMPT);
+  it('returns the base prompt plus outbound media instructions when no identity is available', () => {
+    expect(buildBridgeSystemPrompt(undefined)).toBe(
+      `${BRIDGE_SYSTEM_PROMPT}${BRIDGE_OUTBOUND_MEDIA_PROMPT}`,
+    );
   });
 
   it('appends a concrete identity line with open_id and name', () => {
@@ -68,6 +71,7 @@ describe('prefixBridgeSystemPrompt', () => {
   it('keeps working without an identity', () => {
     const prompt = prefixBridgeSystemPrompt('hello world', undefined);
     expect(prompt.startsWith(BRIDGE_SYSTEM_PROMPT)).toBe(true);
+    expect(prompt).toContain(BRIDGE_OUTBOUND_MEDIA_PROMPT);
     expect(prompt.endsWith('hello world')).toBe(true);
   });
 });

--- a/tests/unit/bot/outbound-artifacts.test.ts
+++ b/tests/unit/bot/outbound-artifacts.test.ts
@@ -7,6 +7,7 @@ import {
   extractOutboundImageCandidates,
   resolveOutboundFileCandidates,
   resolveOutboundImageCandidates,
+  sanitizeOutboundArtifactReferences,
   sendOutboundArtifacts,
 } from '../../../src/bot/outbound-artifacts.js';
 import type { RunState } from '../../../src/card/run-state.js';
@@ -24,6 +25,34 @@ describe('outbound artifacts', () => {
 
     expect(extractOutboundImageCandidates(state)).toEqual(['renders/result.png']);
     expect(extractOutboundFileCandidates(state)).toEqual(['outbound-files/deepsketch_example.3dm']);
+  });
+
+  it('sanitizes local artifact references while preserving surrounding text', () => {
+    const state = finalState(
+      [
+        'before image',
+        '![preview](renders/result.png)',
+        'after image',
+        '[model](bridge-file:outbound-files/deepsketch_example.3dm)',
+        '[docs](src/bot/channel.ts)',
+        '![remote](https://example.com/image.png)',
+      ].join('\n'),
+    );
+
+    expect(sanitizeOutboundArtifactReferences(state).blocks).toEqual([
+      {
+        kind: 'text',
+        streaming: false,
+        content: [
+          'before image',
+          '图片已作为附件发送：preview',
+          'after image',
+          '文件已作为附件发送：model',
+          '[docs](src/bot/channel.ts)',
+          '![remote](https://example.com/image.png)',
+        ].join('\n'),
+      },
+    ]);
   });
 
   it('resolves only workspace-contained image and non-image file candidates', async () => {
@@ -87,6 +116,42 @@ describe('outbound artifacts', () => {
         },
       ]);
       expect(channel.sender.config.allowedFileDirs).toContain(root);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('times out stalled sends and continues with later artifacts', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'outbound-artifacts-timeout-'));
+    try {
+      const image = join(root, 'preview.png');
+      const file = join(root, 'model.3dm');
+      await writeFile(image, Buffer.from([1, 2, 3]));
+      await writeFile(file, Buffer.from([4, 5, 6]));
+      const sent: unknown[] = [];
+      const channel = {
+        sender: { config: { allowedFileDirs: [] as string[] } },
+        send: async (_chatId: string, content: unknown) => {
+          sent.push(content);
+          if ((content as { image?: unknown }).image) {
+            await new Promise(() => undefined);
+          }
+        },
+      };
+
+      await sendOutboundArtifacts(
+        channel as never,
+        'oc_test',
+        finalState(`![preview](preview.png)\n[model](bridge-file:model.3dm)`),
+        root,
+        { replyTo: 'om_test' },
+        { sendTimeoutMs: 5 },
+      );
+
+      expect(sent).toEqual([
+        { image: { source: image } },
+        { file: { source: file, fileName: 'model.3dm' } },
+      ]);
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/tests/unit/bot/outbound-artifacts.test.ts
+++ b/tests/unit/bot/outbound-artifacts.test.ts
@@ -1,0 +1,103 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  extractOutboundFileCandidates,
+  extractOutboundImageCandidates,
+  resolveOutboundFileCandidates,
+  resolveOutboundImageCandidates,
+  sendOutboundArtifacts,
+} from '../../../src/bot/outbound-artifacts.js';
+import type { RunState } from '../../../src/card/run-state.js';
+
+describe('outbound artifacts', () => {
+  it('extracts only markdown images and explicit bridge-file links from final text blocks', () => {
+    const state = finalState(
+      [
+        'image: ![preview](renders/result.png) and plain screenshots/view.webp',
+        'file: [model](bridge-file:outbound-files/deepsketch_example.3dm) plus reports/run.log',
+        'source reference: [channel.ts](src/bot/channel.ts) and package.json',
+        'ignore remote https://example.com/image.png',
+      ].join('\n'),
+    );
+
+    expect(extractOutboundImageCandidates(state)).toEqual(['renders/result.png']);
+    expect(extractOutboundFileCandidates(state)).toEqual(['outbound-files/deepsketch_example.3dm']);
+  });
+
+  it('resolves only workspace-contained image and non-image file candidates', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'outbound-artifacts-'));
+    const outside = await mkdtemp(join(tmpdir(), 'outbound-artifacts-outside-'));
+    try {
+      await mkdir(join(root, 'renders'));
+      await mkdir(join(root, 'files'));
+      const image = join(root, 'renders', 'result.png');
+      const file = join(root, 'files', 'model.3dm');
+      const outsideImage = join(outside, 'outside.png');
+      await writeFile(image, Buffer.from([1, 2, 3]));
+      await writeFile(file, Buffer.from([4, 5, 6]));
+      await writeFile(outsideImage, Buffer.from([7, 8, 9]));
+
+      await expect(resolveOutboundImageCandidates(['renders/result.png', outsideImage], root)).resolves.toEqual([
+        image,
+      ]);
+      await expect(resolveOutboundFileCandidates(['files/model.3dm', 'renders/result.png'], root)).resolves.toEqual([
+        file,
+      ]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+      await rm(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('sends resolved workspace images and files through the channel', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'outbound-artifacts-send-'));
+    try {
+      const image = join(root, 'preview.png');
+      const file = join(root, 'model.3dm');
+      await writeFile(image, Buffer.from([1, 2, 3]));
+      await writeFile(file, Buffer.from([4, 5, 6]));
+      const sent: Array<{ chatId: string; content: unknown; options: unknown }> = [];
+      const channel = {
+        sender: { config: { allowedFileDirs: [] as string[] } },
+        send: async (chatId: string, content: unknown, options: unknown) => {
+          sent.push({ chatId, content, options });
+        },
+      };
+
+      await sendOutboundArtifacts(
+        channel as never,
+        'oc_test',
+        finalState(`![preview](preview.png)\n[model](bridge-file:model.3dm)`),
+        root,
+        { replyTo: 'om_test' },
+      );
+
+      expect(sent).toEqual([
+        {
+          chatId: 'oc_test',
+          content: { image: { source: image } },
+          options: { replyTo: 'om_test' },
+        },
+        {
+          chatId: 'oc_test',
+          content: { file: { source: file, fileName: 'model.3dm' } },
+          options: { replyTo: 'om_test' },
+        },
+      ]);
+      expect(channel.sender.config.allowedFileDirs).toContain(root);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function finalState(content: string): RunState {
+  return {
+    blocks: [{ kind: 'text', content, streaming: false }],
+    reasoning: { content: '', active: false },
+    footer: null,
+    terminal: 'done',
+  };
+}


### PR DESCRIPTION
This fixes two bridge-side issues seen in long agent runs.

- Send workspace-local images referenced with Markdown image syntax in the final reply.
- Send workspace-local files only from explicit `bridge-file:` attachment links.
- Fall back to a final message when a streaming card does not finish cleanly.

Plain paths and ordinary Markdown links are ignored for file upload, so source paths mentioned in an answer are not sent as attachments.

Tests:
- `pnpm vitest run tests/unit/bot/outbound-artifacts.test.ts tests/unit/agent/bridge-system-prompt.test.ts tests/integration/bot/markdown-stream-startup-failure.test.ts`
- `pnpm typecheck`
- `pnpm build`