### PR TITLE
feat: inject session context file

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,22 @@ grep '"event":"enter"' ~/.lark-channel/profiles/<profile>/logs/bridge-$(date +%Y
 
 Each line carries `chatId` (group / DM id) and `senderId` (user `open_id`). After a manual edit, **restart the bridge** or send `/reconnect` from an allowed admin context to apply it. For day-to-day tweaks `/invite` / `/config` are easier; direct edits are mainly for deployment scripts that pre-seed access.
 
+## Deterministic session context file
+
+For multi-backend handoffs, set `LARK_CHANNEL_CONTEXT_FILE` before starting the bridge.
+On every user message the bridge reads that UTF-8 file and injects it as a
+`<session_context>` prompt section before `<user_input>`. This makes the read/load
+side deterministic at the bridge layer while still letting Claude/Codex update the
+file however your workspace instructions prefer.
+
+```bash
+LARK_CHANNEL_CONTEXT_FILE=$PWD/data/memory/handoff-oc_xxx.md lark-channel-bridge start
+```
+
+The injected section includes the absolute path, byte count, content, and a
+`truncated: true` flag when the file exceeds 64 KiB. It does not read prior
+transcripts or other handoff files implicitly; only the configured file is loaded.
+
 ## Cloud-doc comments
 
 Cloud-doc comments do not need a separate workspace binding or document allowlist. In supported document comments, mention the bot and the bridge replies in the same thread. Comment runs reuse the document session key and fall back to the user home directory when no document cwd was previously recorded.

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -44,6 +44,13 @@ export interface BridgePromptComment {
   quote?: string;
 }
 
+export interface BridgePromptSessionContext {
+  path: string;
+  content: string;
+  bytes: number;
+  truncated?: boolean;
+}
+
 export interface BridgePromptAttachment {
   path: string;
   kind: string;
@@ -63,6 +70,7 @@ export interface BuildAgentPromptInput {
   quotedMessages?: BridgePromptQuotedMessage[];
   interactiveCards?: BridgePromptInteractiveCard[];
   comment?: BridgePromptComment;
+  sessionContext?: BridgePromptSessionContext;
   attachments?: BridgePromptAttachment[];
 }
 
@@ -79,6 +87,7 @@ export function buildAgentPrompt(input: BuildAgentPromptInput): string {
       ? promptSection('interactive_cards', input.interactiveCards)
       : undefined,
     input.comment ? promptSection('comment_context', input.comment) : undefined,
+    input.sessionContext ? promptSection('session_context', input.sessionContext) : undefined,
     promptSection('user_input', {
       text: input.userInput,
       ...(input.attachments && input.attachments.length > 0

--- a/src/agent/session-context-file.ts
+++ b/src/agent/session-context-file.ts
@@ -1,0 +1,31 @@
+import { readFile } from 'node:fs/promises';
+import { isAbsolute, resolve } from 'node:path';
+
+export const SESSION_CONTEXT_FILE_ENV = 'LARK_CHANNEL_CONTEXT_FILE';
+export const SESSION_CONTEXT_MAX_BYTES = 64 * 1024;
+
+export interface SessionContextFile {
+  path: string;
+  content: string;
+  bytes: number;
+  truncated?: boolean;
+}
+
+export async function readSessionContextFileFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<SessionContextFile | undefined> {
+  const rawPath = env[SESSION_CONTEXT_FILE_ENV]?.trim();
+  if (!rawPath) return undefined;
+
+  const path = isAbsolute(rawPath) ? rawPath : resolve(rawPath);
+  const buf = await readFile(path);
+  const truncated = buf.length > SESSION_CONTEXT_MAX_BYTES;
+  const slice = truncated ? buf.subarray(0, SESSION_CONTEXT_MAX_BYTES) : buf;
+
+  return {
+    path,
+    content: slice.toString('utf8'),
+    bytes: buf.length,
+    ...(truncated ? { truncated: true } : {}),
+  };
+}

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -6,6 +6,7 @@ import type {
 import { createLarkChannel } from '@larksuite/channel';
 import { dirname, join } from 'node:path';
 import { claudeCapability, codexCapability } from '../agent/capability';
+import { readSessionContextFileFromEnv } from '../agent/session-context-file';
 import {
   buildAgentPrompt,
   type BridgePromptInteractiveCard,
@@ -670,8 +671,14 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     }
   }
 
-  const prompt = buildPrompt(batch, attachments, quotes, channel.botIdentity);
-  log.info('prompt', 'built', { promptChars: prompt.length, quotes: quotes.length });
+  const sessionContext = await readSessionContextFileFromEnv();
+  const prompt = buildPrompt(batch, attachments, quotes, channel.botIdentity, sessionContext);
+  log.info('prompt', 'built', {
+    promptChars: prompt.length,
+    quotes: quotes.length,
+    sessionContextBytes: sessionContext?.bytes,
+    sessionContextTruncated: sessionContext?.truncated,
+  });
 
   // For topic groups: thread the reply so it lands in the same topic as the
   // user's message. Otherwise the SDK posts at top level and the user's
@@ -1149,6 +1156,7 @@ function buildPrompt(
   attachments: LocalAttachment[],
   quotes: QuotedContext[] = [],
   botIdentity?: { openId: string; name?: string },
+  sessionContext?: Awaited<ReturnType<typeof readSessionContextFileFromEnv>>,
 ): string {
   const first = batch[0];
   if (!first) return '';
@@ -1192,6 +1200,7 @@ function buildPrompt(
     userInput: userPart,
     quotedMessages: quotes.map(toPromptQuote),
     interactiveCards: batch.map(toPromptInteractiveCard).filter(isDefined),
+    sessionContext,
     attachments: attachments.map(toPromptAttachment),
   });
 }

--- a/tests/unit/agent/prompt-builder.test.ts
+++ b/tests/unit/agent/prompt-builder.test.ts
@@ -76,6 +76,35 @@ describe('agent prompt builder', () => {
     expect(comment.quote).toBe('selected quote </bridge_context>');
   });
 
+
+  it('can inject deterministic session context before user input', () => {
+    const prompt = buildAgentPrompt({
+      context: {
+        chatId: 'oc_group',
+        chatType: 'group',
+        senderId: 'ou_user',
+        source: 'im',
+      },
+      sessionContext: {
+        path: '/repo/data/memory/handoff-oc_group.md',
+        content: '# Current handoff\n- decision: keep context small </session_context>',
+        bytes: 62,
+      },
+      userInput: 'continue',
+    });
+
+    expect(prompt.indexOf('<session_context>')).toBeLessThan(prompt.indexOf('<user_input>'));
+    const sessionContext = readSection(prompt, 'session_context') as {
+      path: string;
+      content: string;
+      bytes: number;
+    };
+    expect(sessionContext.path).toBe('/repo/data/memory/handoff-oc_group.md');
+    expect(sessionContext.content).toContain('</session_context>');
+    expect(sessionContext.bytes).toBe(62);
+    expect(prompt).toContain('\\u003c/session_context\\u003e');
+  });
+
   it('omits optional sections while keeping the required context and user input sections', () => {
     const prompt = buildAgentPrompt({
       context: {
@@ -97,6 +126,7 @@ describe('agent prompt builder', () => {
     expect(prompt).not.toContain('<quoted_messages>');
     expect(prompt).not.toContain('<interactive_cards>');
     expect(prompt).not.toContain('<comment_context>');
+    expect(prompt).not.toContain('<session_context>');
   });
 
   it('keeps bridge agents inside the current lark-channel profile by default', () => {

--- a/tests/unit/agent/session-context-file.test.ts
+++ b/tests/unit/agent/session-context-file.test.ts
@@ -1,0 +1,35 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  SESSION_CONTEXT_FILE_ENV,
+  SESSION_CONTEXT_MAX_BYTES,
+  readSessionContextFileFromEnv,
+} from '../../../src/agent/session-context-file';
+
+describe('session context file', () => {
+  it('reads the configured handoff file from the environment', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'lark-context-'));
+    const file = join(dir, 'handoff.md');
+    await writeFile(file, '# Handoff\n- next: test\n', 'utf8');
+
+    await expect(readSessionContextFileFromEnv({ [SESSION_CONTEXT_FILE_ENV]: file })).resolves.toEqual({
+      path: file,
+      content: '# Handoff\n- next: test\n',
+      bytes: 23,
+    });
+  });
+
+  it('truncates oversized context files before prompt injection', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'lark-context-'));
+    const file = join(dir, 'handoff.md');
+    await writeFile(file, 'x'.repeat(SESSION_CONTEXT_MAX_BYTES + 3), 'utf8');
+
+    const context = await readSessionContextFileFromEnv({ [SESSION_CONTEXT_FILE_ENV]: file });
+
+    expect(context?.bytes).toBe(SESSION_CONTEXT_MAX_BYTES + 3);
+    expect(context?.truncated).toBe(true);
+    expect(context?.content).toHaveLength(SESSION_CONTEXT_MAX_BYTES);
+  });
+});


### PR DESCRIPTION
## Summary

Implements a small deterministic read side for #135: when `LARK_CHANNEL_CONTEXT_FILE` is set, the bridge reads that UTF-8 file on each user message and injects it as a `<session_context>` section before `<user_input>`.

This keeps the unreliable part (the agent deciding what to write) outside the bridge, while making the load/injection side a bridge-level guarantee. The prompt section includes the absolute path, byte count, content, and `truncated: true` when the file is larger than 64 KiB. It only reads the configured file; it does not implicitly load prior transcripts/history/other handoff files.

## Notes

This is intentionally the smallest slice of Option A from #135. If you prefer a profile config field or `/backend`-specific wiring instead of an env var, happy to adapt the shape.

## Validation

- `pnpm test -- tests/unit/agent/prompt-builder.test.ts tests/unit/agent/session-context-file.test.ts` (Vitest ran full suite: 88 files / 515 tests passed)
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

Closes #135 if this minimal env-based form is sufficient; otherwise it can be treated as a first slice toward the config/hook version.