### PR TITLE
[codex] add bridge compact command with native Codex support

### DIFF
--- a/src/bot/run-flow.ts
+++ b/src/bot/run-flow.ts
@@ -73,6 +73,19 @@ export interface RecordRunSessionEventInput {
   event: AgentEvent;
 }
 
+const COMPACT_HANDOFF_PREFIX = [
+  'Bridge compact handoff: the previous session was summarized to continue in a fresh session.',
+  'Use the handoff summary as continuity context, but follow the new user request normally.',
+  '',
+  '<handoff_summary>',
+].join('\n');
+
+const COMPACT_HANDOFF_SUFFIX = [
+  '</handoff_summary>',
+  '',
+  'New user request:',
+].join('\n');
+
 export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFlowResult> {
   const requestedCwd =
     input.workspaces.cwdFor(input.scopeId) ?? input.profileConfig.workspaces.default ?? '';
@@ -88,7 +101,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
     };
   }
 
-  const policy = evaluateRunPolicy({
+  const basePolicy = evaluateRunPolicy({
     scope: input.scope,
     attachments: input.attachments,
     prompt: input.prompt,
@@ -101,10 +114,10 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
     codexHome: input.profileConfig.codex?.codexHome,
     inheritCodexHome: input.profileConfig.codex?.inheritCodexHome,
   });
-  if (!policy.ok) {
+  if (!basePolicy.ok) {
     return {
       ok: false,
-      rejectReason: policy.rejectReason,
+      rejectReason: basePolicy.rejectReason,
       workspace,
     };
   }
@@ -117,7 +130,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
       scopeId: input.scopeId,
       agentId: input.capability.agentId,
       cwdRealpath: workspace.cwdRealpath,
-      policyFingerprint: policy.policyFingerprint,
+      policyFingerprint: basePolicy.policyFingerprint,
     });
     if (catalogEntry?.agentId === 'claude') {
       sessionId = catalogEntry.sessionId;
@@ -135,6 +148,16 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
       input.sessions.clear(input.scopeId);
     }
   }
+
+  const pendingCompactSummary = resumeFrom
+    ? undefined
+    : input.sessions.getPendingCompactSummary(input.scopeId, workspace.cwdRealpath);
+  const policy: RunPolicyAllow = pendingCompactSummary
+    ? {
+        ...basePolicy,
+        prompt: buildCompactHandoffPrompt(pendingCompactSummary, input.prompt),
+      }
+    : basePolicy;
 
   let execution: RunExecution;
   try {
@@ -172,6 +195,10 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
     throw err;
   }
 
+  if (pendingCompactSummary) {
+    input.sessions.consumePendingCompactSummary(input.scopeId, workspace.cwdRealpath);
+  }
+
   return {
     ok: true,
     execution,
@@ -179,6 +206,10 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
     cwdRealpath: workspace.cwdRealpath,
     ...(resumeFrom ? { resumeFrom } : {}),
   };
+}
+
+function buildCompactHandoffPrompt(summary: string, prompt: string): string {
+  return `${COMPACT_HANDOFF_PREFIX}\n${summary.trim()}\n${COMPACT_HANDOFF_SUFFIX}\n${prompt}`;
 }
 
 export function recordRunSessionEvent(input: RecordRunSessionEventInput): void {

--- a/src/card/templates.ts
+++ b/src/card/templates.ts
@@ -179,6 +179,7 @@ export function helpCard(agentName = 'Agent'): object {
         '**命令列表**',
         '',
         '- `/new` `/reset` — 清空当前 chat 的会话',
+        '- `/compact` — 生成交接摘要并切到新会话（下一条消息自动带摘要）',
         '- `/new chat [name]` — 新建群+新会话，自动拉你进群',
         '- `/resume [N]` — 列出并恢复历史会话（最多 N 条）',
         '- `/cd <path>` — 切换工作目录（会重置 session）',

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -443,6 +443,8 @@ async function handleCompact(_args: string, ctx: CommandContext): Promise<void> 
         binary,
         threadId,
         profileStateDir: commandProfilePaths(ctx).profileDir,
+        cwd: workspace.cwdRealpath,
+        sandbox: policy.sandbox,
         ...(codex.codexHome ? { codexHome: codex.codexHome } : {}),
         ...(codex.inheritCodexHome !== undefined
           ? { inheritCodexHome: codex.inheritCodexHome }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -66,6 +66,10 @@ import {
   type CodexThreadHistoryEntry,
   type ListCodexThreadHistoryOptions,
 } from '../session/codex-history';
+import {
+  compactCodexThread,
+  type CompactCodexThreadOptions,
+} from '../session/codex-compact';
 import type { SessionCatalog, SessionCatalogIdentity } from '../session/catalog';
 import { isAlive, readAndPrune, resolveTarget } from '../runtime/registry';
 import type { SessionStore } from '../session/store';
@@ -131,6 +135,7 @@ export interface CommandContext {
   codexHistoryProvider?: (
     options: ListCodexThreadHistoryOptions,
   ) => Promise<CodexThreadHistoryEntry[]>;
+  codexCompactProvider?: (options: CompactCodexThreadOptions) => Promise<void>;
   claudeHistoryProvider?: (cwd: string, limit: number) => Promise<SessionSummary[]>;
   /** Set when invoked from a CardKit 2.0 form submit. Keys are input `name`s. */
   formValue?: Record<string, unknown>;
@@ -418,9 +423,35 @@ async function handleCompact(_args: string, ctx: CommandContext): Promise<void> 
     return;
   }
 
-  await reply(ctx, '正在压缩当前会话：会先生成交接摘要，成功后再开始新会话。');
+  await reply(
+    ctx,
+    capability.agentId === 'codex'
+      ? '正在调用 Codex 原生 compact；成功后会保留当前 thread。'
+      : '正在压缩当前会话：会先生成交接摘要，成功后再开始新会话。',
+  );
   compactInFlightScopes.add(ctx.scope);
   try {
+    if (capability.agentId === 'codex' && threadId) {
+      const codex = ctx.controls.profileConfig.codex;
+      const binary = codex?.binaryPath;
+      if (!binary) {
+        await reply(ctx, '❌ 当前 Codex profile 没有配置 binaryPath，无法调用原生 compact。');
+        return;
+      }
+      const provider = ctx.codexCompactProvider ?? compactCodexThread;
+      await provider({
+        binary,
+        threadId,
+        profileStateDir: commandProfilePaths(ctx).profileDir,
+        ...(codex.codexHome ? { codexHome: codex.codexHome } : {}),
+        ...(codex.inheritCodexHome !== undefined
+          ? { inheritCodexHome: codex.inheritCodexHome }
+          : {}),
+      });
+      await reply(ctx, '✓ Codex 原生 compact 已完成，当前 thread 保持不变。');
+      return;
+    }
+
     const execution = await ctx.runExecutor.submit({
       scopeId: `${ctx.scope}:compact`,
       policy,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,7 +4,7 @@ import { homedir } from 'node:os';
 import { dirname, isAbsolute } from 'node:path';
 import type { LarkChannel, NormalizedMessage } from '@larksuite/channel';
 import { claudeCapability, codexCapability } from '../agent/capability';
-import type { AgentAdapter } from '../agent/types';
+import type { AgentAdapter, AgentEvent } from '../agent/types';
 import type { ActiveRuns } from '../bot/active-runs';
 import {
   accountCurrentCard,
@@ -163,6 +163,7 @@ const handlers: Record<string, Handler> = {
   '/cd': handleCd,
   '/ws': handleWs,
   '/resume': handleResume,
+  '/compact': handleCompact,
   '/status': handleStatus,
   '/help': handleHelp,
   '/account': handleAccount,
@@ -190,6 +191,7 @@ const ADMIN_COMMANDS = new Set([
   '/exit',
   '/reconnect',
   '/doctor',
+  '/compact',
   '/cd',
   '/ws',
   '/invite',
@@ -311,15 +313,215 @@ async function handleNew(args: string, ctx: CommandContext): Promise<void> {
     return handleNewChat(rawName, ctx);
   }
 
+  const wasRunning = resetCurrentScopeSession(ctx);
+  await reply(ctx, wasRunning ? '已中断当前任务并开始新会话。' : '已开始新会话。');
+}
+
+function resetCurrentScopeSession(
+  ctx: CommandContext,
+  identity = ctx.sessionCatalogIdentity,
+): boolean {
   const wasRunning = ctx.activeRuns.interrupt(ctx.scope);
-  if (ctx.sessionCatalog && ctx.sessionCatalogIdentity) {
+  if (ctx.sessionCatalog && identity) {
     ctx.sessionCatalog.archiveActive({
-      ...ctx.sessionCatalogIdentity,
+      ...identity,
       now: Date.now(),
     });
   }
   ctx.sessions.clear(ctx.scope);
-  await reply(ctx, wasRunning ? '已中断当前任务并开始新会话。' : '已开始新会话。');
+  return wasRunning;
+}
+
+const COMPACT_SUMMARY_PROMPT = [
+  'You are compacting this agent session for continuation in a new thread.',
+  'Write a concise Markdown handoff summary only. Include:',
+  '- Current objective and workspace',
+  '- Important decisions and current state',
+  '- Files, commands, data sources, and IDs that matter',
+  '- Known blockers, risks, and unfinished work',
+  '- Concrete next steps',
+  'Do not continue the task. Do not ask follow-up questions. Do not run tools unless absolutely necessary to inspect already-local state.',
+].join('\n');
+
+const compactInFlightScopes = new Set<string>();
+
+async function handleCompact(_args: string, ctx: CommandContext): Promise<void> {
+  if (!ctx.runExecutor) {
+    await reply(ctx, '❌ 当前 bridge 没有可用的 run executor，无法压缩会话。');
+    return;
+  }
+  if (ctx.activeRuns.get(ctx.scope)) {
+    await reply(ctx, '当前会话已有运行在执行，请先等它结束，或用 `/stop` 停止后再 `/compact`。');
+    return;
+  }
+  if (compactInFlightScopes.has(ctx.scope)) {
+    await reply(ctx, '当前会话已经在 compact 中，请稍后。');
+    return;
+  }
+
+  const requestedCwd = effectiveWorkspaceCwd(ctx);
+  if (!requestedCwd) {
+    await reply(ctx, '未设置工作目录。先用 `/cd <path>` 或 `/ws use <name>` 选择工作目录后再 `/compact`。');
+    return;
+  }
+
+  const workspace = await resolveWorkingDirectory(requestedCwd);
+  if (!workspace.ok) {
+    await reply(ctx, workspace.userVisible);
+    return;
+  }
+
+  const capability =
+    ctx.controls.profileConfig.agentKind === 'codex'
+      ? codexCapability(ctx.controls.profileConfig)
+      : claudeCapability(ctx.controls.profileConfig);
+  const now = Date.now();
+  const access = canRunAdminCommand(ctx.controls.profileConfig, ctx.controls, ctx.msg.senderId);
+  const policy = evaluateRunPolicy({
+    scope: {
+      source: 'im',
+      chatId: ctx.msg.chatId,
+      actorId: ctx.msg.senderId,
+      ...(ctx.chatMode === 'topic' && ctx.msg.threadId ? { threadId: ctx.msg.threadId } : {}),
+    },
+    attachments: [],
+    prompt: COMPACT_SUMMARY_PROMPT,
+    requestedCwd,
+    cwdRealpath: workspace.cwdRealpath,
+    access,
+    capability,
+    profileConfig: ctx.controls.profileConfig,
+    now,
+    codexHome: ctx.controls.profileConfig.codex?.codexHome,
+    inheritCodexHome: ctx.controls.profileConfig.codex?.inheritCodexHome,
+    ttlMs: 5 * 60_000,
+  });
+  if (!policy.ok) {
+    await reply(ctx, policy.rejectReason.userVisible);
+    return;
+  }
+
+  const identity: SessionCatalogIdentity = {
+    scopeId: ctx.scope,
+    agentId: capability.agentId,
+    cwdRealpath: workspace.cwdRealpath,
+    policyFingerprint: policy.policyFingerprint,
+  };
+  const activeEntry = compactCatalogEntry(ctx, identity);
+  const sessionId =
+    capability.agentId === 'claude'
+      ? activeEntry?.sessionId ?? ctx.sessions.resumeFor(ctx.scope, workspace.cwdRealpath)
+      : undefined;
+  const threadId = capability.agentId === 'codex' ? activeEntry?.threadId : undefined;
+  if (!sessionId && !threadId) {
+    await reply(ctx, '当前没有可压缩的历史会话；已经是新会话或还没有建立 session。');
+    return;
+  }
+
+  await reply(ctx, '正在压缩当前会话：会先生成交接摘要，成功后再开始新会话。');
+  compactInFlightScopes.add(ctx.scope);
+  try {
+    const execution = await ctx.runExecutor.submit({
+      scopeId: `${ctx.scope}:compact`,
+      policy,
+      sessionId,
+      threadId,
+      stopGraceMs: getAgentStopGraceMs(ctx.controls.cfg),
+      observability: {
+        profile: ctx.controls.profile,
+        agent: capability.agentId,
+        source: 'compact',
+        stage: 'summarize',
+      },
+    });
+
+    const result = await collectCompactSummary(execution.subscribe());
+    if (!result.ok) {
+      await reply(ctx, `❌ compact 失败：${result.message}\n旧会话未归档。`);
+      return;
+    }
+
+    resetCurrentScopeSession(ctx, activeEntry ? catalogEntryIdentity(activeEntry) : identity);
+    ctx.sessions.setPendingCompactSummary(ctx.scope, workspace.cwdRealpath, result.summary);
+    await reply(
+      ctx,
+      [
+        '✓ 已压缩并开始新会话。',
+        '下一条普通消息会自动携带这份交接摘要，然后摘要会从 bridge 待注入队列中清除。',
+      ].join('\n'),
+    );
+  } catch (err) {
+    if (err instanceof RunRejected) {
+      await reply(
+        ctx,
+        err.code === 'pool-full'
+          ? '❌ 当前运行池已满，稍后再 `/compact`。'
+          : err.code === 'run-already-active'
+            ? '❌ compact 已在运行，请稍后。'
+            : `❌ compact 未能启动：${err.code}`,
+      );
+      return;
+    }
+    log.fail('command', err, { step: 'compact' });
+    reportMetric('command_fail', 1, { step: 'compact' });
+    await reply(ctx, `❌ compact 失败：${err instanceof Error ? err.message : String(err)}`);
+  } finally {
+    compactInFlightScopes.delete(ctx.scope);
+  }
+}
+
+function compactCatalogEntry(ctx: CommandContext, identity: SessionCatalogIdentity) {
+  const exact = ctx.sessionCatalog?.activeFor(identity);
+  if (exact) return exact;
+  return ctx.sessionCatalog
+    ?.entries()
+    .filter(
+      (entry) =>
+        entry.status === 'active' &&
+        entry.scopeId === identity.scopeId &&
+        entry.agentId === identity.agentId &&
+        entry.cwdRealpath === identity.cwdRealpath,
+    )
+    .sort((a, b) => b.updatedAt - a.updatedAt)[0];
+}
+
+function catalogEntryIdentity(entry: SessionCatalogIdentity): SessionCatalogIdentity {
+  return {
+    scopeId: entry.scopeId,
+    agentId: entry.agentId,
+    cwdRealpath: entry.cwdRealpath,
+    policyFingerprint: entry.policyFingerprint,
+  };
+}
+
+type CompactSummaryResult =
+  | { ok: true; summary: string }
+  | { ok: false; message: string };
+
+async function collectCompactSummary(
+  events: AsyncIterable<AgentEvent>,
+): Promise<CompactSummaryResult> {
+  let summary = '';
+  for await (const evt of events) {
+    if (evt.type === 'text') {
+      summary += evt.delta;
+      continue;
+    }
+    if (evt.type === 'done') {
+      if (evt.terminationReason !== 'normal') {
+        return { ok: false, message: evt.terminationReason };
+      }
+      const trimmed = summary.trim();
+      if (!trimmed) return { ok: false, message: 'agent 没有生成摘要' };
+      return { ok: true, summary: trimmed };
+    }
+    if (evt.type === 'error') {
+      return { ok: false, message: evt.message || evt.terminationReason };
+    }
+  }
+  const trimmed = summary.trim();
+  if (!trimmed) return { ok: false, message: 'agent 输出流提前结束且没有摘要' };
+  return { ok: true, summary: trimmed };
 }
 
 async function handleNewChat(rawName: string, ctx: CommandContext): Promise<void> {

--- a/src/session/codex-compact.ts
+++ b/src/session/codex-compact.ts
@@ -13,6 +13,8 @@ export interface CompactCodexThreadOptions {
   binary: string;
   threadId: string;
   profileStateDir: string;
+  cwd?: string;
+  sandbox?: string;
   codexHome?: string;
   inheritCodexHome?: boolean;
   timeoutMs?: number;
@@ -34,7 +36,7 @@ export class CodexCompactError extends Error {
   }
 }
 
-const DEFAULT_COMPACT_TIMEOUT_MS = 3 * 60 * 1000;
+const DEFAULT_COMPACT_TIMEOUT_MS = 10 * 60 * 1000;
 
 export async function compactCodexThread(options: CompactCodexThreadOptions): Promise<void> {
   const child = spawnCodexAppServer(options);
@@ -82,6 +84,10 @@ export async function compactCodexThread(options: CompactCodexThreadOptions): Pr
     rl.on('line', (line) => {
       const trimmed = line.trim();
       if (!trimmed) return;
+      if (trimmed.startsWith('{"id":2,"result"')) {
+        return;
+      }
+
       let msg: unknown;
       try {
         msg = JSON.parse(trimmed);
@@ -91,6 +97,13 @@ export async function compactCodexThread(options: CompactCodexThreadOptions): Pr
       const response = recordValue(msg);
       if (!response) return;
       if (response.id === 2) {
+        if (response.error) {
+          reject(new CodexCompactError('app-server-error', appServerErrorMessage(response.error)));
+          cleanup({ kill: true });
+        }
+        return;
+      }
+      if (response.id === 3) {
         if (response.error) {
           reject(new CodexCompactError('app-server-error', appServerErrorMessage(response.error)));
           cleanup({ kill: true });
@@ -128,7 +141,11 @@ export async function compactCodexThread(options: CompactCodexThreadOptions): Pr
 
     try {
       child.stdin.write(
-        `${JSON.stringify(initializeRequest())}\n${JSON.stringify(compactRequest(options.threadId))}\n`,
+        [
+          initializeRequest(),
+          resumeRequest(options),
+          compactRequest(options.threadId),
+        ].map((request) => JSON.stringify(request)).join('\n') + '\n',
         'utf8',
         (err?: Error | null) => {
           if (err) fail(err);
@@ -174,8 +191,20 @@ function initializeRequest() {
 function compactRequest(threadId: string) {
   return {
     method: 'thread/compact/start',
-    id: 2,
+    id: 3,
     params: { threadId },
+  };
+}
+
+function resumeRequest(options: CompactCodexThreadOptions) {
+  return {
+    method: 'thread/resume',
+    id: 2,
+    params: {
+      threadId: options.threadId,
+      ...(options.cwd ? { cwd: options.cwd } : {}),
+      ...(options.sandbox ? { sandbox: options.sandbox } : {}),
+    },
   };
 }
 

--- a/src/session/codex-compact.ts
+++ b/src/session/codex-compact.ts
@@ -1,0 +1,219 @@
+import { createInterface } from 'node:readline';
+import type { Readable, Writable } from 'node:stream';
+import { join } from 'node:path';
+import {
+  mergeProcessEnv,
+  spawnProcess,
+  type SpawnedProcessByStdio,
+} from '../platform/spawn';
+
+type CodexAppServerChild = SpawnedProcessByStdio<Writable, Readable, Readable>;
+
+export interface CompactCodexThreadOptions {
+  binary: string;
+  threadId: string;
+  profileStateDir: string;
+  codexHome?: string;
+  inheritCodexHome?: boolean;
+  timeoutMs?: number;
+}
+
+export type CodexCompactErrorCode =
+  | 'spawn-failed'
+  | 'timeout'
+  | 'app-server-error'
+  | 'malformed-response';
+
+export class CodexCompactError extends Error {
+  readonly code: CodexCompactErrorCode;
+
+  constructor(code: CodexCompactErrorCode, message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'CodexCompactError';
+    this.code = code;
+  }
+}
+
+const DEFAULT_COMPACT_TIMEOUT_MS = 3 * 60 * 1000;
+
+export async function compactCodexThread(options: CompactCodexThreadOptions): Promise<void> {
+  const child = spawnCodexAppServer(options);
+  const timeoutMs = options.timeoutMs ?? DEFAULT_COMPACT_TIMEOUT_MS;
+  const stderrChunks: Buffer[] = [];
+  let settled = false;
+
+  await new Promise<void>((resolve, reject) => {
+    const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let requestAccepted = false;
+
+    const fail = (err: unknown): void => {
+      if (settled) return;
+      reject(
+        err instanceof CodexCompactError
+          ? err
+          : new CodexCompactError('spawn-failed', errorMessage(err)),
+      );
+      cleanup({ kill: true });
+    };
+
+    const cleanup = (opts: { kill: boolean }): void => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      rl.close();
+      child.removeListener('error', fail);
+      child.stdin.removeListener('error', fail);
+      child.stderr.removeAllListeners('data');
+      if (opts.kill && child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+    };
+
+    timer = setTimeout(() => {
+      reject(new CodexCompactError('timeout', `codex compact timed out after ${timeoutMs}ms`));
+      cleanup({ kill: true });
+    }, timeoutMs);
+
+    child.once('error', fail);
+    child.stdin.once('error', fail);
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+    });
+
+    rl.on('line', (line) => {
+      const trimmed = line.trim();
+      if (!trimmed) return;
+      let msg: unknown;
+      try {
+        msg = JSON.parse(trimmed);
+      } catch {
+        return;
+      }
+      const response = recordValue(msg);
+      if (!response) return;
+      if (response.id === 2) {
+        if (response.error) {
+          reject(new CodexCompactError('app-server-error', appServerErrorMessage(response.error)));
+          cleanup({ kill: true });
+          return;
+        }
+        requestAccepted = true;
+        return;
+      }
+      if (response.method === 'thread/compacted') {
+        const params = recordValue(response.params);
+        if (stringValue(params?.threadId) !== options.threadId) return;
+        resolve();
+        cleanup({ kill: true });
+        return;
+      }
+      if (response.method === 'error') {
+        const params = recordValue(response.params);
+        if (stringValue(params?.threadId) !== options.threadId) return;
+        reject(new CodexCompactError('app-server-error', appServerErrorMessage(params?.error ?? params)));
+        cleanup({ kill: true });
+      }
+    });
+
+    child.once('exit', (code) => {
+      if (settled) return;
+      const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+      reject(
+        new CodexCompactError(
+          requestAccepted ? 'malformed-response' : 'spawn-failed',
+          `codex app-server exited before compact completed: ${code ?? 'signal'}${stderr ? `: ${stderr}` : ''}`,
+        ),
+      );
+      cleanup({ kill: true });
+    });
+
+    try {
+      child.stdin.write(
+        `${JSON.stringify(initializeRequest())}\n${JSON.stringify(compactRequest(options.threadId))}\n`,
+        'utf8',
+        (err?: Error | null) => {
+          if (err) fail(err);
+        },
+      );
+    } catch (err) {
+      fail(err);
+    }
+  });
+
+  await waitForChildExit(child, 250);
+}
+
+function spawnCodexAppServer(options: CompactCodexThreadOptions): CodexAppServerChild {
+  const envOverrides: NodeJS.ProcessEnv = {};
+  if (options.codexHome) {
+    envOverrides.CODEX_HOME = options.codexHome;
+  } else if (options.inheritCodexHome === false) {
+    envOverrides.CODEX_HOME = join(options.profileStateDir, 'codex-home');
+  }
+
+  return spawnProcess(options.binary, ['app-server', '--listen', 'stdio://'], {
+    env: mergeProcessEnv(process.env, envOverrides),
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) as CodexAppServerChild;
+}
+
+function initializeRequest() {
+  return {
+    method: 'initialize',
+    id: 1,
+    params: {
+      clientInfo: {
+        name: 'lark-channel-bridge',
+        title: 'Lark Channel Bridge',
+        version: '0.2.3',
+      },
+      capabilities: null,
+    },
+  };
+}
+
+function compactRequest(threadId: string) {
+  return {
+    method: 'thread/compact/start',
+    id: 2,
+    params: { threadId },
+  };
+}
+
+async function waitForChildExit(child: CodexAppServerChild, timeoutMs: number): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  await new Promise<void>((resolve) => {
+    const timer = setTimeout(() => {
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+      resolve();
+    }, timeoutMs);
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+function appServerErrorMessage(input: unknown): string {
+  const raw = recordValue(input);
+  const message = stringValue(raw?.message) ?? stringValue(raw?.error);
+  if (message) return message;
+  try {
+    return JSON.stringify(input);
+  } catch {
+    return String(input);
+  }
+}
+
+function stringValue(input: unknown): string | undefined {
+  return typeof input === 'string' ? input : undefined;
+}
+
+function recordValue(input: unknown): Record<string, unknown> | undefined {
+  return input && typeof input === 'object' && !Array.isArray(input)
+    ? (input as Record<string, unknown>)
+    : undefined;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/src/session/store.ts
+++ b/src/session/store.ts
@@ -14,6 +14,10 @@ export interface SessionEntry {
    * scope, undefined = follow global default. Session resets preserve this
    * scope preference while removing the resumable session id/cwd. */
   idleTimeoutMinutes?: number;
+  /** One-shot handoff summary injected into the next fresh run after /compact. */
+  pendingCompactSummary?: string;
+  pendingCompactCwd?: string;
+  pendingCompactUpdatedAt?: number;
 }
 
 type SessionMap = Record<string, SessionEntry>;
@@ -43,13 +47,36 @@ export class SessionStore {
         const cwd = typeof entry.cwd === 'string' ? entry.cwd : undefined;
         const idleTimeoutMinutes =
           typeof entry.idleTimeoutMinutes === 'number' ? entry.idleTimeoutMinutes : undefined;
+        const pendingCompactSummary =
+          typeof entry.pendingCompactSummary === 'string' && entry.pendingCompactSummary.trim()
+            ? entry.pendingCompactSummary.trim()
+            : undefined;
+        const pendingCompactCwd =
+          typeof entry.pendingCompactCwd === 'string' && entry.pendingCompactCwd.trim()
+            ? entry.pendingCompactCwd.trim()
+            : undefined;
+        const pendingCompactUpdatedAt =
+          typeof entry.pendingCompactUpdatedAt === 'number'
+            ? entry.pendingCompactUpdatedAt
+            : undefined;
         const hasSession = sessionId !== undefined && cwd !== undefined;
-        if (!hasSession && idleTimeoutMinutes === undefined) continue;
+        const hasPendingCompact =
+          pendingCompactSummary !== undefined && pendingCompactCwd !== undefined;
+        if (!hasSession && idleTimeoutMinutes === undefined && !hasPendingCompact) continue;
         this.data[chatId] = {
           ...(sessionId !== undefined ? { sessionId } : {}),
           ...(cwd !== undefined ? { cwd } : {}),
           updatedAt: entry.updatedAt,
           ...(idleTimeoutMinutes !== undefined ? { idleTimeoutMinutes } : {}),
+          ...(hasPendingCompact
+            ? {
+                pendingCompactSummary,
+                pendingCompactCwd,
+                ...(pendingCompactUpdatedAt !== undefined
+                  ? { pendingCompactUpdatedAt }
+                  : {}),
+              }
+            : {}),
         };
       }
     } catch (err) {
@@ -126,6 +153,53 @@ export class SessionStore {
     if (!prev || prev.idleTimeoutMinutes === undefined) return false;
     const { idleTimeoutMinutes: _, ...rest } = prev;
     this.data[chatId] = { ...rest, updatedAt: Date.now() };
+    this.pruneEmptyPreferenceOnlyEntry(chatId);
+    this.schedulePersist();
+    return true;
+  }
+
+  getPendingCompactSummary(chatId: string, cwd: string): string | undefined {
+    const entry = this.data[chatId];
+    if (!entry) return undefined;
+    if (entry.pendingCompactCwd !== cwd) return undefined;
+    return entry.pendingCompactSummary;
+  }
+
+  setPendingCompactSummary(chatId: string, cwd: string, summary: string): void {
+    const value = compactSummary(summary);
+    if (!value) {
+      this.clearPendingCompactSummary(chatId);
+      return;
+    }
+    const prev = this.data[chatId];
+    this.data[chatId] = {
+      ...(prev ?? { updatedAt: Date.now() }),
+      pendingCompactSummary: value,
+      pendingCompactCwd: cwd,
+      pendingCompactUpdatedAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+    this.schedulePersist();
+  }
+
+  consumePendingCompactSummary(chatId: string, cwd: string): string | undefined {
+    const summary = this.getPendingCompactSummary(chatId, cwd);
+    if (!summary) return undefined;
+    this.clearPendingCompactSummary(chatId);
+    return summary;
+  }
+
+  clearPendingCompactSummary(chatId: string): boolean {
+    const prev = this.data[chatId];
+    if (!prev || prev.pendingCompactSummary === undefined) return false;
+    const {
+      pendingCompactSummary: _summary,
+      pendingCompactCwd: _cwd,
+      pendingCompactUpdatedAt: _updatedAt,
+      ...rest
+    } = prev;
+    this.data[chatId] = { ...rest, updatedAt: Date.now() };
+    this.pruneEmptyPreferenceOnlyEntry(chatId);
     this.schedulePersist();
     return true;
   }
@@ -145,4 +219,25 @@ export class SessionStore {
         log.fail('session', err, { step: 'persist' });
       });
   }
+
+  private pruneEmptyPreferenceOnlyEntry(chatId: string): void {
+    const entry = this.data[chatId];
+    if (!entry) return;
+    if (
+      entry.sessionId === undefined &&
+      entry.cwd === undefined &&
+      entry.idleTimeoutMinutes === undefined &&
+      entry.pendingCompactSummary === undefined &&
+      entry.pendingCompactCwd === undefined &&
+      entry.pendingCompactUpdatedAt === undefined
+    ) {
+      delete this.data[chatId];
+    }
+  }
+}
+
+function compactSummary(summary: string): string {
+  const trimmed = summary.trim();
+  if (trimmed.length <= 30_000) return trimmed;
+  return `${trimmed.slice(0, 30_000)}\n\n[summary truncated by bridge]`;
 }

--- a/tests/integration/commands/commands-v1.test.ts
+++ b/tests/integration/commands/commands-v1.test.ts
@@ -287,7 +287,9 @@ describe('Bridge command contracts', () => {
     await expect(h.run('/compact')).resolves.toBe(true);
 
     expect(lastMarkdown(h.channel)).toContain('Codex 原生 compact 已完成');
-    expect(h.codexCompactCalls).toMatchObject([{ threadId: 'thread-old', binary: 'codex' }]);
+    expect(h.codexCompactCalls).toMatchObject([
+      { threadId: 'thread-old', binary: 'codex', cwd: cwdRealpath, sandbox: 'read-only' },
+    ]);
     expect(h.agent.runOptions).toHaveLength(0);
     expect(h.sessions.getPendingCompactSummary('chat-1', cwdRealpath)).toBeUndefined();
     expect(

--- a/tests/integration/commands/commands-v1.test.ts
+++ b/tests/integration/commands/commands-v1.test.ts
@@ -2,7 +2,7 @@ import { mkdir, realpath, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { NormalizedMessage } from '@larksuite/channel';
-import { codexCapability } from '../../../src/agent/capability.js';
+import { claudeCapability, codexCapability } from '../../../src/agent/capability.js';
 import { ActiveRuns } from '../../../src/bot/active-runs.js';
 import { ProcessPool } from '../../../src/bot/process-pool.js';
 import { tryHandleCommand, type CommandContext, type Controls } from '../../../src/commands/index.js';
@@ -11,6 +11,7 @@ import { createRootConfig, loadRootConfig, saveRootConfig } from '../../../src/c
 import { evaluateRunPolicy } from '../../../src/policy/run-policy.js';
 import { RunExecutor } from '../../../src/runtime/run-executor.js';
 import { SessionCatalog } from '../../../src/session/catalog.js';
+import type { CompactCodexThreadOptions } from '../../../src/session/codex-compact.js';
 import { SessionStore } from '../../../src/session/store.js';
 import { WorkspaceStore } from '../../../src/workspace/store.js';
 import { createFakeAgent } from '../../helpers/fake-agent.js';
@@ -35,6 +36,7 @@ interface Harness {
   agent: ReturnType<typeof createFakeAgent>;
   controls: Controls;
   runExecutor: RunExecutor;
+  codexCompactCalls: CompactCodexThreadOptions[];
   run(content: string, overrides?: RunOverrides): Promise<boolean>;
 }
 
@@ -249,7 +251,7 @@ describe('Bridge command contracts', () => {
     expect(status).toContain(jsonStringFragment(await realpath(h.tmp.workspace)));
   });
 
-  it('compacts an active Codex thread into a one-shot handoff', async () => {
+  it('compacts an active Codex thread through native app-server compact', async () => {
     const h = await createHarness({ agentKind: 'codex' });
     const cwdRealpath = await realpath(h.tmp.workspace);
     const policy = evaluateRunPolicy({
@@ -281,6 +283,47 @@ describe('Bridge command contracts', () => {
         policyFingerprint: policy.policyFingerprint,
       }),
     ).toMatchObject({ threadId: 'thread-old' });
+
+    await expect(h.run('/compact')).resolves.toBe(true);
+
+    expect(lastMarkdown(h.channel)).toContain('Codex 原生 compact 已完成');
+    expect(h.codexCompactCalls).toMatchObject([{ threadId: 'thread-old', binary: 'codex' }]);
+    expect(h.agent.runOptions).toHaveLength(0);
+    expect(h.sessions.getPendingCompactSummary('chat-1', cwdRealpath)).toBeUndefined();
+    expect(
+      h.sessionCatalog.activeFor({
+        scopeId: 'chat-1',
+        agentId: 'codex',
+        cwdRealpath,
+        policyFingerprint: policy.policyFingerprint,
+      }),
+    ).toMatchObject({ threadId: 'thread-old' });
+  });
+
+  it('compacts a Claude session into a one-shot handoff', async () => {
+    const h = await createHarness({ agentKind: 'claude' });
+    const cwdRealpath = await realpath(h.tmp.workspace);
+    const policy = evaluateRunPolicy({
+      scope: { source: 'im', chatId: 'chat-1', actorId: 'ou-admin' },
+      attachments: [],
+      prompt: '',
+      requestedCwd: cwdRealpath,
+      cwdRealpath,
+      access: { ok: true, reason: 'allowed-admin' },
+      capability: claudeCapability(h.controls.profileConfig),
+      profileConfig: h.controls.profileConfig,
+      now: 1000,
+    });
+    expect(policy.ok).toBe(true);
+    if (!policy.ok) throw new Error('expected allowed policy');
+    h.sessionCatalog.upsertActive({
+      scopeId: 'chat-1',
+      agentId: 'claude',
+      cwdRealpath,
+      policyFingerprint: policy.policyFingerprint,
+      sessionId: 'session-old',
+      now: 1000,
+    });
     h.agent.setEvents([
       { type: 'text', delta: 'Handoff summary' },
       { type: 'done', terminationReason: 'normal' },
@@ -289,12 +332,12 @@ describe('Bridge command contracts', () => {
     await expect(h.run('/compact')).resolves.toBe(true);
 
     expect(lastMarkdown(h.channel)).toContain('已压缩并开始新会话');
-    expect(h.agent.runOptions[0]).toMatchObject({ threadId: 'thread-old' });
+    expect(h.agent.runOptions[0]).toMatchObject({ sessionId: 'session-old' });
     expect(h.sessions.getPendingCompactSummary('chat-1', cwdRealpath)).toBe('Handoff summary');
     expect(
       h.sessionCatalog.activeFor({
         scopeId: 'chat-1',
-        agentId: 'codex',
+        agentId: 'claude',
         cwdRealpath,
         policyFingerprint: policy.policyFingerprint,
       }),
@@ -384,6 +427,7 @@ async function createHarness(options: HarnessOptions = {}): Promise<Harness> {
   const workspaces = new WorkspaceStore(join(tmp.profile, 'workspaces.json'));
   const activeRuns = new ActiveRuns();
   const agent = createFakeAgent();
+  const codexCompactCalls: CompactCodexThreadOptions[] = [];
   const workspaceRealpath = await realpath(tmp.workspace);
   const agentKind = options.agentKind ?? 'claude';
   const profileConfig = appConfig(workspaceRealpath, agentKind);
@@ -430,6 +474,9 @@ async function createHarness(options: HarnessOptions = {}): Promise<Harness> {
       activeRuns,
       sessionCatalog,
       runExecutor,
+      codexCompactProvider: async (compactOptions) => {
+        codexCompactCalls.push(compactOptions);
+      },
       controls,
     });
   };
@@ -449,6 +496,7 @@ async function createHarness(options: HarnessOptions = {}): Promise<Harness> {
     agent,
     controls,
     runExecutor,
+    codexCompactCalls,
     run,
   };
 }

--- a/tests/integration/commands/commands-v1.test.ts
+++ b/tests/integration/commands/commands-v1.test.ts
@@ -2,10 +2,15 @@ import { mkdir, realpath, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { NormalizedMessage } from '@larksuite/channel';
+import { codexCapability } from '../../../src/agent/capability.js';
 import { ActiveRuns } from '../../../src/bot/active-runs.js';
+import { ProcessPool } from '../../../src/bot/process-pool.js';
 import { tryHandleCommand, type CommandContext, type Controls } from '../../../src/commands/index.js';
 import { createDefaultProfileConfig, type ProfileConfig } from '../../../src/config/profile-schema.js';
 import { createRootConfig, loadRootConfig, saveRootConfig } from '../../../src/config/profile-store.js';
+import { evaluateRunPolicy } from '../../../src/policy/run-policy.js';
+import { RunExecutor } from '../../../src/runtime/run-executor.js';
+import { SessionCatalog } from '../../../src/session/catalog.js';
 import { SessionStore } from '../../../src/session/store.js';
 import { WorkspaceStore } from '../../../src/workspace/store.js';
 import { createFakeAgent } from '../../helpers/fake-agent.js';
@@ -24,11 +29,17 @@ interface Harness {
   tmp: TmpProfile;
   channel: FakeChannel;
   sessions: SessionStore;
+  sessionCatalog: SessionCatalog;
   workspaces: WorkspaceStore;
   activeRuns: ActiveRuns;
   agent: ReturnType<typeof createFakeAgent>;
   controls: Controls;
+  runExecutor: RunExecutor;
   run(content: string, overrides?: RunOverrides): Promise<boolean>;
+}
+
+interface HarnessOptions {
+  agentKind?: 'claude' | 'codex';
 }
 
 const cleanups: Array<() => Promise<void>> = [];
@@ -238,6 +249,58 @@ describe('Bridge command contracts', () => {
     expect(status).toContain(jsonStringFragment(await realpath(h.tmp.workspace)));
   });
 
+  it('compacts an active Codex thread into a one-shot handoff', async () => {
+    const h = await createHarness({ agentKind: 'codex' });
+    const cwdRealpath = await realpath(h.tmp.workspace);
+    const policy = evaluateRunPolicy({
+      scope: { source: 'im', chatId: 'chat-1', actorId: 'ou-admin' },
+      attachments: [],
+      prompt: '',
+      requestedCwd: cwdRealpath,
+      cwdRealpath,
+      access: { ok: true, reason: 'allowed-admin' },
+      capability: codexCapability(h.controls.profileConfig),
+      profileConfig: h.controls.profileConfig,
+      now: 1000,
+    });
+    expect(policy.ok).toBe(true);
+    if (!policy.ok) throw new Error('expected allowed policy');
+    h.sessionCatalog.upsertActive({
+      scopeId: 'chat-1',
+      agentId: 'codex',
+      cwdRealpath,
+      policyFingerprint: policy.policyFingerprint,
+      threadId: 'thread-old',
+      now: 1000,
+    });
+    expect(
+      h.sessionCatalog.activeFor({
+        scopeId: 'chat-1',
+        agentId: 'codex',
+        cwdRealpath,
+        policyFingerprint: policy.policyFingerprint,
+      }),
+    ).toMatchObject({ threadId: 'thread-old' });
+    h.agent.setEvents([
+      { type: 'text', delta: 'Handoff summary' },
+      { type: 'done', terminationReason: 'normal' },
+    ]);
+
+    await expect(h.run('/compact')).resolves.toBe(true);
+
+    expect(lastMarkdown(h.channel)).toContain('已压缩并开始新会话');
+    expect(h.agent.runOptions[0]).toMatchObject({ threadId: 'thread-old' });
+    expect(h.sessions.getPendingCompactSummary('chat-1', cwdRealpath)).toBe('Handoff summary');
+    expect(
+      h.sessionCatalog.activeFor({
+        scopeId: 'chat-1',
+        agentId: 'codex',
+        cwdRealpath,
+        policyFingerprint: policy.policyFingerprint,
+      }),
+    ).toBeUndefined();
+  });
+
   it('shows workspace paths in group-visible /status replies', async () => {
     const h = await createHarness();
 
@@ -313,19 +376,21 @@ describe('Bridge command contracts', () => {
   });
 });
 
-async function createHarness(): Promise<Harness> {
+async function createHarness(options: HarnessOptions = {}): Promise<Harness> {
   const tmp = await createTmpProfile('commands-v1-');
   const channel = createFakeChannel();
   const sessions = new SessionStore(join(tmp.profile, 'sessions.json'));
+  const sessionCatalog = new SessionCatalog(join(tmp.profile, 'sessions.catalog.json'));
   const workspaces = new WorkspaceStore(join(tmp.profile, 'workspaces.json'));
   const activeRuns = new ActiveRuns();
   const agent = createFakeAgent();
   const workspaceRealpath = await realpath(tmp.workspace);
-  const profileConfig = appConfig(workspaceRealpath);
+  const agentKind = options.agentKind ?? 'claude';
+  const profileConfig = appConfig(workspaceRealpath, agentKind);
   const configPath = join(tmp.root, 'config.json');
-  await saveRootConfig(createRootConfig('claude', profileConfig), configPath);
+  await saveRootConfig(createRootConfig(agentKind, profileConfig), configPath);
   const controls = {
-    profile: 'claude',
+    profile: agentKind,
     profileConfig,
     botOwnerId: 'ou-owner',
     ownerRefreshState: 'ok',
@@ -337,6 +402,13 @@ async function createHarness(): Promise<Harness> {
     cfg: profileConfig,
     processId: 'proc-1',
   } satisfies Controls;
+  const runExecutor = new RunExecutor({
+    agent,
+    pool: new ProcessPool(() => 10),
+    activeRuns,
+    createRunId: () => `run-${agent.runOptions.length + 1}`,
+    now: () => 1000,
+  });
 
   workspaces.setCwd('chat-1', workspaceRealpath);
 
@@ -356,25 +428,39 @@ async function createHarness(): Promise<Harness> {
       workspaces,
       agent,
       activeRuns,
+      sessionCatalog,
+      runExecutor,
       controls,
     });
   };
 
   cleanups.push(async () => {
-    await Promise.all([sessions.flush(), workspaces.flush()]);
+    await Promise.all([sessions.flush(), sessionCatalog.flush(), workspaces.flush()]);
     await tmp.cleanup();
   });
 
-  return { tmp, channel, sessions, workspaces, activeRuns, agent, controls, run };
+  return {
+    tmp,
+    channel,
+    sessions,
+    sessionCatalog,
+    workspaces,
+    activeRuns,
+    agent,
+    controls,
+    runExecutor,
+    run,
+  };
 }
 
-function appConfig(defaultWorkspace: string): ProfileConfig {
+function appConfig(defaultWorkspace: string, agentKind: 'claude' | 'codex' = 'claude'): ProfileConfig {
   const config = createDefaultProfileConfig({
-    agentKind: 'claude',
+    agentKind,
     accounts: { app: { id: 'app-id', secret: 'secret', tenant: 'feishu' } },
     access: { admins: ['ou-admin'] },
     sandbox: { defaultMode: 'read-only', maxMode: 'workspace-write' },
     preferences: { maxConcurrentRuns: 2 },
+    ...(agentKind === 'codex' ? { codex: { binaryPath: 'codex' } } : {}),
   });
   config.workspaces.default = defaultWorkspace;
   return config;

--- a/tests/integration/session/resume.test.ts
+++ b/tests/integration/session/resume.test.ts
@@ -121,6 +121,55 @@ describe('agent-aware run-flow resume', () => {
     });
   });
 
+  it('injects a compact handoff into the next fresh run only once', async () => {
+    const h = await createHarness('codex');
+    const cwdRealpath = await realpath(h.tmp.workspace);
+    h.sessions.setPendingCompactSummary('chat-1', cwdRealpath, 'Important handoff state');
+
+    const first = await start(h);
+
+    expect(first.ok).toBe(true);
+    if (!first.ok) throw new Error('expected fresh run');
+    expect(first.resumeFrom).toBeUndefined();
+    expect(h.agent.runOptions[0]?.prompt).toContain('Important handoff state');
+    expect(h.agent.runOptions[0]?.prompt).toContain('New user request:');
+    expect(h.sessions.getPendingCompactSummary('chat-1', cwdRealpath)).toBeUndefined();
+    await collect(first.execution.subscribe());
+
+    const second = await start(h);
+
+    expect(second.ok).toBe(true);
+    if (!second.ok) throw new Error('expected second run');
+    expect(h.agent.runOptions[1]?.prompt).toBe('hello');
+  });
+
+  it('does not inject a pending compact handoff when resuming an active session', async () => {
+    const h = await createHarness('codex');
+    const probe = await start(h);
+    expect(probe.ok).toBe(true);
+    if (!probe.ok) throw new Error('expected probe run');
+    await collect(probe.execution.subscribe());
+
+    h.catalog.upsertActive({
+      scopeId: 'chat-1',
+      agentId: 'codex',
+      cwdRealpath: probe.cwdRealpath,
+      policyFingerprint: probe.policy.policyFingerprint,
+      threadId: 'thread-catalog',
+      now: 1000,
+    });
+    h.sessions.setPendingCompactSummary('chat-1', probe.cwdRealpath, 'Should wait');
+
+    const resumed = await start(h);
+
+    expect(resumed.ok).toBe(true);
+    if (!resumed.ok) throw new Error('expected resumed run');
+    expect(resumed.resumeFrom).toBe('thread-catalog');
+    expect(h.agent.runOptions[1]?.threadId).toBe('thread-catalog');
+    expect(h.agent.runOptions[1]?.prompt).toBe('hello');
+    expect(h.sessions.getPendingCompactSummary('chat-1', probe.cwdRealpath)).toBe('Should wait');
+  });
+
   it('records system session identifiers into the agent-aware catalog', async () => {
     const claude = await createHarness('claude');
     const claudeRun = await start(claude);


### PR DESCRIPTION
## What changed

Adds a bridge-level `/compact` command for long-running Claude/Codex sessions.

- Uses Codex's native app-server `thread/compact/start` API when the active session is a Codex thread, so the same thread is compacted in place and remains active.
- Resumes/loads the Codex thread in app-server before compacting, which lets older rollout-backed threads compact instead of failing with `thread not found`.
- Keeps the fallback handoff flow for Claude sessions: generate a Markdown summary, archive the old active session only after summary generation succeeds, and inject the summary once into the next fresh run.
- Stores pending handoff summaries in the local session store and clears them after injection.
- Keeps `/compact` admin-only because it mutates shared chat session state.

## Why

The original bridge run path uses `codex exec resume`, which can continue a Codex thread but does not expose Codex's native compact operation. Without this command, users either hit the model context limit or have to start a blank thread manually. This PR gives bridge users an explicit compact path while preserving continuity.

## Validation

- `pnpm vitest run tests/integration/commands/commands-v1.test.ts tests/integration/session/resume.test.ts --passWithNoTests`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check origin/main...HEAD`