### PR TITLE
Add optional card callback acknowledgements

### DIFF
--- a/src/card/dispatcher.ts
+++ b/src/card/dispatcher.ts
@@ -13,6 +13,7 @@ import type { SessionCatalog } from '../session/catalog';
 import type { SessionStore } from '../session/store';
 import type { WorkspaceStore } from '../workspace/store';
 import { commandSessionCatalogIdentity } from '../bot/session-catalog-identity';
+import { isManaged, updateManagedCard } from './managed';
 
 /** Marker key on a button's value object that flags the cardAction as
  * a callback that should be forwarded back to the agent instead
@@ -21,6 +22,7 @@ import { commandSessionCatalogIdentity } from '../bot/session-catalog-identity';
  * fields the agent might set.
  */
 const BRIDGE_CALLBACK_MARKER = '__bridge_cb';
+const BRIDGE_CALLBACK_ACK = 'bridge_ack';
 const LEGACY_CLAUDE_CALLBACK_MARKER = '__claude_cb';
 
 export interface CardDispatchDeps {
@@ -133,6 +135,7 @@ export async function handleCardAction(deps: CardDispatchDeps): Promise<void> {
   // as a follow-up message, with full context of what it sent.
   if (BRIDGE_CALLBACK_MARKER in payload) {
     if (!verifyBridgeToken(deps, payload, scope, 'agent_callback')) return;
+    await acknowledgeAgentCallback(deps, payload);
     forwardToAgent(deps, payload, formValue, scope, threadId, mode);
     return;
   }
@@ -180,6 +183,69 @@ async function lookupMessageThreadId(
   }
 }
 
+async function acknowledgeAgentCallback(
+  deps: CardDispatchDeps,
+  payload: Record<string, unknown>,
+): Promise<void> {
+  const ack = parseCallbackAck(payload[BRIDGE_CALLBACK_ACK]);
+  if (!ack) return;
+  if (!isManaged(deps.evt.messageId)) {
+    log.info('cardAction', 'ack-skip-unmanaged', { messageId: deps.evt.messageId });
+    return;
+  }
+  try {
+    await updateManagedCard(deps.channel, deps.evt.messageId, callbackAckCard(ack));
+  } catch (err) {
+    log.warn('cardAction', 'ack-update-failed', {
+      messageId: deps.evt.messageId,
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+interface CallbackAck {
+  title: string;
+  message: string;
+}
+
+function parseCallbackAck(value: unknown): CallbackAck | undefined {
+  if (value === true) {
+    return {
+      title: 'Action received',
+      message: 'The button click was sent to the local agent.',
+    };
+  }
+  if (!value || typeof value !== 'object') return undefined;
+  const input = value as Record<string, unknown>;
+  return {
+    title: cleanAckText(input.title, 'Action received'),
+    message: cleanAckText(input.message, 'The button click was sent to the local agent.'),
+  };
+}
+
+function cleanAckText(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, 200) : fallback;
+}
+
+function callbackAckCard(ack: CallbackAck): object {
+  return {
+    schema: '2.0',
+    config: {
+      summary: { content: ack.title },
+    },
+    body: {
+      elements: [
+        {
+          tag: 'markdown',
+          content: `**${ack.title}**\n\n${ack.message}`,
+        },
+      ],
+    },
+  };
+}
+
 function forwardToAgent(
   deps: CardDispatchDeps,
   payload: Record<string, unknown>,
@@ -191,6 +257,7 @@ function forwardToAgent(
   // Strip the marker so the agent only sees the meaningful fields it set.
   const {
     [BRIDGE_CALLBACK_MARKER]: _marker,
+    [BRIDGE_CALLBACK_ACK]: _ack,
     bridge_token: _token,
     ...agentPayload
   } = payload;

--- a/tests/integration/card/callback-dispatch.test.ts
+++ b/tests/integration/card/callback-dispatch.test.ts
@@ -6,6 +6,7 @@ import { PendingQueue } from '../../../src/bot/pending-queue.js';
 import { CallbackAuth } from '../../../src/card/callback-auth.js';
 import { CallbackNonceStore } from '../../../src/card/callback-store.js';
 import { handleCardAction } from '../../../src/card/dispatcher.js';
+import { sendManagedCard } from '../../../src/card/managed.js';
 import type { Controls } from '../../../src/commands/index.js';
 import { createDefaultProfileConfig } from '../../../src/config/profile-schema.js';
 import { SessionStore } from '../../../src/session/store.js';
@@ -63,6 +64,65 @@ describe('signed card callback dispatch', () => {
     expect(queued).toHaveLength(1);
     expect(queued[0]?.content).toBe('[card-click] {"choice":"a","form_value":{"note":"from form"}}');
     expect(queued[0]?.chatType).toBe('group');
+  });
+
+  it('updates a managed card when a signed bridge callback requests an acknowledgement', async () => {
+    const h = await createHarness();
+    h.activeRuns.register('oc_group', h.agent.run({ runId: 'run-active', prompt: 'running' }));
+    const { messageId } = await sendManagedCard(
+      h.channel as unknown as Parameters<typeof sendManagedCard>[0],
+      'oc_group',
+      {
+        schema: '2.0',
+        body: { elements: [{ tag: 'markdown', content: 'Choose an option.' }] },
+      },
+    );
+
+    await h.dispatch(
+      {
+        __bridge_cb: true,
+        bridge_token: h.token('agent_callback', { nonce: 'nonce-ack' }),
+        bridge_ack: {
+          title: 'Action received',
+          message: 'The button click was sent to the local agent.',
+        },
+        choice: 'a',
+      },
+      undefined,
+      { messageId },
+    );
+
+    const queued = h.pending.cancel('oc_group');
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.content).toBe('[card-click] {"choice":"a"}');
+
+    const update = h.channel.rawClient.requests.find(
+      (request) => request.method === 'cardkit.v1.card.update',
+    );
+    expect(update).toBeDefined();
+    expect(JSON.stringify(update?.params)).toContain('Action received');
+    expect(JSON.stringify(update?.params)).toContain('The button click was sent to the local agent.');
+    expect(JSON.stringify(update?.params)).not.toContain('"tag":"button"');
+    expect(JSON.stringify(update?.params)).not.toContain('"behaviors"');
+  });
+
+  it('still forwards an acknowledgement callback when the card is not managed', async () => {
+    const h = await createHarness();
+    h.activeRuns.register('oc_group', h.agent.run({ runId: 'run-active', prompt: 'running' }));
+
+    await h.dispatch({
+      __bridge_cb: true,
+      bridge_token: h.token('agent_callback', { nonce: 'nonce-unmanaged' }),
+      bridge_ack: true,
+      choice: 'b',
+    });
+
+    const queued = h.pending.cancel('oc_group');
+    expect(queued).toHaveLength(1);
+    expect(queued[0]?.content).toBe('[card-click] {"choice":"b"}');
+    expect(
+      h.channel.rawClient.requests.some((request) => request.method === 'cardkit.v1.card.update'),
+    ).toBe(false);
   });
 
   it('drops legacy Claude callback markers before command dispatch', async () => {
@@ -125,7 +185,11 @@ type Harness = {
   controls: Controls;
   pending: PendingQueue;
   auth: CallbackAuth;
-  dispatch(value: Record<string, unknown>, formValue?: Record<string, unknown>): Promise<void>;
+  dispatch(
+    value: Record<string, unknown>,
+    formValue?: Record<string, unknown>,
+    event?: { messageId?: string },
+  ): Promise<void>;
   token(
     action: string,
     overrides?: { operatorOpenId?: string; nonce?: string; scope?: string },
@@ -201,10 +265,10 @@ async function createHarness(
         ttlMs: 60_000,
       });
     },
-    dispatch: (value, formValue) =>
+    dispatch: (value, formValue, event) =>
       handleCardAction({
         channel: channel as unknown as Parameters<typeof handleCardAction>[0]['channel'],
-        evt: cardEvent(value, formValue),
+        evt: cardEvent(value, formValue, event),
         sessions,
         workspaces,
         activeRuns,
@@ -221,11 +285,12 @@ async function createHarness(
 function cardEvent(
   value: Record<string, unknown>,
   formValue?: Record<string, unknown>,
+  event: { messageId?: string } = {},
 ): CardActionEvent {
   return {
     action: { value },
     chatId: 'oc_group',
-    messageId: 'om_card',
+    messageId: event.messageId ?? 'om_card',
     operator: {
       openId: 'ou_operator',
       name: 'Operator',


### PR DESCRIPTION
## Summary

- Add an opt-in `bridge_ack` payload field for signed agent card callbacks.
- When the clicked card is managed by the bridge, replace it with a simple acknowledgement card before forwarding the callback to the agent.
- Strip bridge-only callback fields from the synthetic `[card-click]` payload and keep forwarding behavior unchanged for unmanaged cards.

## Verification

- `corepack pnpm exec vitest run tests/integration/card/callback-dispatch.test.ts`
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `git diff --check -- src/card/dispatcher.ts tests/integration/card/callback-dispatch.test.ts`