### PR TITLE
feat(claude): support image inputs via stream-json stdin | 支持Claude接收 Lark 图片输入

### DIFF
--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -1,26 +1,27 @@
 import { createInterface } from 'node:readline';
-import type { Readable } from 'node:stream';
+import type { Readable, Writable } from 'node:stream';
 import { log } from '../../core/logger';
 import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
 import { buildBridgeSystemPrompt } from '../bridge-system-prompt';
 import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel-env';
 import { checkAgentAvailability, type AgentAvailability } from '../preflight';
 import {
-  CLAUDE_DEFAULT_PERMISSION_MODE,
   type AgentAdapter,
   type AgentBotIdentity,
   type AgentEvent,
   type AgentRun,
   type AgentRunOptions,
 } from '../types';
+import { buildClaudeArgs } from './argv';
 import { translateEvent } from './stream-json';
+import { buildStreamJsonInput } from './stream-json-input';
 
 export interface ClaudeAdapterOptions {
   binary?: string;
   larkChannel?: LarkChannelEnvContext;
 }
 
-type ClaudeChild = SpawnedProcessByStdio<null, Readable, Readable>;
+type ClaudeChild = SpawnedProcessByStdio<Writable | null, Readable, Readable>;
 
 export class ClaudeAdapter implements AgentAdapter {
   readonly id = 'claude';
@@ -29,6 +30,14 @@ export class ClaudeAdapter implements AgentAdapter {
   private readonly binary: string;
   private readonly larkChannel: LarkChannelEnvContext | undefined;
   private botIdentity: AgentBotIdentity | undefined;
+  // stream-json stdin payloads precomputed in prepareRun() and consumed once by
+  // the matching run(). Base64-encoding images is async, but run() must stay
+  // synchronous (it attaches process listeners in the same tick), so the async
+  // work happens in the prepareRun() hook beforehand. Keyed on the AgentRunOptions
+  // object (the executor passes the same reference to both hooks) via a WeakMap,
+  // so a prepareRun() that is never followed by run() — e.g. the executor aborts
+  // between the two — leaves no leaked entry.
+  private readonly pendingStdin = new WeakMap<AgentRunOptions, string>();
 
   constructor(opts: ClaudeAdapterOptions = {}) {
     this.binary = opts.binary ?? 'claude';
@@ -52,29 +61,39 @@ export class ClaudeAdapter implements AgentAdapter {
     });
   }
 
+  // Claude Code ingests images only through `--input-format stream-json` on
+  // stdin (no `--image` flag). When the run carries accepted images, encode
+  // them into a stream-json user message here so run() can feed it via stdin.
+  async prepareRun(opts: AgentRunOptions): Promise<void> {
+    if (!opts.images || opts.images.length === 0) return;
+    const payload = await buildStreamJsonInput(opts.prompt, opts.images);
+    if (payload) this.pendingStdin.set(opts, payload);
+  }
+
   run(opts: AgentRunOptions): AgentRun {
     if (!opts.cwd) {
       throw new Error('cwd is required for ClaudeAdapter.run');
     }
 
-    const args = [
-      '-p',
-      opts.prompt,
-      '--output-format',
-      'stream-json',
-      '--verbose',
-      '--permission-mode',
-      opts.permissionMode ?? CLAUDE_DEFAULT_PERMISSION_MODE,
-      '--append-system-prompt',
-      buildBridgeSystemPrompt(this.botIdentity),
-    ];
-    if (opts.sessionId) args.push('--resume', opts.sessionId);
-    if (opts.model) args.push('--model', opts.model);
+    // prepareRun() stages a stdin payload only when the run has images; its
+    // presence selects stdin stream-json over the plain `-p <prompt>` path.
+    const stdinPayload = this.pendingStdin.get(opts);
+    this.pendingStdin.delete(opts);
+    const useStreamJson = stdinPayload !== undefined;
+
+    const args = buildClaudeArgs({
+      prompt: opts.prompt,
+      systemPrompt: buildBridgeSystemPrompt(this.botIdentity),
+      permissionMode: opts.permissionMode,
+      sessionId: opts.sessionId,
+      model: opts.model,
+      streamJson: useStreamJson,
+    });
 
     const child = spawnProcess(this.binary, args, {
       cwd: opts.cwd,
       env: mergeProcessEnv(process.env, buildLarkChannelEnv(this.larkChannel)),
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: [useStreamJson ? 'pipe' : 'ignore', 'pipe', 'pipe'],
     }) as ClaudeChild;
 
     log.info('agent', 'spawn', {
@@ -83,7 +102,19 @@ export class ClaudeAdapter implements AgentAdapter {
       hasSession: Boolean(opts.sessionId),
       promptChars: opts.prompt.length,
       model: opts.model,
+      images: opts.images?.length ?? 0,
+      streamJson: useStreamJson,
     });
+
+    // Feed the stream-json user message (text + base64 image blocks) and close
+    // stdin so claude starts processing. Guard stdin errors like the codex
+    // adapter does — a broken pipe here must not crash the bridge.
+    if (useStreamJson && child.stdin) {
+      child.stdin.on('error', (err: Error) => {
+        log.warn('agent', 'stdin-error', { message: err.message });
+      });
+      child.stdin.end(stdinPayload, 'utf8');
+    }
 
     // Listeners MUST be attached synchronously here, before we return.
     // The 'error' and exit-related events can fire in the next tick; if we

--- a/src/agent/claude/argv.ts
+++ b/src/agent/claude/argv.ts
@@ -1,0 +1,35 @@
+import { CLAUDE_DEFAULT_PERMISSION_MODE, type ClaudePermissionMode } from '../types';
+
+export interface BuildClaudeArgsInput {
+  /** The user prompt. Only placed in argv on the text path; on the
+   *  stream-json path it travels via stdin instead, so it's omitted here. */
+  prompt: string;
+  systemPrompt: string;
+  permissionMode?: ClaudePermissionMode;
+  sessionId?: string;
+  model?: string;
+  /** When true, read the user message from stdin as stream-json (the image
+   *  path) instead of passing `-p <prompt>` in argv (the text path). */
+  streamJson?: boolean;
+}
+
+export function buildClaudeArgs(input: BuildClaudeArgsInput): string[] {
+  // Both paths share everything except how the prompt is delivered: the
+  // text path puts it in argv (`-p <prompt>`), the stream-json path leaves
+  // `-p` bare and feeds the prompt + images over stdin.
+  const promptArgs = input.streamJson ? ['-p', '--input-format', 'stream-json'] : ['-p', input.prompt];
+
+  const args = [
+    ...promptArgs,
+    '--output-format',
+    'stream-json',
+    '--verbose',
+    '--permission-mode',
+    input.permissionMode ?? CLAUDE_DEFAULT_PERMISSION_MODE,
+    '--append-system-prompt',
+    input.systemPrompt,
+  ];
+  if (input.sessionId) args.push('--resume', input.sessionId);
+  if (input.model) args.push('--model', input.model);
+  return args;
+}

--- a/src/agent/claude/stream-json-input.ts
+++ b/src/agent/claude/stream-json-input.ts
@@ -1,0 +1,94 @@
+import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
+import { log } from '../../core/logger';
+
+/**
+ * Claude Code's `--print` mode accepts images only via `--input-format
+ * stream-json`: a single `user` message on stdin whose `content` array carries
+ * text plus one or more base64 image blocks (the standard Anthropic Messages
+ * shape). There is no `--image` flag like codex has. This module turns the
+ * text prompt + local image paths into that stdin payload.
+ */
+
+const IMAGE_MEDIA_TYPE: Record<string, string> = {
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.gif': 'image/gif',
+};
+
+// Anthropic rejects images whose base64 payload exceeds ~5MB. The bridge media
+// policy already caps accepted images well below this, but guard anyway so a
+// stray large file degrades to "path only" instead of failing the whole run.
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+
+function mediaTypeFor(path: string): string | undefined {
+  return IMAGE_MEDIA_TYPE[extname(path).toLowerCase()];
+}
+
+interface TextBlock {
+  type: 'text';
+  text: string;
+}
+
+interface ImageBlock {
+  type: 'image';
+  source: { type: 'base64'; media_type: string; data: string };
+}
+
+type ContentBlock = TextBlock | ImageBlock;
+
+/**
+ * Read each image path and encode it as a base64 image block. Paths that can't
+ * be read or have an unsupported extension are skipped (logged) rather than
+ * aborting the run — the path still appears in the prompt JSON, so the agent
+ * can fall back to reading it explicitly.
+ */
+export async function buildImageBlocks(paths: readonly string[]): Promise<ImageBlock[]> {
+  const blocks: ImageBlock[] = [];
+  for (const path of paths) {
+    const mediaType = mediaTypeFor(path);
+    if (!mediaType) {
+      log.warn('agent', 'image-skip-mime', { path, reason: 'unsupported-extension' });
+      continue;
+    }
+    try {
+      const buf = await readFile(path);
+      if (buf.byteLength === 0 || buf.byteLength > MAX_IMAGE_BYTES) {
+        log.warn('agent', 'image-skip-size', { path, bytes: buf.byteLength });
+        continue;
+      }
+      blocks.push({
+        type: 'image',
+        source: { type: 'base64', media_type: mediaType, data: buf.toString('base64') },
+      });
+    } catch (err) {
+      log.warn('agent', 'image-skip-read', {
+        path,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return blocks;
+}
+
+/**
+ * Build the newline-terminated stream-json user message to write to claude's
+ * stdin. Returns null when there are no usable image blocks, signalling the
+ * caller to stay on the plain `-p` text path (zero behaviour change).
+ */
+export async function buildStreamJsonInput(
+  prompt: string,
+  imagePaths: readonly string[],
+): Promise<string | null> {
+  const imageBlocks = await buildImageBlocks(imagePaths);
+  if (imageBlocks.length === 0) return null;
+
+  const content: ContentBlock[] = [{ type: 'text', text: prompt }, ...imageBlocks];
+  const message = {
+    type: 'user',
+    message: { role: 'user', content },
+  };
+  return `${JSON.stringify(message)}\n`;
+}

--- a/src/bot/run-flow.ts
+++ b/src/bot/run-flow.ts
@@ -143,8 +143,11 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
       policy,
       sessionId,
       threadId,
+      // Both codex and claude can ingest images now; codex via --image argv,
+      // claude via stream-json stdin (see claude/adapter.ts). Other agents
+      // still get undefined.
       images:
-        input.capability.agentId === 'codex'
+        input.capability.agentId === 'codex' || input.capability.agentId === 'claude'
           ? policy.attachments
               .filter((attachment) => attachment.kind === 'image' && attachment.decision === 'accepted')
               .map((attachment) => attachment.path)

--- a/tests/unit/agent/claude-argv.test.ts
+++ b/tests/unit/agent/claude-argv.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { buildClaudeArgs } from '../../../src/agent/claude/argv.js';
+
+describe('Claude argv contract', () => {
+  it('builds the text path with the prompt in argv', () => {
+    expect(
+      buildClaudeArgs({ prompt: 'hello', systemPrompt: 'SYS' }),
+    ).toEqual([
+      '-p',
+      'hello',
+      '--output-format',
+      'stream-json',
+      '--verbose',
+      '--permission-mode',
+      'bypassPermissions',
+      '--append-system-prompt',
+      'SYS',
+    ]);
+  });
+
+  it('builds the stream-json path without the prompt in argv', () => {
+    const args = buildClaudeArgs({ prompt: 'hello', systemPrompt: 'SYS', streamJson: true });
+    expect(args.slice(0, 3)).toEqual(['-p', '--input-format', 'stream-json']);
+    // The prompt travels via stdin on this path, never argv.
+    expect(args).not.toContain('hello');
+    expect(args).toContain('--output-format');
+    expect(args).toContain('--append-system-prompt');
+  });
+
+  it('honours an explicit permission mode', () => {
+    const args = buildClaudeArgs({ prompt: 'x', systemPrompt: 'SYS', permissionMode: 'default' });
+    const i = args.indexOf('--permission-mode');
+    expect(args[i + 1]).toBe('default');
+  });
+
+  it('appends resume and model flags in order when present', () => {
+    const args = buildClaudeArgs({
+      prompt: 'x',
+      systemPrompt: 'SYS',
+      sessionId: 'sess-1',
+      model: 'opus',
+    });
+    expect(args).toContain('--resume');
+    expect(args[args.indexOf('--resume') + 1]).toBe('sess-1');
+    expect(args[args.indexOf('--model') + 1]).toBe('opus');
+  });
+
+  it('omits resume and model flags when absent', () => {
+    const args = buildClaudeArgs({ prompt: 'x', systemPrompt: 'SYS' });
+    expect(args).not.toContain('--resume');
+    expect(args).not.toContain('--model');
+  });
+});

--- a/tests/unit/agent/claude-stream-json-input.test.ts
+++ b/tests/unit/agent/claude-stream-json-input.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { buildStreamJsonInput } from '../../../src/agent/claude/stream-json-input.js';
+
+const cleanups: Array<() => Promise<void>> = [];
+
+async function tmpImage(name: string, bytes: Buffer): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'claude-img-'));
+  cleanups.push(() => rm(dir, { recursive: true, force: true }));
+  const path = join(dir, name);
+  await writeFile(path, bytes);
+  return path;
+}
+
+// 1x1 transparent PNG.
+const PNG_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+describe('buildStreamJsonInput', () => {
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+  });
+
+  it('returns null when there are no image paths', async () => {
+    expect(await buildStreamJsonInput('hello', [])).toBeNull();
+  });
+
+  it('builds a stream-json user message with text + base64 image block', async () => {
+    const path = await tmpImage('a.png', PNG_BYTES);
+    const payload = await buildStreamJsonInput('describe this', [path]);
+    expect(payload).not.toBeNull();
+    expect(payload!.endsWith('\n')).toBe(true);
+
+    const msg = JSON.parse(payload!.trim());
+    expect(msg.type).toBe('user');
+    expect(msg.message.role).toBe('user');
+    const content = msg.message.content;
+    expect(content[0]).toEqual({ type: 'text', text: 'describe this' });
+    expect(content[1].type).toBe('image');
+    expect(content[1].source).toMatchObject({ type: 'base64', media_type: 'image/png' });
+    expect(content[1].source.data).toBe(PNG_BYTES.toString('base64'));
+  });
+
+  it('maps known extensions to the right media type', async () => {
+    const path = await tmpImage('a.jpg', PNG_BYTES);
+    const payload = await buildStreamJsonInput('x', [path]);
+    const msg = JSON.parse(payload!.trim());
+    expect(msg.message.content[1].source.media_type).toBe('image/jpeg');
+  });
+
+  it('skips unsupported extensions and returns null when nothing usable remains', async () => {
+    const path = await tmpImage('a.bmp', PNG_BYTES);
+    expect(await buildStreamJsonInput('x', [path])).toBeNull();
+  });
+
+  it('skips unreadable paths and returns null', async () => {
+    expect(await buildStreamJsonInput('x', ['/no/such/file.png'])).toBeNull();
+  });
+
+  it('skips empty files', async () => {
+    const path = await tmpImage('empty.png', Buffer.alloc(0));
+    expect(await buildStreamJsonInput('x', [path])).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Lark image attachments now reach the Claude agent. Previously only the codex adapter forwarded images (via its `--image` argv); the claude adapter dropped them. Claude Code's `--print` mode doesn't have an `--image` flag — it accepts images only through `--input-format stream-json` on stdin — so this PR adds that path.

When a run carries accepted images, the adapter encodes the text prompt plus base64 image blocks into a single stream-json `user` message and feeds it over stdin. Runs without images are completely unchanged: they stay on the existing `-p <prompt>` text path.

## How it works

- **`src/agent/claude/stream-json-input.ts`** (new) — reads each accepted image path, base64-encodes it into an Anthropic image block, and builds the newline-terminated stream-json `user` message. Returns `null` when no usable image remains, signalling the caller to stay on the plain text path.
- **`src/agent/claude/adapter.ts`** — encoding (async) happens in the `prepareRun()` hook; the payload is staged on a `WeakMap` keyed by the run options object and consumed by the matching `run()`. This keeps `run()` synchronous (it must attach process listeners in the same tick) and means an aborted run leaves nothing behind.
- **`src/agent/claude/argv.ts`** (new) — argv construction extracted into `buildClaudeArgs()`, mirroring codex's `buildCodexArgs`, so the text and stream-json paths share one flag list instead of duplicating it.
- **`src/bot/run-flow.ts`** — forwards accepted image attachments to the claude agent (codex already received them).

---
Lark 的图片附件现在可以送达 Claude agent。此前只有 codex adapter 会转发图片（通过它的 `--image` 参数），claude adapter 会直接丢弃。Claude Code 的`--print` 模式没有 `--image` 参数 —— 它只能通过 stdin 上的`--input-format stream-json` 接收图片 —— 所以本 PR 补上了这条路径。
