### PR TITLE
fix: forward device-flow OAuth URL to the chat as a safety net

### DIFF
--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -53,6 +53,7 @@ import type { WorkspaceStore } from '../workspace/store';
 import { ActiveRuns, type RunHandle } from './active-runs';
 import { ChatModeCache, type ChatMode } from './chat-mode-cache';
 import { handleCommentMention } from './comments';
+import { deviceAuthForwardMessage, extractDeviceAuthUrl } from './device-auth';
 import { recordRunSessionEvent, startRunFlow } from './run-flow';
 import { commandSessionCatalogIdentity } from './session-catalog-identity';
 import { startKeepalive } from './keepalive';
@@ -797,6 +798,23 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
   const reactionPromise =
     replyMode === 'card' ? undefined : addWorkingReaction(channel, lastMsg.messageId);
 
+  // Forward a device-flow OAuth URL into the chat as a safety net (the agent is
+  // supposed to surface it but doesn't always). In a p2p chat we send the link
+  // directly; in a group we must not (whoever clicks first binds the token to
+  // the wrong identity), so we steer the user to DM instead — and only once.
+  let groupAuthHintSent = false;
+  const forwardDeviceAuthUrl = async (url: string): Promise<void> => {
+    const forward = deviceAuthForwardMessage(firstMsg.chatType, url);
+    // The group variant carries no URL and is identical for every code, so send
+    // it at most once even if the agent regenerates the device code.
+    if (!forward.includesUrl) {
+      if (groupAuthHintSent) return;
+      groupAuthHintSent = true;
+    }
+    log.info('agent', 'device-auth-url-forwarded', { scope, chatType: firstMsg.chatType });
+    await channel.send(chatId, { markdown: forward.markdown }, sendOpts);
+  };
+
   try {
     if (replyMode === 'card') {
       let latestState: RunState = initialState;
@@ -816,6 +834,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
             await cardCtrl.update(renderCard(filterForPrefs(state), cardRenderOptions));
           }
         },
+        forwardDeviceAuthUrl,
       );
       const streamDone = channel.stream(
         chatId,
@@ -861,6 +880,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
             await markdownCtrl.setContent(renderText(filterForPrefs(state)));
           }
         },
+        forwardDeviceAuthUrl,
       );
       const streamDone = channel.stream(
         chatId,
@@ -897,6 +917,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         idleTimeoutMs,
         recordSession,
         async () => {},
+        forwardDeviceAuthUrl,
       );
       const body = renderText(filterForPrefs(finalState));
       if (body.trim()) {
@@ -923,6 +944,7 @@ async function processAgentStream(
   idleTimeoutMs: number | undefined,
   recordSession: (event: AgentEvent) => void,
   flush: (state: RunState) => Promise<void>,
+  onDeviceAuthUrl?: (url: string) => void | Promise<void>,
 ): Promise<RunState> {
   const runStart = Date.now();
   let state: RunState = initialState;
@@ -944,6 +966,9 @@ async function processAgentStream(
   let idleFired = false;
   let timer: NodeJS.Timeout | undefined;
   const inFlightTools = new Set<string>();
+  // Device-flow verification URLs we've already forwarded, so a re-run of the
+  // same `--no-wait` call doesn't spam the chat with duplicate links.
+  const forwardedAuthUrls = new Set<string>();
   const armOrPauseIdle = (): void => {
     if (!idleTimeoutMs) return;
     if (timer) clearTimeout(timer);
@@ -976,6 +1001,21 @@ async function processAgentStream(
       } else if (evt.type === 'tool_result') {
         inFlightTools.delete(evt.id);
         log.info('agent', 'tool-done', { inFlight: inFlightTools.size });
+        // Safety net: if a tool surfaced a device-flow auth URL, forward it to
+        // the chat ourselves. The agent is told to do this (see the OAuth
+        // section of the bridge system prompt) but doesn't always comply, and
+        // the subsequent `--device-code` poll blocks silently for ~10 minutes
+        // with no link for the user to click. The poll keeps running while we
+        // forward — once the user authorizes, it completes on its own.
+        if (onDeviceAuthUrl) {
+          const url = extractDeviceAuthUrl(evt.output);
+          if (url && !forwardedAuthUrls.has(url)) {
+            forwardedAuthUrls.add(url);
+            void Promise.resolve(onDeviceAuthUrl(url)).catch((err) =>
+              log.warn('agent', 'device-auth-forward-failed', { err: String(err) }),
+            );
+          }
+        }
       }
       armOrPauseIdle();
 

--- a/src/bot/device-auth.ts
+++ b/src/bot/device-auth.ts
@@ -1,0 +1,115 @@
+/**
+ * Detect a Feishu/Lark device-flow OAuth verification URL inside a `lark-cli`
+ * tool_result payload.
+ *
+ * Background: when the active profile has no usable user identity, `lark-cli`
+ * skills fall back to device-flow authorization. The agent is *supposed* to
+ * surface the `verification_url` to the user (see the OAuth section of the
+ * bridge system prompt) and then block on `auth login --device-code` until the
+ * user authorizes. In practice agents sometimes skip the "surface the URL"
+ * step and jump straight to the blocking poll — leaving the user staring at a
+ * silent run with no link to click, while the poll quietly retries until it
+ * times out. The bridge forwards the URL itself as a safety net so the user
+ * can always complete authorization.
+ *
+ * The detector is deliberately conservative to avoid forwarding unrelated URLs:
+ *  - The structured path only matches a JSON envelope that carries BOTH a
+ *    verification URL and a `device_code` (the device-flow signature).
+ *  - The text fallback only matches the device-flow verify path.
+ */
+
+interface DeviceAuthEnvelope {
+  verification_url?: unknown;
+  verification_uri?: unknown;
+  verification_uri_complete?: unknown;
+  device_code?: unknown;
+}
+
+// e.g. https://accounts.feishu.cn/oauth/v1/device/verify?flow_id=...
+const DEVICE_VERIFY_URL =
+  /https:\/\/[a-z0-9.-]*(?:feishu\.cn|larksuite\.com)\/oauth\/v1\/device\/verify[^\s"')]*/i;
+
+/**
+ * Return the verification URL if `toolOutput` looks like a device-flow
+ * authorization response, otherwise `undefined`.
+ */
+export function extractDeviceAuthUrl(toolOutput: string): string | undefined {
+  if (!toolOutput) return undefined;
+
+  const envelope = parseDeviceAuthEnvelope(toolOutput);
+  if (envelope) {
+    const url =
+      pickString(envelope.verification_uri_complete) ??
+      pickString(envelope.verification_url) ??
+      pickString(envelope.verification_uri);
+    if (url) return url;
+  }
+
+  const match = toolOutput.match(DEVICE_VERIFY_URL);
+  return match ? match[0] : undefined;
+}
+
+export interface DeviceAuthForward {
+  markdown: string;
+  /** Whether this message exposes the verification URL (only safe in p2p). */
+  includesUrl: boolean;
+}
+
+/**
+ * Build the chat message that surfaces a device-flow authorization to the user.
+ *
+ * In a p2p chat we include the link directly. In a group we must NOT leak it:
+ * device flow binds the token to whoever clicks first, so a link in a group
+ * would authorize the wrong identity. There we steer the user to DM instead.
+ */
+export function deviceAuthForwardMessage(chatType: string, url: string): DeviceAuthForward {
+  if (chatType === 'p2p') {
+    return {
+      includesUrl: true,
+      markdown: `🔐 需要先完成一次飞书授权才能继续。请打开下面的链接完成授权，完成后我会自动继续，无需回复：\n\`\`\`\n${url}\n\`\`\``,
+    };
+  }
+  return {
+    includesUrl: false,
+    markdown:
+      '🔐 需要先完成一次飞书授权才能继续，但授权必须在私聊里做（在群里授权会绑定到错误的身份）。请单独私信我，我会把授权链接发给你。',
+  };
+}
+
+function pickString(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Find the first JSON object in `text` that parses and carries the device-flow
+ * signature (a `device_code` plus some verification URI). tool_result output is
+ * usually the raw command stdout, but may be wrapped in surrounding log lines,
+ * so we also try the substring spanning the outermost braces.
+ */
+function parseDeviceAuthEnvelope(text: string): DeviceAuthEnvelope | undefined {
+  const trimmed = text.trim();
+  const candidates: string[] = [];
+  if (trimmed.startsWith('{')) candidates.push(trimmed);
+  const start = trimmed.indexOf('{');
+  const end = trimmed.lastIndexOf('}');
+  if (start !== -1 && end > start) candidates.push(trimmed.slice(start, end + 1));
+
+  for (const candidate of candidates) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(candidate);
+    } catch {
+      continue;
+    }
+    if (!parsed || typeof parsed !== 'object') continue;
+    const envelope = parsed as DeviceAuthEnvelope;
+    const hasVerification =
+      pickString(envelope.verification_uri_complete) ??
+      pickString(envelope.verification_url) ??
+      pickString(envelope.verification_uri);
+    if (pickString(envelope.device_code) && hasVerification) return envelope;
+  }
+  return undefined;
+}

--- a/tests/unit/bot/device-auth.test.ts
+++ b/tests/unit/bot/device-auth.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { deviceAuthForwardMessage, extractDeviceAuthUrl } from '../../../src/bot/device-auth.js';
+
+describe('extractDeviceAuthUrl', () => {
+  it('extracts verification_url from a real lark-cli --no-wait --json envelope', () => {
+    const output = JSON.stringify({
+      device_code: 'ODd-9vze31MFmDdHmR9tECbkM-FUeUOCGROOOOOOOOOO-yHUGROOOOOt.Vg1',
+      expires_in: 600,
+      hint: 'MUST generate QR code AND display it ...',
+      verification_url: 'https://accounts.feishu.cn/oauth/v1/device/verify?flow_id=Odeadbeef',
+    });
+    expect(extractDeviceAuthUrl(output)).toBe(
+      'https://accounts.feishu.cn/oauth/v1/device/verify?flow_id=Odeadbeef',
+    );
+  });
+
+  it('prefers verification_uri_complete when present', () => {
+    const output = JSON.stringify({
+      device_code: 'abc',
+      verification_url: 'https://accounts.feishu.cn/oauth/v1/device/verify',
+      verification_uri_complete:
+        'https://accounts.feishu.cn/oauth/v1/device/verify?flow_id=xyz&user_code=AB12',
+    });
+    expect(extractDeviceAuthUrl(output)).toBe(
+      'https://accounts.feishu.cn/oauth/v1/device/verify?flow_id=xyz&user_code=AB12',
+    );
+  });
+
+  it('matches a larksuite (international) device URL', () => {
+    const output = JSON.stringify({
+      device_code: 'abc',
+      verification_url: 'https://accounts.larksuite.com/oauth/v1/device/verify?flow_id=intl',
+    });
+    expect(extractDeviceAuthUrl(output)).toBe(
+      'https://accounts.larksuite.com/oauth/v1/device/verify?flow_id=intl',
+    );
+  });
+
+  it('finds the URL even when JSON is wrapped in surrounding log lines', () => {
+    const output = [
+      'Starting device authorization...',
+      JSON.stringify({
+        device_code: 'abc',
+        verification_url: 'https://accounts.feishu.cn/oauth/v1/device/verify?flow_id=wrapped',
+      }),
+      'waiting for authorization',
+    ].join('\n');
+    expect(extractDeviceAuthUrl(output)).toBe(
+      'https://accounts.feishu.cn/oauth/v1/device/verify?flow_id=wrapped',
+    );
+  });
+
+  it('falls back to the device verify URL in plain (non-JSON) text', () => {
+    const output =
+      'Open this link to authorize: https://accounts.feishu.cn/oauth/v1/device/verify?flow_id=plain then come back';
+    expect(extractDeviceAuthUrl(output)).toBe(
+      'https://accounts.feishu.cn/oauth/v1/device/verify?flow_id=plain',
+    );
+  });
+
+  it('ignores a JSON envelope without a device_code (not a device flow)', () => {
+    const output = JSON.stringify({
+      verification_url: 'https://accounts.feishu.cn/some/other/path',
+    });
+    expect(extractDeviceAuthUrl(output)).toBeUndefined();
+  });
+
+  it('ignores unrelated feishu URLs', () => {
+    const output =
+      '{"ok":true,"data":{"url":"https://example.feishu.cn/docx/abcdef","title":"notes"}}';
+    expect(extractDeviceAuthUrl(output)).toBeUndefined();
+  });
+
+  it('ignores a successful auth token result with no verification URL', () => {
+    const output = JSON.stringify({ ok: true, identity: 'user', message: 'login success' });
+    expect(extractDeviceAuthUrl(output)).toBeUndefined();
+  });
+
+  it('returns undefined for empty input', () => {
+    expect(extractDeviceAuthUrl('')).toBeUndefined();
+  });
+});
+
+describe('deviceAuthForwardMessage', () => {
+  const url = 'https://accounts.feishu.cn/oauth/v1/device/verify?flow_id=abc';
+
+  it('includes the verification URL in a p2p chat', () => {
+    const forward = deviceAuthForwardMessage('p2p', url);
+    expect(forward.includesUrl).toBe(true);
+    expect(forward.markdown).toContain(url);
+  });
+
+  it('never leaks the URL in a group chat and steers the user to DM', () => {
+    for (const chatType of ['group', 'topic']) {
+      const forward = deviceAuthForwardMessage(chatType, url);
+      expect(forward.includesUrl).toBe(false);
+      expect(forward.markdown).not.toContain(url);
+      expect(forward.markdown).toContain('私信');
+    }
+  });
+});


### PR DESCRIPTION
## Problem

When the active profile has no usable **user** identity, `lark-cli` skills fall back to **device-flow** authorization. The bridge system prompt already tells the agent to surface the `verification_url` and then block on `lark-cli auth login --device-code` until the user authorizes.

In practice agents don't always do the *"surface the URL"* step — they run `auth login --no-wait --json` (which returns the URL), then jump straight to the blocking `--device-code` poll **without ever sending the link to the user**. The poll blocks silently for ~10 minutes; the user sees a run that just sits there (often with a placeholder like `?`), then the agent regenerates a code and loops. There is no way for the user to authorize because the link never reaches them.

## Fix

Forward the URL ourselves as a safety net. `processAgentStream` already observes every `tool_result`, so detect a device-flow verification URL there and post it to the chat:

- **p2p**: send the link directly, verbatim, in a code block.
- **group**: do **not** leak the link — device flow binds the token to whoever clicks first, which would authorize the wrong identity. Steer the user to DM instead (sent at most once).

Details:
- The detector (`extractDeviceAuthUrl`) is conservative to avoid forwarding unrelated URLs: it requires the device-flow signature — a JSON envelope with both a verification URL **and** a `device_code`, or a raw `…/oauth/v1/device/verify` URL.
- Forwarded URLs are de-duplicated, so a regenerated code doesn't spam the chat.
- The `--device-code` poll keeps running while we forward; once the user authorizes, it completes on its own. No change to the auth flow itself — this is purely additive.

## Why at the bridge level

The existing guidance lives in the system prompt, i.e. it depends on the agent complying. Making the bridge surface the URL turns a best-effort instruction into a guarantee, which matches the harness already being aware of this case (the idle watchdog explicitly pauses for the blocking OAuth poll).

## Testing

- New unit tests for the detector and the message builder (p2p includes the URL; group never does and steers to DM).
- `pnpm typecheck`, `pnpm test` (full suite, 523 tests), `pnpm build`, and `git diff --check` all pass locally.

Related to #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
