### PR TITLE
feat(agent): add Cursor CLI agent support with session resume

### DIFF
--- a/src/agent/capability.ts
+++ b/src/agent/capability.ts
@@ -2,8 +2,8 @@ import type { AccessMode } from '../config/permissions';
 import type { ProfileConfig } from '../config/profile-schema';
 import { BRIDGE_SYSTEM_PROMPT } from './bridge-system-prompt';
 
-export type AgentCapabilityId = 'claude' | 'codex';
-export type AgentSessionKind = 'claude-session' | 'codex-thread';
+export type AgentCapabilityId = 'claude' | 'codex' | 'cursor';
+export type AgentSessionKind = 'claude-session' | 'codex-thread' | 'cursor-session';
 export type PromptInjectionMode = 'append-system-prompt' | 'stdin-prefix';
 
 export interface AgentCapability {
@@ -47,6 +47,24 @@ export function codexCapability(profile: Pick<ProfileConfig, 'permissions'>): Ag
     promptInjection: 'stdin-prefix',
     systemPrompt: BRIDGE_SYSTEM_PROMPT,
     supportsNativeHistory: false,
+    callback: {
+      marker: '__bridge_cb',
+      legacyMarkers: [],
+    },
+    permissions: {
+      maxAccess,
+    },
+  };
+}
+
+export function cursorCapability(profile?: Pick<ProfileConfig, 'permissions'>): AgentCapability {
+  const maxAccess = profile?.permissions.maxAccess ?? 'full';
+  return {
+    agentId: 'cursor',
+    sessionKind: 'cursor-session',
+    promptInjection: 'stdin-prefix',
+    systemPrompt: BRIDGE_SYSTEM_PROMPT,
+    supportsNativeHistory: true,
     callback: {
       marker: '__bridge_cb',
       legacyMarkers: [],

--- a/src/agent/cursor/adapter.ts
+++ b/src/agent/cursor/adapter.ts
@@ -1,0 +1,248 @@
+import { createInterface } from 'node:readline';
+import type { Readable } from 'node:stream';
+import { log } from '../../core/logger';
+import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
+import { prefixBridgeSystemPrompt } from '../bridge-system-prompt';
+import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel-env';
+import { checkAgentAvailability, type AgentAvailability } from '../preflight';
+import {
+  type AgentAdapter,
+  type AgentBotIdentity,
+  type AgentEvent,
+  type AgentRun,
+  type AgentRunOptions,
+} from '../types';
+import { translateEvent } from './stream-json';
+
+export interface CursorAdapterOptions {
+  binary?: string;
+  larkChannel?: LarkChannelEnvContext;
+}
+
+type CursorChild = SpawnedProcessByStdio<null, Readable, Readable>;
+
+export class CursorAdapter implements AgentAdapter {
+  readonly id = 'cursor';
+  readonly displayName = 'Cursor';
+
+  private readonly binary: string;
+  private readonly larkChannel: LarkChannelEnvContext | undefined;
+  private botIdentity: AgentBotIdentity | undefined;
+
+  constructor(opts: CursorAdapterOptions = {}) {
+    this.binary = opts.binary ?? 'cursor';
+    this.larkChannel = opts.larkChannel;
+  }
+
+  setBotIdentity(identity: AgentBotIdentity): void {
+    this.botIdentity = identity;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return (await this.checkAvailability()).ok;
+  }
+
+  async checkAvailability(): Promise<AgentAvailability> {
+    return checkAgentAvailability({
+      agentId: 'cursor',
+      agentName: 'Cursor',
+      command: this.binary,
+      binaryPath: this.binary,
+    });
+  }
+
+  run(opts: AgentRunOptions): AgentRun {
+    if (!opts.cwd) {
+      throw new Error('cwd is required for CursorAdapter.run');
+    }
+
+    // Cursor has no --append-system-prompt; inject via stdin-prefix style
+    // (prepend system prompt to the user prompt).
+    const prompt = prefixBridgeSystemPrompt(opts.prompt, this.botIdentity);
+
+    const args = [
+      'agent',
+      '-p',
+      prompt,
+      '--output-format',
+      'stream-json',
+      '--force',
+      '--trust',
+    ];
+    if (opts.sessionId) args.push('--resume', opts.sessionId);
+    if (opts.model) args.push('--model', opts.model);
+
+    const child = spawnProcess(this.binary, args, {
+      cwd: opts.cwd,
+      env: mergeProcessEnv(process.env, buildLarkChannelEnv(this.larkChannel)),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }) as CursorChild;
+
+    log.info('agent', 'spawn', {
+      backend: 'cursor',
+      pid: child.pid ?? null,
+      cwd: opts.cwd ?? process.cwd(),
+      hasSession: Boolean(opts.sessionId),
+      promptChars: prompt.length,
+      model: opts.model,
+    });
+
+    const stderrChunks: Buffer[] = [];
+    let runtimeError: Error | null = null;
+    let stderrBuffer = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+      stderrBuffer += chunk.toString('utf8');
+      let nl = stderrBuffer.indexOf('\n');
+      while (nl !== -1) {
+        const line = stderrBuffer.slice(0, nl);
+        stderrBuffer = stderrBuffer.slice(nl + 1);
+        if (line.trim()) log.warn('agent', 'stderr', { line });
+        if (isWindowsCommandNotFoundLine(line)) {
+          runtimeError = new Error(`failed to spawn cursor: ${line.trim()}`);
+          child.stdout.destroy();
+          child.kill();
+        }
+        nl = stderrBuffer.indexOf('\n');
+      }
+    });
+
+    child.on('error', (err) => {
+      runtimeError = err;
+    });
+    child.on('exit', (code, signal) => {
+      log.info('agent', 'exit', { pid: child.pid ?? null, code, signal });
+    });
+
+    const stopGraceMs = opts.stopGraceMs ?? 5000;
+
+    return {
+      runId: opts.runId,
+      events: createEventStream(child, stderrChunks, () => runtimeError),
+      async stop() {
+        if (child.exitCode !== null || child.signalCode !== null) return;
+        log.info('agent', 'stop-sigterm', { pid: child.pid ?? null, graceMs: stopGraceMs });
+        child.kill('SIGTERM');
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            if (child.exitCode === null && child.signalCode === null) {
+              log.warn('agent', 'stop-sigkill', {
+                pid: child.pid ?? null,
+                graceMs: stopGraceMs,
+                reason: 'grace-period-expired',
+              });
+              child.kill('SIGKILL');
+            }
+            resolve();
+          }, stopGraceMs);
+          child.once('exit', () => {
+            clearTimeout(timer);
+            resolve();
+          });
+        });
+      },
+      waitForExit(timeoutMs: number): Promise<boolean> {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          return Promise.resolve(true);
+        }
+        return new Promise<boolean>((resolve) => {
+          const onExit = (): void => {
+            clearTimeout(timer);
+            resolve(true);
+          };
+          const timer = setTimeout(() => {
+            child.removeListener('exit', onExit);
+            resolve(false);
+          }, timeoutMs);
+          child.once('exit', onExit);
+        });
+      },
+    };
+  }
+}
+
+async function* createEventStream(
+  child: CursorChild,
+  stderrChunks: Buffer[],
+  getError: () => Error | null,
+): AsyncGenerator<AgentEvent> {
+  if (!child.pid) {
+    const err = getError();
+    yield {
+      type: 'error',
+      message: err ? `failed to spawn cursor: ${err.message}` : 'spawn returned no pid',
+      terminationReason: 'failed',
+    };
+    return;
+  }
+
+  const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  let sawStdout = false;
+  let silentExitTimer: ReturnType<typeof setTimeout> | undefined;
+  const closeSilentStdout = (): void => {
+    silentExitTimer = setTimeout(() => {
+      if (!sawStdout && !child.stdout.readableEnded) child.stdout.destroy();
+    }, 50);
+  };
+  child.once('exit', closeSilentStdout);
+  try {
+    for await (const line of rl) {
+      sawStdout = true;
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      yield* translateEvent(parsed);
+    }
+  } finally {
+    if (silentExitTimer) clearTimeout(silentExitTimer);
+    child.removeListener('exit', closeSilentStdout);
+    rl.close();
+  }
+
+  const earlyRuntimeError = getError();
+  if (earlyRuntimeError && child.exitCode === null && child.signalCode === null) {
+    yield {
+      type: 'error',
+      message: `cursor runtime error: ${earlyRuntimeError.message}`,
+      terminationReason: 'failed',
+    };
+    return;
+  }
+
+  const exitCode = await new Promise<number | null>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve(child.exitCode);
+    } else {
+      child.once('exit', (code) => resolve(code));
+    }
+  });
+
+  const runtimeError = getError();
+  if (exitCode !== 0 && exitCode !== null) {
+    const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+    const detail = stderr ? `: ${stderr.slice(0, 500)}` : '';
+    yield {
+      type: 'error',
+      message: `cursor exited with code ${exitCode}${detail}`,
+      terminationReason: 'failed',
+    };
+  } else if (runtimeError) {
+    yield {
+      type: 'error',
+      message: `cursor runtime error: ${runtimeError.message}`,
+      terminationReason: 'failed',
+    };
+  }
+}
+
+function isWindowsCommandNotFoundLine(line: string): boolean {
+  return (
+    process.platform === 'win32' &&
+    /is not recognized as an internal or external command|operable program or batch file/i.test(line)
+  );
+}

--- a/src/agent/cursor/stream-json.ts
+++ b/src/agent/cursor/stream-json.ts
@@ -1,0 +1,103 @@
+import type { AgentEvent } from '../types';
+
+interface ContentBlock {
+  type: string;
+  text?: string;
+  thinking?: string;
+  id?: string;
+  name?: string;
+  input?: unknown;
+  tool_use_id?: string;
+  content?: unknown;
+  is_error?: boolean;
+}
+
+interface CursorRawEvent {
+  type?: string;
+  subtype?: string;
+  session_id?: string;
+  cwd?: string;
+  model?: string;
+  message?: { content?: ContentBlock[] };
+  usage?: {
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+  };
+}
+
+/**
+ * Normalize Cursor's camelCase usage fields to the snake_case shape the
+ * bridge's usage pipeline expects (matching Claude's format).
+ */
+export function normalizeCursorUsage(usage: CursorRawEvent['usage']): {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+} | undefined {
+  if (!usage) return undefined;
+  return {
+    input_tokens: usage.inputTokens,
+    output_tokens: usage.outputTokens,
+    cache_read_input_tokens: usage.cacheReadTokens,
+  };
+}
+
+export function* translateEvent(raw: unknown): Generator<AgentEvent> {
+  if (!raw || typeof raw !== 'object') return;
+  const evt = raw as CursorRawEvent;
+
+  if (evt.type === 'system' && evt.subtype === 'init') {
+    yield {
+      type: 'system',
+      sessionId: evt.session_id,
+      cwd: evt.cwd,
+      model: evt.model,
+    };
+    return;
+  }
+
+  if (evt.type === 'assistant' && evt.message?.content) {
+    for (const block of evt.message.content) {
+      if (block.type === 'text' && typeof block.text === 'string' && block.text) {
+        yield { type: 'text', delta: block.text };
+      } else if (block.type === 'thinking' && typeof block.thinking === 'string' && block.thinking) {
+        yield { type: 'thinking', delta: block.thinking };
+      } else if (block.type === 'tool_use' && block.id && block.name) {
+        yield { type: 'tool_use', id: block.id, name: block.name, input: block.input };
+      }
+    }
+    return;
+  }
+
+  if (evt.type === 'user' && evt.message?.content) {
+    for (const block of evt.message.content) {
+      if (block.type === 'tool_result' && block.tool_use_id) {
+        const output =
+          typeof block.content === 'string' ? block.content : JSON.stringify(block.content);
+        yield {
+          type: 'tool_result',
+          id: block.tool_use_id,
+          output,
+          isError: block.is_error === true,
+        };
+      }
+    }
+    return;
+  }
+
+  if (evt.type === 'result') {
+    if (evt.usage) {
+      const normalized = normalizeCursorUsage(evt.usage);
+      yield {
+        type: 'usage',
+        inputTokens: normalized?.input_tokens,
+        outputTokens: normalized?.output_tokens,
+        cachedInputTokens: normalized?.cache_read_input_tokens,
+        // Cursor does not report total_cost_usd
+      };
+    }
+    yield { type: 'done', sessionId: evt.session_id, terminationReason: 'normal' };
+  }
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,3 +1,4 @@
 export type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from './types';
 export { ClaudeAdapter } from './claude/adapter';
 export { CodexAdapter } from './codex/adapter';
+export { CursorAdapter } from './cursor/adapter';

--- a/src/agent/preflight.ts
+++ b/src/agent/preflight.ts
@@ -1,6 +1,6 @@
 import { spawnProcess } from '../platform/spawn';
 
-export type LocalAgentId = 'claude' | 'codex';
+export type LocalAgentId = 'claude' | 'codex' | 'cursor';
 
 export type AgentPreflightErrorCode =
   | 'agent-binary-not-found'
@@ -279,7 +279,7 @@ export function isAgentPreflightDiagnostic(input: unknown): input is AgentPrefli
   return (
     typeof raw.code === 'string' &&
     raw.code.startsWith('agent-') &&
-    (raw.agentId === 'claude' || raw.agentId === 'codex') &&
+    (raw.agentId === 'claude' || raw.agentId === 'codex' || raw.agentId === 'cursor') &&
     typeof raw.agentName === 'string' &&
     typeof raw.command === 'string'
   );

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -5,7 +5,7 @@ import type {
 } from '@larksuite/channel';
 import { createLarkChannel } from '@larksuite/channel';
 import { dirname, join } from 'node:path';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { claudeCapability, codexCapability, cursorCapability } from '../agent/capability';
 import {
   buildAgentPrompt,
   type BridgePromptInteractiveCard,
@@ -694,7 +694,9 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
   const capability =
     controls.profileConfig.agentKind === 'codex'
       ? codexCapability(controls.profileConfig)
-      : claudeCapability(controls.profileConfig);
+      : controls.profileConfig.agentKind === 'cursor'
+        ? cursorCapability(controls.profileConfig)
+        : claudeCapability(controls.profileConfig);
   const flow = await startRunFlow({
     scopeId: scope,
     scope: scopeContext,

--- a/src/bot/comments.ts
+++ b/src/bot/comments.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { CommentEvent, LarkChannel } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { claudeCapability, codexCapability, cursorCapability } from '../agent/capability';
 import type { AgentAdapter, AgentEvent } from '../agent/types';
 import { getAgentStopGraceMs } from '../config/schema';
 import type { Controls } from '../commands';
@@ -184,7 +184,9 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
     const capability =
       controls.profileConfig.agentKind === 'codex'
         ? codexCapability(controls.profileConfig)
-        : claudeCapability(controls.profileConfig);
+        : controls.profileConfig.agentKind === 'cursor'
+          ? cursorCapability(controls.profileConfig)
+          : claudeCapability(controls.profileConfig);
     const runTimeoutMs = commentRunTimeoutMs(sessions, runScopeId);
     const threadTimeoutMs = commentRunTimeoutMs(sessions, commentThreadScopeId);
     const commentTimeoutMs = runTimeoutMs !== undefined ? runTimeoutMs : threadTimeoutMs;
@@ -238,7 +240,7 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
           })
         : undefined;
       const sessionId =
-        canResumeAgentSession && capability.agentId === 'claude'
+        canResumeAgentSession && (capability.agentId === 'claude' || capability.agentId === 'cursor')
           ? sessions.resumeFor(docSessionScopeId, cwdRealpath) ??
             sessions.resumeFor(legacyDocSessionScopeId, cwdRealpath)
           : undefined;
@@ -323,7 +325,7 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
             policy,
             event: e,
           });
-          if (capability.agentId === 'claude' && e.type === 'system' && e.sessionId) {
+          if ((capability.agentId === 'claude' || capability.agentId === 'cursor') && e.type === 'system' && e.sessionId) {
             sessions.set(docSessionScopeId, e.sessionId, policy.cwdRealpath);
           }
           switch (e.type) {

--- a/src/bot/run-flow.ts
+++ b/src/bot/run-flow.ts
@@ -119,7 +119,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
       cwdRealpath: workspace.cwdRealpath,
       policyFingerprint: policy.policyFingerprint,
     });
-    if (catalogEntry?.agentId === 'claude') {
+    if (catalogEntry?.agentId === 'claude' || catalogEntry?.agentId === 'cursor') {
       sessionId = catalogEntry.sessionId;
       resumeFrom = sessionId;
     } else if (catalogEntry?.agentId === 'codex') {
@@ -127,7 +127,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
       resumeFrom = threadId;
     }
   }
-  if (!resumeFrom && input.capability.agentId === 'claude') {
+  if (!resumeFrom && (input.capability.agentId === 'claude' || input.capability.agentId === 'cursor')) {
     resumeFrom = input.sessions.resumeFor(input.scopeId, workspace.cwdRealpath);
     sessionId = resumeFrom;
     const stale = input.sessions.getRaw(input.scopeId);
@@ -183,12 +183,12 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
 
 export function recordRunSessionEvent(input: RecordRunSessionEventInput): void {
   if (input.event.type !== 'system') return;
-  if (input.capability.agentId === 'claude' && input.event.sessionId) {
+  if ((input.capability.agentId === 'claude' || input.capability.agentId === 'cursor') && input.event.sessionId) {
     const cwdRealpath = input.event.cwd ?? input.policy.cwdRealpath;
     input.sessions.set(input.scopeId, input.event.sessionId, cwdRealpath);
     input.sessionCatalog?.upsertActive({
       scopeId: input.scopeId,
-      agentId: 'claude',
+      agentId: input.capability.agentId,
       cwdRealpath,
       policyFingerprint: input.policy.policyFingerprint,
       sessionId: input.event.sessionId,

--- a/src/bot/session-catalog-identity.ts
+++ b/src/bot/session-catalog-identity.ts
@@ -1,5 +1,5 @@
 import type { NormalizedMessage } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { claudeCapability, codexCapability, cursorCapability } from '../agent/capability';
 import type { Controls } from '../commands';
 import type { AccessDecision } from '../policy/access';
 import { evaluateRunPolicy } from '../policy/run-policy';
@@ -24,7 +24,9 @@ export async function commandSessionCatalogIdentity(input: {
   const capability =
     input.controls.profileConfig.agentKind === 'codex'
       ? codexCapability(input.controls.profileConfig)
-      : claudeCapability(input.controls.profileConfig);
+      : input.controls.profileConfig.agentKind === 'cursor'
+        ? cursorCapability(input.controls.profileConfig)
+        : claudeCapability(input.controls.profileConfig);
   const policy = evaluateRunPolicy({
     scope: {
       source: 'im',

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -469,7 +469,7 @@ async function maybeResolveProfileRuntime(
 }
 
 function agentDisplay(agentKind: ProcessEntry['agentKind']): { id: string; displayName: string } {
-  return agentKind === 'codex'
-    ? { id: 'codex', displayName: 'Codex CLI' }
-    : { id: 'claude', displayName: 'Claude Code' };
+  if (agentKind === 'codex') return { id: 'codex', displayName: 'Codex CLI' };
+  if (agentKind === 'cursor') return { id: 'cursor', displayName: 'Cursor' };
+  return { id: 'claude', displayName: 'Claude Code' };
 }

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -4,6 +4,7 @@ import { createInterface } from 'node:readline';
 import pkg from '../../../package.json';
 import { ClaudeAdapter } from '../../agent/claude/adapter';
 import { CodexAdapter } from '../../agent/codex/adapter';
+import { CursorAdapter } from '../../agent/cursor/adapter';
 import {
   AgentPreflightError,
   formatAgentPreflightDiagnostic,
@@ -431,6 +432,12 @@ export function createRuntimeAgent(
       ignoreUserConfig: codex.ignoreUserConfig === true,
       ignoreRules: codex.ignoreRules !== false,
       sandbox: profileConfig.sandbox.defaultMode,
+      larkChannel,
+    });
+  }
+  if (profileConfig.agentKind === 'cursor') {
+    return new CursorAdapter({
+      binary: process.env.LARK_CHANNEL_CURSOR_BIN ?? 'cursor',
       larkChannel,
     });
   }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute } from 'node:path';
 import type { LarkChannel, NormalizedMessage } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { claudeCapability, codexCapability, cursorCapability } from '../agent/capability';
 import type { AgentAdapter } from '../agent/types';
 import type { ActiveRuns } from '../bot/active-runs';
 import {
@@ -144,7 +144,7 @@ type Handler = (args: string, ctx: CommandContext) => Promise<void>;
 
 interface ResumeCandidate {
   scopeId: string;
-  agentId: 'claude' | 'codex';
+  agentId: 'claude' | 'codex' | 'cursor';
   cwdRealpath: string;
   policyFingerprint: string;
   sessionId?: string;
@@ -606,7 +606,7 @@ async function applyResume(sessionId: string, ctx: CommandContext): Promise<void
       } else {
         ctx.sessionCatalog.upsertActive({
           scopeId: ctx.sessionCatalogIdentity.scopeId,
-          agentId: 'claude',
+          agentId: ctx.sessionCatalogIdentity.agentId,
           cwdRealpath: ctx.sessionCatalogIdentity.cwdRealpath,
           policyFingerprint: ctx.sessionCatalogIdentity.policyFingerprint,
           sessionId: resolved.sessionId!,
@@ -626,7 +626,7 @@ async function applyResume(sessionId: string, ctx: CommandContext): Promise<void
       return;
     }
     ctx.activeRuns.interrupt(ctx.scope);
-    if (ctx.sessionCatalogIdentity.agentId === 'claude') {
+    if (ctx.sessionCatalogIdentity.agentId === 'claude' || ctx.sessionCatalogIdentity.agentId === 'cursor') {
       ctx.sessions.set(ctx.scope, sessionId, ctx.sessionCatalogIdentity.cwdRealpath);
     }
     await reply(ctx, RESUME_APPLIED_REPLY);
@@ -679,7 +679,7 @@ function consumeResumeCandidate(
     candidate.agentId !== identity.agentId ||
     candidate.cwdRealpath !== identity.cwdRealpath ||
     candidate.policyFingerprint !== identity.policyFingerprint ||
-    (identity.agentId === 'claude' && !candidate.sessionId) ||
+    ((identity.agentId === 'claude' || identity.agentId === 'cursor') && !candidate.sessionId) ||
     (identity.agentId === 'codex' && !candidate.threadId)
   ) {
     return undefined;
@@ -742,7 +742,7 @@ function selectedResumeCwd(ctx: CommandContext): string | undefined {
 function runtimeAccessStatus(
   profileConfig: ProfileConfig,
 ): { label: string; value: string } {
-  if (profileConfig.agentKind === 'claude') {
+  if (profileConfig.agentKind === 'claude' || profileConfig.agentKind === 'cursor') {
     return {
       label: 'permission',
       value: accessToClaudePermissionMode(
@@ -1109,7 +1109,9 @@ async function handleDoctor(args: string, ctx: CommandContext): Promise<void> {
   const capability =
     ctx.controls.profileConfig.agentKind === 'codex'
       ? codexCapability(ctx.controls.profileConfig)
-      : claudeCapability(ctx.controls.profileConfig);
+      : ctx.controls.profileConfig.agentKind === 'cursor'
+        ? cursorCapability(ctx.controls.profileConfig)
+        : claudeCapability(ctx.controls.profileConfig);
   const policy = evaluateRunPolicy({
     scope: {
       source: 'im',

--- a/src/config/migrate-v2.ts
+++ b/src/config/migrate-v2.ts
@@ -200,7 +200,7 @@ function activeProcessFromRegistryEntry(entry: RegistryEntry): ActiveBridgeMigra
   if (typeof entry.appId === 'string') active.appId = entry.appId;
   if (typeof entry.tenant === 'string') active.tenant = entry.tenant;
   if (typeof entry.profileName === 'string') active.profileName = entry.profileName;
-  if (entry.agentKind === 'claude' || entry.agentKind === 'codex') active.agentKind = entry.agentKind;
+  if (entry.agentKind === 'claude' || entry.agentKind === 'codex' || entry.agentKind === 'cursor') active.agentKind = entry.agentKind;
   if (typeof entry.configPath === 'string') active.configPath = entry.configPath;
   if (typeof entry.startedAt === 'string') active.startedAt = entry.startedAt;
   if (typeof entry.version === 'string') active.version = entry.version;

--- a/src/config/profile-schema.ts
+++ b/src/config/profile-schema.ts
@@ -13,7 +13,7 @@ import {
   type PermissionSource,
 } from './permissions';
 
-export type AgentKind = 'claude' | 'codex';
+export type AgentKind = 'claude' | 'codex' | 'cursor';
 export type SandboxMode = CodexSandboxMode;
 export type { AccessMode, PermissionConfig, PermissionSource };
 
@@ -158,8 +158,8 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
   if (raw.schemaVersion !== 2) {
     throw new Error('profile schemaVersion must be 2');
   }
-  if (raw.agentKind !== 'claude' && raw.agentKind !== 'codex') {
-    throw new Error('agentKind must be claude or codex');
+  if (raw.agentKind !== 'claude' && raw.agentKind !== 'codex' && raw.agentKind !== 'cursor') {
+    throw new Error('agentKind must be claude, codex, or cursor');
   }
   const accounts = normalizeAccounts(raw.accounts);
   if (raw.agentKind === 'codex' && !raw.codex) {

--- a/src/config/profile-store.ts
+++ b/src/config/profile-store.ts
@@ -292,7 +292,7 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 export function agentKindFromString(value: string | undefined): AgentKind | undefined {
-  if (value === 'claude' || value === 'codex') return value;
+  if (value === 'claude' || value === 'codex' || value === 'cursor') return value;
   if (value === undefined) return undefined;
   throw new Error(`unsupported agent: ${value}`);
 }

--- a/src/runtime/locks.ts
+++ b/src/runtime/locks.ts
@@ -178,7 +178,7 @@ function isRuntimeLockMeta(value: unknown): value is RuntimeLockMeta {
     (meta.kind === 'profile' || meta.kind === 'app') &&
     typeof meta.target === 'string' &&
     typeof meta.profile === 'string' &&
-    (meta.agentKind === 'claude' || meta.agentKind === 'codex') &&
+    (meta.agentKind === 'claude' || meta.agentKind === 'codex' || meta.agentKind === 'cursor') &&
     typeof meta.pid === 'number' &&
     typeof meta.startedAt === 'string' &&
     (meta.appId === undefined || typeof meta.appId === 'string')

--- a/src/runtime/registry.ts
+++ b/src/runtime/registry.ts
@@ -64,7 +64,7 @@ function isValidEntry(e: unknown): e is ProcessEntry {
     typeof x.appId === 'string' &&
     (x.tenant === 'feishu' || x.tenant === 'lark') &&
     typeof x.profileName === 'string' &&
-    (x.agentKind === 'claude' || x.agentKind === 'codex') &&
+    (x.agentKind === 'claude' || x.agentKind === 'codex' || x.agentKind === 'cursor') &&
     typeof x.configPath === 'string' &&
     typeof x.startedAt === 'string' &&
     typeof x.version === 'string'

--- a/src/session/catalog.ts
+++ b/src/session/catalog.ts
@@ -214,7 +214,7 @@ function normalizeEntry(input: unknown): SessionCatalogEntry | undefined {
   if (
     typeof raw.key !== 'string' ||
     typeof raw.scopeId !== 'string' ||
-    (raw.agentId !== 'claude' && raw.agentId !== 'codex') ||
+    (raw.agentId !== 'claude' && raw.agentId !== 'codex' && raw.agentId !== 'cursor') ||
     typeof raw.cwdRealpath !== 'string' ||
     typeof raw.policyFingerprint !== 'string' ||
     (raw.status !== 'active' && raw.status !== 'archived') ||
@@ -247,14 +247,14 @@ function matchesIdentity(entry: SessionCatalogEntry, input: SessionCatalogIdenti
 }
 
 function isValidAgentEntry(entry: SessionCatalogEntry): boolean {
-  if (entry.agentId === 'claude') return Boolean(entry.sessionId) && !entry.threadId;
+  if (entry.agentId === 'claude' || entry.agentId === 'cursor') return Boolean(entry.sessionId) && !entry.threadId;
   return Boolean(entry.threadId) && !entry.sessionId;
 }
 
 function assertAgentIdentity(input: UpsertSessionCatalogInput): void {
-  if (input.agentId === 'claude') {
+  if (input.agentId === 'claude' || input.agentId === 'cursor') {
     if (!input.sessionId || input.threadId) {
-      throw new Error('Claude catalog entries require sessionId and must not include threadId');
+      throw new Error(`${input.agentId} catalog entries require sessionId and must not include threadId`);
     }
     return;
   }


### PR DESCRIPTION
## Summary

Adds Cursor CLI (`cursor agent`) as a first-class agent backend, including session resume support that lets users maintain conversation context across messages — the same way Claude Code does.

### What's included

- **CursorAdapter** (`src/agent/cursor/adapter.ts`) — spawns `cursor agent -p --output-format stream-json --force --trust`, with `--resume` and `--model` support
- **Cursor stream-json translator** (`src/agent/cursor/stream-json.ts`) — normalizes Cursor's camelCase usage fields (`inputTokens` → `input_tokens`) to match the bridge's existing pipeline
- **System prompt injection** — uses `prefixBridgeSystemPrompt()` since Cursor CLI has no `--append-system-prompt` flag
- **Session resume fix** — the core change: Cursor uses the same `session_id` protocol as Claude Code, but `recordRunSessionEvent()`, `startRunFlow()`, and comment handlers were hardcoded to `agentId === 'claude'`. This PR extends all session persistence and resume paths to include `'cursor'`, enabling multi-turn conversations.
- **Full type system integration** — `AgentCapabilityId`, `AgentKind`, profile schema, migration validation, preflight checks, runtime locks, process registry, session catalog, and all command handlers updated.

### Why this matters

Without session resume, every message to a Cursor-backed bridge starts a fresh context — the agent can't remember what the user said 30 seconds ago. This makes Cursor unusable for real conversations through the bridge. With this PR, Cursor sessions persist and resume identically to Claude Code sessions.

### Files changed (18)

| Area | Files | Change |
|------|-------|--------|
| New adapter | `cursor/adapter.ts`, `cursor/stream-json.ts` | CursorAdapter + event translator |
| Capability | `capability.ts`, `index.ts`, `preflight.ts` | `'cursor'` agent type |
| Session resume | `run-flow.ts`, `comments.ts`, `catalog.ts`, `commands/index.ts` | Extend `=== 'claude'` checks to include cursor |
| Config | `profile-schema.ts`, `profile-store.ts`, `migrate-v2.ts` | `agentKind: 'cursor'` |
| Runtime | `channel.ts`, `session-catalog-identity.ts`, `locks.ts`, `registry.ts`, `start.ts`, `service.ts` | Cursor factory branch + display |

### Testing

Tested locally with `lark-channel-bridge` v0.3.1 on macOS:
- `cursor agent -p --force --trust --output-format stream-json` headless execution ✅
- `--resume <sessionId>` cross-message context retention ✅
- `/backend cursor` ↔ `/backend claude` runtime switching ✅
- Session catalog persistence across bridge restarts ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)