### PR TITLE
i18n: translate main user-facing card UIs to English

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A lightweight bot that bridges Feishu / Lark messenger with your local Claude Co
 
 [中文 README](./README.zh.md)
 
-关于能实现的效果，详情可以阅读[飞书文档](https://larkcommunity.feishu.cn/docx/OaRIdFIRFoLM3xxTmKwcetHqn5e)
+For a full walkthrough of what this bot can do (with screenshots and demos), see the [Feishu docs](https://larkcommunity.feishu.cn/docx/OaRIdFIRFoLM3xxTmKwcetHqn5e).
 
 ## What it does
 

--- a/src/card/account-cards.ts
+++ b/src/card/account-cards.ts
@@ -14,23 +14,23 @@ export interface CurrentInfo {
 export function accountCurrentCard(info: CurrentInfo): object {
   return {
     schema: '2.0',
-    config: { summary: { content: '当前应用' } },
+    config: { summary: { content: 'Current app' } },
     body: {
       elements: [
         {
           tag: 'markdown',
           content: [
-            '📋 **当前应用**',
+            '📋 **Current app**',
             '',
             `**App ID**: \`${maskAppId(info.appId)}\``,
-            `**Bot 名**: ${info.botName ?? '(未知)'}`,
+            `**Bot name**: ${info.botName ?? '(unknown)'}`,
             `**Tenant**: ${info.tenant}`,
           ].join('\n'),
         },
         { tag: 'hr' },
         {
           tag: 'button',
-          text: { tag: 'plain_text', content: '更换凭据' },
+          text: { tag: 'plain_text', content: 'Change credentials' },
           type: 'primary',
           behaviors: [{ type: 'callback', value: { cmd: 'account.change' } }],
         },
@@ -51,7 +51,7 @@ export function accountFormCard(opts: FormCardOpts = {}): object {
   if (errorMessage) {
     bodyElements.push({
       tag: 'markdown',
-      content: `❌ **校验失败**：${errorMessage}`,
+      content: `❌ **Validation failed**: ${errorMessage}`,
     });
   }
   bodyElements.push({
@@ -70,7 +70,7 @@ export function accountFormCard(opts: FormCardOpts = {}): object {
         tag: 'input',
         name: 'app_secret',
         label: { tag: 'plain_text', content: 'App Secret' },
-        placeholder: { tag: 'plain_text', content: '32 位字符串' },
+        placeholder: { tag: 'plain_text', content: '32-character string' },
         // Never prefill secret — even on validation retry. Pre-filled secrets
         // can leak into Lark's server-side card cache.
         required: true,
@@ -81,8 +81,8 @@ export function accountFormCard(opts: FormCardOpts = {}): object {
         name: 'tenant',
         initial_option: initialTenant,
         options: [
-          { text: { tag: 'plain_text', content: 'Feishu (国内)' }, value: 'feishu' },
-          { text: { tag: 'plain_text', content: 'Lark (海外)' }, value: 'lark' },
+          { text: { tag: 'plain_text', content: 'Feishu (China)' }, value: 'feishu' },
+          { text: { tag: 'plain_text', content: 'Lark (overseas)' }, value: 'lark' },
         ],
       },
       {
@@ -97,7 +97,7 @@ export function accountFormCard(opts: FormCardOpts = {}): object {
               {
                 tag: 'button',
                 name: 'submit_btn',
-                text: { tag: 'plain_text', content: '提交' },
+                text: { tag: 'plain_text', content: 'Submit' },
                 type: 'primary',
                 form_action_type: 'submit',
                 behaviors: [{ type: 'callback', value: { cmd: 'account.submit' } }],
@@ -111,7 +111,7 @@ export function accountFormCard(opts: FormCardOpts = {}): object {
               {
                 tag: 'button',
                 name: 'cancel_btn',
-                text: { tag: 'plain_text', content: '取消' },
+                text: { tag: 'plain_text', content: 'Cancel' },
                 behaviors: [{ type: 'callback', value: { cmd: 'account.cancel' } }],
               },
             ],
@@ -123,7 +123,7 @@ export function accountFormCard(opts: FormCardOpts = {}): object {
 
   return {
     schema: '2.0',
-    config: { summary: { content: '更换凭据' } },
+    config: { summary: { content: 'Change credentials' } },
     body: { elements: bodyElements },
   };
 }
@@ -131,28 +131,28 @@ export function accountFormCard(opts: FormCardOpts = {}): object {
 export function accountValidatingCard(): object {
   return {
     schema: '2.0',
-    config: { summary: { content: '正在校验...' } },
-    body: { elements: [{ tag: 'markdown', content: '⏳ **正在校验凭据...**' }] },
+    config: { summary: { content: 'Validating…' } },
+    body: { elements: [{ tag: 'markdown', content: '⏳ **Validating credentials…**' }] },
   };
 }
 
 export function accountSuccessCard(info: CurrentInfo): object {
   return {
     schema: '2.0',
-    config: { summary: { content: '已保存' } },
+    config: { summary: { content: 'Saved' } },
     body: {
       elements: [
         {
           tag: 'markdown',
           content: [
-            '✅ **凭据已保存**',
+            '✅ **Credentials saved**',
             '',
             `**App ID**: \`${maskAppId(info.appId)}\``,
-            info.botName ? `**Bot 名**: ${info.botName}` : '',
+            info.botName ? `**Bot name**: ${info.botName}` : '',
             `**Tenant**: ${info.tenant}`,
             '',
-            '正在用新凭据重连 WebSocket...',
-            '⚠️ 如果新 bot 不在此群，后续消息将由新 bot 接管，老 bot 不会再回复。',
+            'Reconnecting WebSocket with the new credentials…',
+            '⚠️ If the new bot isn\'t a member of this chat, subsequent messages will be handled by the new bot — the old bot will no longer reply.',
           ]
             .filter(Boolean)
             .join('\n'),
@@ -165,12 +165,12 @@ export function accountSuccessCard(info: CurrentInfo): object {
 export function accountFailureCard(reason: string): object {
   return {
     schema: '2.0',
-    config: { summary: { content: '校验失败' } },
+    config: { summary: { content: 'Validation failed' } },
     body: {
       elements: [
         {
           tag: 'markdown',
-          content: `❌ **校验失败**\n\n\`${reason}\`\n\n请检查 App ID 和 Secret 是否正确，重发 \`/account change\` 重试。`,
+          content: `❌ **Validation failed**\n\n\`${reason}\`\n\nCheck that the App ID and Secret are correct, then re-send \`/account change\` to retry.`,
         },
       ],
     },
@@ -180,7 +180,7 @@ export function accountFailureCard(reason: string): object {
 export function accountCancelledCard(): object {
   return {
     schema: '2.0',
-    config: { summary: { content: '已取消' } },
-    body: { elements: [{ tag: 'markdown', content: '已取消，未做任何修改。' }] },
+    config: { summary: { content: 'Cancelled' } },
+    body: { elements: [{ tag: 'markdown', content: 'Cancelled — no changes saved.' }] },
   };
 }

--- a/src/card/config-card.ts
+++ b/src/card/config-card.ts
@@ -47,7 +47,7 @@ function collapsedAccessPanel(title: string, elements: object[]): object {
  * profile) entirely client-side — the bridge doesn't fetch anything.
  */
 function atMentionLine(openIds: string[]): string {
-  if (openIds.length === 0) return '_（暂无）_';
+  if (openIds.length === 0) return '_(none)_';
   return openIds.map((id) => `<at id="${id}"></at>`).join('  ');
 }
 
@@ -57,10 +57,10 @@ function atMentionLine(openIds: string[]): string {
  * (zero extra API calls); unknown ids fall back to a short id suffix.
  */
 function chatList(chatIds: string[], known: KnownChat[]): string {
-  if (chatIds.length === 0) return '_（暂无）_';
+  if (chatIds.length === 0) return '_(none)_';
   const nameMap = new Map(known.map((c) => [c.id, c.name]));
   return chatIds
-    .map((id) => `- 💬 **${nameMap.get(id) ?? '(未知群)'}**（…${id.slice(-6)}）`)
+    .map((id) => `- 💬 **${nameMap.get(id) ?? '(unknown group)'}** (…${id.slice(-6)})`)
     .join('\n');
 }
 
@@ -73,46 +73,46 @@ export function configFormCard(opts: ConfigFormOpts): object {
     {
       tag: 'markdown',
       content:
-        '_控制谁能跟 bot 互动。**留空 = 不响应**。增删走命令，下面是当前状态。_',
+        '_Controls who can interact with the bot. **Empty = bot ignores everyone.** Add/remove via commands; the lines below show the current state._',
     },
     { tag: 'hr' },
     {
       tag: 'markdown',
       content:
-        `**允许私聊的用户**（共 ${opts.allowedUsers.length} 人）\n` +
+        `**Users allowed to DM** (${opts.allowedUsers.length} total)\n` +
         `${atMentionLine(opts.allowedUsers)}\n\n` +
-        '_加 / 删：_ `/invite user @某人`　`/remove user @某人`',
+        '_Add / remove:_ `/invite user @someone`　`/remove user @someone`',
     },
     { tag: 'hr' },
     {
       tag: 'markdown',
       content:
-        `**允许响应的群**（共 ${opts.allowedChats.length} 个）\n` +
+        `**Groups where the bot responds** (${opts.allowedChats.length} total)\n` +
         `${chatList(opts.allowedChats, opts.knownChats)}\n\n` +
-        '_一键加全部 bot 所在的群：_ `/invite all group`\n' +
-        '_加 / 删（在目标群里发）：_ `/invite group`　`/remove group`',
+        '_Add all groups the bot is already in:_ `/invite all group`\n' +
+        '_Add / remove (run inside the target group):_ `/invite group`　`/remove group`',
     },
     { tag: 'hr' },
     {
       tag: 'markdown',
       content:
-        `**管理员**（共 ${opts.admins.length} 人）\n` +
+        `**Admins** (${opts.admins.length} total)\n` +
         `${atMentionLine(opts.admins)}\n\n` +
-        '_可以跑敏感命令：`/account` `/config` `/exit` `/reconnect` `/doctor` `/cd` `/ws` `/invite` `/remove`。管理员也自动获得私聊权限。_\n\n' +
-        '_加 / 删：_ `/invite admin @某人`　`/remove admin @某人`',
+        '_Admins can run sensitive commands: `/account` `/config` `/exit` `/reconnect` `/doctor` `/cd` `/ws` `/invite` `/remove`. Admins also get DM access automatically._\n\n' +
+        '_Add / remove:_ `/invite admin @someone`　`/remove admin @someone`',
     },
   ];
 
   return {
     schema: '2.0',
-    config: { summary: { content: '偏好设置' } },
+    config: { summary: { content: 'Preferences' } },
     body: {
       elements: [
         {
           tag: 'markdown',
           content:
-            '⚙️ **偏好设置**\n\n' +
-            '调整 bot 的行为偏好。改完点提交，**立即生效**（无需重启）并写入 `~/.lark-channel/config.json`。',
+            '⚙️ **Preferences**\n\n' +
+            'Tweak the bot\'s behavior. Hit Submit to apply — **takes effect immediately** (no restart) and is written to `~/.lark-channel/config.json`.',
         },
         { tag: 'hr' },
         {
@@ -122,9 +122,9 @@ export function configFormCard(opts: ConfigFormOpts): object {
             {
               tag: 'markdown',
               content:
-                '**消息回复方式**\n' +
-                '_纯文本：agent 跑完一次性发出，不流式，体感最轻_\n' +
-                '_消息卡片：轻量流式 markdown 卡片，飞书原生打字机动画_',
+                '**Reply style**\n' +
+                '_Plain text: agent posts a single message after the run finishes — no streaming, lightest feel._\n' +
+                '_Message card: streaming markdown card with Lark\'s native typewriter animation._',
             },
             {
               tag: 'select_static',
@@ -132,32 +132,32 @@ export function configFormCard(opts: ConfigFormOpts): object {
               // 'card' is hidden — existing 'card' configs map to 'markdown' on display.
               initial_option: opts.messageReply === 'card' ? 'markdown' : opts.messageReply,
               options: [
-                { text: { tag: 'plain_text', content: '纯文本' }, value: 'text' },
-                { text: { tag: 'plain_text', content: '消息卡片（默认）' }, value: 'markdown' },
+                { text: { tag: 'plain_text', content: 'Plain text' }, value: 'text' },
+                { text: { tag: 'plain_text', content: 'Message card (default)' }, value: 'markdown' },
               ],
             },
             {
               tag: 'markdown',
               content:
-                '\n**工具调用显示**\n' +
-                '_显示：可以看到 bot 跑了什么命令、读了哪些文件等过程_\n' +
-                '_隐藏：只看 agent 最终的文字答复，跳过所有工具块_',
+                '\n**Tool-call display**\n' +
+                '_Show: see what commands the bot ran, which files it read, etc._\n' +
+                '_Hide: only the agent\'s final text reply, skip all tool blocks._',
             },
             {
               tag: 'select_static',
               name: 'show_tool_calls',
               initial_option: opts.showToolCalls ? 'show' : 'hide',
               options: [
-                { text: { tag: 'plain_text', content: '显示（默认）' }, value: 'show' },
-                { text: { tag: 'plain_text', content: '隐藏' }, value: 'hide' },
+                { text: { tag: 'plain_text', content: 'Show (default)' }, value: 'show' },
+                { text: { tag: 'plain_text', content: 'Hide' }, value: 'hide' },
               ],
             },
             {
               tag: 'markdown',
               content:
-                '\n**并发上限**\n' +
-                '_全局同时运行的 agent 进程数（主要影响话题群多话题并行场景）_\n' +
-                '_默认 10，范围 1-50。超出的请求会 FIFO 排队_',
+                '\n**Max concurrent runs**\n' +
+                '_Total agent processes running at once across the bridge (mostly relevant for topic groups with many parallel topics)._\n' +
+                '_Default 10, range 1–50. Excess requests queue FIFO._',
             },
             {
               tag: 'input',
@@ -169,9 +169,9 @@ export function configFormCard(opts: ConfigFormOpts): object {
             {
               tag: 'markdown',
               content:
-                '\n**run 探活（分钟）**\n' +
-                '_agent 长时间没输出时自动 kill，防止假死_\n' +
-                '_0 = 关闭（默认），范围 1-120。可被 `/timeout` 在单个 scope 覆盖_',
+                '\n**Run idle watchdog (minutes)**\n' +
+                '_Kills the agent automatically if it produces no output for N minutes — guards against hangs._\n' +
+                '_0 = disabled (default). Range 1–120. Can be overridden per scope with `/timeout`._',
             },
             {
               tag: 'input',
@@ -183,22 +183,22 @@ export function configFormCard(opts: ConfigFormOpts): object {
             {
               tag: 'markdown',
               content:
-                '\n**群里需要 @ bot**\n' +
-                '_是（默认）：群和话题群里，不 @ bot 的消息不会触发回复_\n' +
-                '_否：任何消息都会发给 agent（0.1.21 及更早版本的行为）_\n' +
-                '_私聊永远不需要 @；`@全员` 永远不响应_',
+                '\n**Require `@bot` in groups**\n' +
+                '_Yes (default): in groups and topic groups, messages that don\'t `@` the bot are ignored._\n' +
+                '_No: every message is sent to the agent (the 0.1.21-and-earlier behavior)._\n' +
+                '_DMs never require `@`; `@all` is never answered._',
             },
             {
               tag: 'select_static',
               name: 'require_mention_in_group',
               initial_option: opts.requireMentionInGroup ? 'yes' : 'no',
               options: [
-                { text: { tag: 'plain_text', content: '是（默认）' }, value: 'yes' },
-                { text: { tag: 'plain_text', content: '否' }, value: 'no' },
+                { text: { tag: 'plain_text', content: 'Yes (default)' }, value: 'yes' },
+                { text: { tag: 'plain_text', content: 'No' }, value: 'no' },
               ],
             },
             { tag: 'hr' },
-            collapsedAccessPanel('🔒 **访问控制**（点击展开）', accessElements),
+            collapsedAccessPanel('🔒 **Access control** (click to expand)', accessElements),
             {
               tag: 'column_set',
               flex_mode: 'flow',
@@ -211,7 +211,7 @@ export function configFormCard(opts: ConfigFormOpts): object {
                     {
                       tag: 'button',
                       name: 'submit_btn',
-                      text: { tag: 'plain_text', content: '提交' },
+                      text: { tag: 'plain_text', content: 'Submit' },
                       type: 'primary',
                       form_action_type: 'submit',
                       behaviors: [{ type: 'callback', value: { cmd: 'config.submit' } }],
@@ -225,7 +225,7 @@ export function configFormCard(opts: ConfigFormOpts): object {
                     {
                       tag: 'button',
                       name: 'cancel_btn',
-                      text: { tag: 'plain_text', content: '取消' },
+                      text: { tag: 'plain_text', content: 'Cancel' },
                       behaviors: [{ type: 'callback', value: { cmd: 'config.cancel' } }],
                     },
                   ],
@@ -242,31 +242,31 @@ export function configFormCard(opts: ConfigFormOpts): object {
 export function configSavedCard(opts: ConfigFormOpts): object {
   const replyLabel =
     opts.messageReply === 'card'
-      ? '交互卡片'
+      ? 'Interactive card'
       : opts.messageReply === 'markdown'
-        ? '消息卡片'
-        : '纯文本';
+        ? 'Message card'
+        : 'Plain text';
   const summarize = (list: string[]): string =>
-    list.length === 0 ? '_(空)_' : `${list.length} 项`;
+    list.length === 0 ? '_(empty)_' : `${list.length} entries`;
   return {
     schema: '2.0',
-    config: { summary: { content: '偏好已保存' } },
+    config: { summary: { content: 'Preferences saved' } },
     body: {
       elements: [
         {
           tag: 'markdown',
           content:
-            '✅ **偏好已保存**\n\n' +
-            `**消息回复方式**：${replyLabel}\n` +
-            `**工具调用显示**：\`${opts.showToolCalls ? 'show' : 'hide'}\`\n` +
-            `**并发上限**：\`${opts.maxConcurrentRuns}\`\n` +
-            `**run 探活**：\`${opts.runIdleTimeoutMinutes > 0 ? `${opts.runIdleTimeoutMinutes} 分钟` : '关闭'}\`\n` +
-            `**群里需要 @ bot**：\`${opts.requireMentionInGroup ? '是' : '否'}\`\n\n` +
-            '🔒 **访问控制**\n' +
-            `**允许私聊的用户**：${summarize(opts.allowedUsers)}\n` +
-            `**允许响应的群**：${summarize(opts.allowedChats)}\n` +
-            `**管理员**：${summarize(opts.admins)}\n\n` +
-            '下条消息开始生效。',
+            '✅ **Preferences saved**\n\n' +
+            `**Reply style**: ${replyLabel}\n` +
+            `**Tool-call display**: \`${opts.showToolCalls ? 'show' : 'hide'}\`\n` +
+            `**Max concurrent runs**: \`${opts.maxConcurrentRuns}\`\n` +
+            `**Run idle watchdog**: \`${opts.runIdleTimeoutMinutes > 0 ? `${opts.runIdleTimeoutMinutes} min` : 'disabled'}\`\n` +
+            `**Require @bot in groups**: \`${opts.requireMentionInGroup ? 'yes' : 'no'}\`\n\n` +
+            '🔒 **Access control**\n' +
+            `**Users allowed to DM**: ${summarize(opts.allowedUsers)}\n` +
+            `**Groups where bot responds**: ${summarize(opts.allowedChats)}\n` +
+            `**Admins**: ${summarize(opts.admins)}\n\n` +
+            'Takes effect on the next message.',
         },
       ],
     },
@@ -276,9 +276,9 @@ export function configSavedCard(opts: ConfigFormOpts): object {
 export function configCancelledCard(): object {
   return {
     schema: '2.0',
-    config: { summary: { content: '已取消' } },
+    config: { summary: { content: 'Cancelled' } },
     body: {
-      elements: [{ tag: 'markdown', content: '已取消，未做任何修改。' }],
+      elements: [{ tag: 'markdown', content: 'Cancelled — no changes saved.' }],
     },
   };
 }

--- a/src/card/run-renderer.ts
+++ b/src/card/run-renderer.ts
@@ -32,14 +32,14 @@ export function renderCard(state: RunState): object {
   }
 
   if (state.terminal === 'interrupted') {
-    elements.push(noteMd('_⏹ 已被中断_'));
+    elements.push(noteMd('_⏹ Interrupted_'));
   } else if (state.terminal === 'idle_timeout') {
     const mins = state.idleTimeoutMinutes ?? 0;
-    elements.push(noteMd(`_⏱ ${mins} 分钟无响应,已自动终止_`));
+    elements.push(noteMd(`_⏱ No response for ${mins} min — auto-terminated_`));
   } else if (state.terminal === 'error' && state.errorMsg) {
-    elements.push(noteMd(`⚠️ agent 失败：${state.errorMsg}`));
+    elements.push(noteMd(`⚠️ Agent failed: ${state.errorMsg}`));
   } else if (state.terminal === 'done' && elements.length === 0) {
-    elements.push(noteMd('_（未返回内容）_'));
+    elements.push(noteMd('_(no content returned)_'));
   }
 
   if (state.terminal === 'running') {
@@ -91,7 +91,7 @@ function renderToolGroup(tools: ToolEntry[], finalized: boolean): object[] {
 }
 
 function reasoningPanel(content: string, active: boolean): object {
-  const title = active ? '🧠 **思考中**' : '🧠 **思考完成，点击查看**';
+  const title = active ? '🧠 **Thinking…**' : '🧠 **Thought complete — click to view**';
   return collapsiblePanel({
     title,
     expanded: active,
@@ -105,7 +105,7 @@ function toolPanel(tool: ToolEntry, expanded: boolean): object {
     title: toolHeaderText(tool),
     expanded,
     border: tool.status === 'error' ? 'red' : 'grey',
-    body: toolBodyMd(tool) || '_无输出_',
+    body: toolBodyMd(tool) || '_(no output)_',
   });
 }
 
@@ -122,8 +122,8 @@ function toolPanel(tool: ToolEntry, expanded: boolean): object {
  * `toolPanel(latest, true)` so live observation isn't sacrificed.
  */
 function collapsedToolSummary(tools: ToolEntry[], finalized: boolean): object {
-  const suffix = finalized ? '（已结束）' : '';
-  const title = `☕ **${tools.length} 个工具调用${suffix}**`;
+  const suffix = finalized ? ' (finished)' : '';
+  const title = `☕ **${tools.length} tool call${tools.length === 1 ? '' : 's'}${suffix}**`;
   const headerList = tools.map((t) => `- ${toolHeaderText(t)}`).join('\n');
   return {
     tag: 'collapsible_panel',
@@ -176,7 +176,7 @@ function noteMd(content: string): object {
 function stopButton(): object {
   return {
     tag: 'button',
-    text: { tag: 'plain_text', content: '⏹ 终止' },
+    text: { tag: 'plain_text', content: '⏹ Stop' },
     type: 'danger',
     behaviors: [{ type: 'callback', value: { cmd: 'stop' } }],
   };
@@ -185,21 +185,21 @@ function stopButton(): object {
 function footerStatus(status: Exclude<FooterStatus, null>): object {
   const text =
     status === 'thinking'
-      ? '🧠 正在思考'
+      ? '🧠 Thinking…'
       : status === 'tool_running'
-        ? '🧰 正在调用工具'
-        : '✍️ 正在输出';
+        ? '🧰 Running tool…'
+        : '✍️ Writing…';
   return noteMd(text);
 }
 
 function summaryText(state: RunState): string {
-  if (state.terminal === 'interrupted') return '已中断';
-  if (state.terminal === 'idle_timeout') return '已超时';
-  if (state.terminal === 'error') return '出错';
-  if (state.terminal === 'done') return '已完成';
-  if (state.footer === 'tool_running') return '正在调用工具';
-  if (state.footer === 'streaming') return '正在输出';
-  return '思考中';
+  if (state.terminal === 'interrupted') return 'Interrupted';
+  if (state.terminal === 'idle_timeout') return 'Timed out';
+  if (state.terminal === 'error') return 'Error';
+  if (state.terminal === 'done') return 'Done';
+  if (state.footer === 'tool_running') return 'Running tool…';
+  if (state.footer === 'streaming') return 'Writing…';
+  return 'Thinking…';
 }
 
 function truncate(s: string, max: number): string {

--- a/src/card/templates.ts
+++ b/src/card/templates.ts
@@ -35,30 +35,30 @@ export function workspacesCard(current: string | undefined, named: Record<string
   const entries = Object.entries(named);
   const elements: object[] = [];
 
-  elements.push(divMd(`当前 cwd：\`${escapeCode(current ?? '(未设置，使用 $HOME)')}\``));
+  elements.push(divMd(`Current cwd: \`${escapeCode(current ?? '(not set, using $HOME)')}\``));
 
   if (entries.length === 0) {
     elements.push(HR);
-    elements.push(divMd('暂无命名工作空间。'));
+    elements.push(divMd('No named workspaces yet.'));
     elements.push(
-      divMd('💡 发送 `/ws save <name>` 把当前 cwd 存为命名工作空间'),
+      divMd('💡 Send `/ws save <name>` to save the current cwd as a named workspace.'),
     );
   } else {
     elements.push(HR);
     entries.forEach(([name, path], i) => {
-      const marker = path === current ? '  ← 当前' : '';
+      const marker = path === current ? '  ← current' : '';
       elements.push(divMd(`**${escapeMd(name)}** → \`${escapeCode(path)}\`${marker}`));
       elements.push(
         actions([
-          { text: '切换到此处', value: { cmd: 'ws.use', name }, style: 'primary' },
-          { text: '删除', value: { cmd: 'ws.remove', name }, style: 'danger' },
+          { text: 'Switch here', value: { cmd: 'ws.use', name }, style: 'primary' },
+          { text: 'Delete', value: { cmd: 'ws.remove', name }, style: 'danger' },
         ]),
       );
       if (i < entries.length - 1) elements.push(HR);
     });
   }
 
-  return shell('📂 工作空间', elements);
+  return shell('📂 Workspaces', elements);
 }
 
 export interface StatusInfo {
@@ -74,13 +74,13 @@ export interface StatusInfo {
 
 export function statusCard(info: StatusInfo): object {
   const sessionLine = info.sessionId
-    ? `\`${info.sessionId.slice(0, 8)}…\`${info.sessionStale ? ' ⚠️ 旧 cwd，下一条会新建' : ''}`
-    : '(无)';
+    ? `\`${info.sessionId.slice(0, 8)}…\`${info.sessionStale ? ' ⚠️ stale cwd, the next message will start a new session' : ''}`
+    : '(none)';
   // For topic groups, surface that the scope is per-topic so the user
   // knows /cd / /new only affect this topic.
   const scopeLine =
     info.chatMode === 'topic'
-      ? `\`${escapeCode(info.scope)}\` _（话题独立 session）_`
+      ? `\`${escapeCode(info.scope)}\` _(per-topic session)_`
       : `\`${escapeCode(info.scope)}\``;
   const lines = [
     `🧭 **scope**: ${scopeLine}`,
@@ -88,14 +88,14 @@ export function statusCard(info: StatusInfo): object {
     `🔗 **session**: ${sessionLine}`,
     `🤖 **agent**: ${escapeMd(info.agentName)}`,
   ];
-  return shell('📊 当前状态', [
+  return shell('📊 Status', [
     divMd(lines.join('\n')),
     HR,
     actions([
-      { text: '🆕 新会话', value: { cmd: 'new' }, style: 'primary' },
-      { text: '🔁 恢复会话', value: { cmd: 'resume' } },
-      { text: '📂 工作空间', value: { cmd: 'ws.list' } },
-      { text: '💡 帮助', value: { cmd: 'help' } },
+      { text: '🆕 New session', value: { cmd: 'new' }, style: 'primary' },
+      { text: '🔁 Resume session', value: { cmd: 'resume' } },
+      { text: '📂 Workspaces', value: { cmd: 'ws.list' } },
+      { text: '💡 Help', value: { cmd: 'help' } },
     ]),
   ]);
 }
@@ -110,26 +110,26 @@ export interface ResumeEntry {
 
 export function resumeCard(cwd: string, entries: ResumeEntry[]): object {
   const elements: object[] = [];
-  elements.push(divMd(`当前 cwd：\`${escapeCode(cwd)}\``));
+  elements.push(divMd(`Current cwd: \`${escapeCode(cwd)}\``));
 
   if (entries.length === 0) {
     elements.push(HR);
-    elements.push(divMd('此 cwd 下没有历史会话。'));
-    return shell('🔁 恢复历史会话', elements);
+    elements.push(divMd('No previous sessions under this cwd.'));
+    return shell('🔁 Resume session', elements);
   }
 
   elements.push(HR);
   entries.forEach((e, i) => {
-    const marker = e.current ? '  ← 当前' : '';
+    const marker = e.current ? '  ← current' : '';
     elements.push(
       divMd(
-        `**${i + 1}.** ${escapeMd(e.preview)}${marker}\n\`${e.sessionId.slice(0, 8)}…\` · ${e.relTime} · ${e.lineCount} 条`,
+        `**${i + 1}.** ${escapeMd(e.preview)}${marker}\n\`${e.sessionId.slice(0, 8)}…\` · ${e.relTime} · ${e.lineCount} msgs`,
       ),
     );
     elements.push(
       actions([
         {
-          text: e.current ? '已是当前会话' : '▸ 恢复此会话',
+          text: e.current ? 'Already current session' : '▸ Resume this session',
           value: { cmd: 'resume.use', arg: e.sessionId },
           style: e.current ? 'default' : 'primary',
         },
@@ -138,40 +138,40 @@ export function resumeCard(cwd: string, entries: ResumeEntry[]): object {
     if (i < entries.length - 1) elements.push(HR);
   });
 
-  return shell('🔁 恢复历史会话', elements);
+  return shell('🔁 Resume session', elements);
 }
 
 export function helpCard(): object {
-  return shell('💡 使用帮助', [
+  return shell('💡 Help', [
     divMd(
       [
-        '**命令列表**',
+        '**Commands**',
         '',
-        '- `/new` `/reset` — 清空当前 chat 的会话',
-        '- `/new chat [name]` — 新建群+新会话，自动拉你进群',
-        '- `/resume [N]` — 列出并恢复历史会话（最多 N 条）',
-        '- `/cd <path>` — 切换工作目录（会重置 session）',
-        '- `/ws list|save <name>|use <name>|remove <name>` — 工作空间',
-        '- `/account` — 查看当前应用；`/account change` 换 appId/secret 并重连',
-        '- `/config` — 调整偏好（消息回复方式、工具调用显示）',
-        '- `/status` — 当前状态',
-        '- `/stop` — 结束当前正在跑的任务（也可点卡片底部 ⏹ 终止 按钮）',
-        '- `/timeout [N|off|default]` — 当前 session 的探活分钟数,`/config` 改全局默认',
-        '- `/ps` — 列出本机所有 bot,标识当前正在回复的那个',
-        '- `/exit <id|#>` — 关掉指定 bot(用 `/ps` 看 id/序号)',
-        '- `/reconnect` — 强制重连 WebSocket(网络抖动后 bot 没反应时用)',
-        '- `/doctor [描述]` — 把日志和描述喂给 Claude 自助诊断',
-        '- `/help` — 本帮助',
+        '- `/new` `/reset` — clear the current chat\'s session',
+        '- `/new chat [name]` — create a new group + fresh session, auto-invites you',
+        '- `/resume [N]` — list and resume historical sessions (up to N)',
+        '- `/cd <path>` — change working directory (resets the session)',
+        '- `/ws list|save <name>|use <name>|remove <name>` — manage workspaces',
+        '- `/account` — show the current Lark app; `/account change` to swap appId/secret and reconnect',
+        '- `/config` — tweak preferences (reply behavior, tool-call display)',
+        '- `/status` — current status',
+        '- `/stop` — stop the currently running task (also the ⏹ button at the bottom of the card)',
+        '- `/timeout [N|off|default]` — idle-watchdog minutes for this session; `/config` sets the global default',
+        '- `/ps` — list all bot processes on this machine; marks the one currently replying',
+        '- `/exit <id|#>` — kill a bot process (use `/ps` to look up id/index)',
+        '- `/reconnect` — force a WebSocket reconnect (use when the bot stops responding after a flaky network)',
+        '- `/doctor [description]` — feed logs + description to Claude for self-diagnosis',
+        '- `/help` — this help',
         '',
-        '其他内容直接交给 Claude。',
+        'Anything else goes straight to Claude.',
       ].join('\n'),
     ),
     HR,
     actions([
-      { text: '📊 状态', value: { cmd: 'status' }, style: 'primary' },
-      { text: '🔁 恢复会话', value: { cmd: 'resume' } },
-      { text: '📂 工作空间', value: { cmd: 'ws.list' } },
-      { text: '🆕 新会话', value: { cmd: 'new' } },
+      { text: '📊 Status', value: { cmd: 'status' }, style: 'primary' },
+      { text: '🔁 Resume session', value: { cmd: 'resume' } },
+      { text: '📂 Workspaces', value: { cmd: 'ws.list' } },
+      { text: '🆕 New session', value: { cmd: 'new' } },
     ]),
   ]);
 }


### PR DESCRIPTION
Translates the highest-impact user-facing strings from Chinese to English
so foreign colleagues can use the bot without seeing 中文 in every card.
Covered (4 modules):
- card/templates.ts — /ws, /status, /resume, /help
- card/config-card.ts — full /config form (reply style, tool display,
  concurrency, watchdog, group @-toggle, access control)
- card/run-renderer.ts — the streaming card shown on every reply
- card/account-cards.ts — first-run auth wizard
Not in this PR (lower priority, follow-up):
- commands/index.ts — command response strings (errors, /cd, /ws action
  feedback, /timeout, /ps, /exit, /reconnect, /doctor, /invite, /remove)
- CLI command output (cli/commands/*)
- bot/* error messages
- code comments (~750 chars remaining, no user impact)
Verified: pnpm typecheck + pnpm build pass.