### PR TITLE
feat: add Trae CLI agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lark-channel-bridge
 
-A lightweight bot that bridges Feishu / Lark messenger with your local Claude Code or Codex CLI. Run one command, scan a QR code to bind a PersonalAgent app, and talk to your local coding agent from chat.
+A lightweight bot that bridges Feishu / Lark messenger with your local Claude Code, Codex CLI, or Trae CLI. Run one command, scan a QR code to bind a PersonalAgent app, and talk to your local coding agent from chat.
 
 [中文 README](./README.zh.md)
 
@@ -8,7 +8,7 @@ For a product walkthrough, see the [Feishu document](https://larkcommunity.feish
 
 ## What it does
 
-- Forwards Feishu / Lark messages to local Claude Code or Codex CLI. Send a DM directly, or `@bot` in a group.
+- Forwards Feishu / Lark messages to local Claude Code, Codex CLI, or Trae CLI. Send a DM directly, or `@bot` in a group.
 - **Streaming card**: text replies and tool calls update on one Lark card in real time.
 - **Session continuity**: each chat, topic, or document comment thread keeps its own session.
 - **Queueing and batching**: messages sent in quick succession are handled together; messages sent during a run are queued for the next turn, while commands like `/new`, `/cd`, `/ws use`, and `/stop` can interrupt the current task.
@@ -22,6 +22,7 @@ For a product walkthrough, see the [Feishu document](https://larkcommunity.feish
 - At least one local agent installed and logged in:
   - Claude Code: `claude`, see https://docs.anthropic.com/en/docs/claude-code/quickstart
   - Codex CLI: `codex`, see https://developers.openai.com/codex/cli
+  - Trae CLI: `traecli`
 - A Feishu / Lark **PersonalAgent** app. The first-run QR wizard can create and bind one for you.
 
 ## Install
@@ -87,13 +88,14 @@ Platform mapping:
 
 Daemon logs are under `~/.lark-channel/profiles/<profile>/logs/daemon/`.
 
-### Multiple profiles: Claude and Codex
+### Multiple profiles: Claude, Codex, and Trae
 
-By default, the bridge starts with the currently selected profile. Use `profile use <name>` to change it. Each profile keeps its own app credentials, sessions, working directories, and logs. Create multiple profiles only when you need to connect multiple PersonalAgent apps, or run Claude and Codex as separate bots:
+By default, the bridge starts with the currently selected profile. Use `profile use <name>` to change it. Each profile keeps its own app credentials, sessions, working directories, and logs. Create multiple profiles only when you need to connect multiple PersonalAgent apps, or run Claude, Codex, and Trae as separate bots:
 
 ```bash
 lark-channel-bridge start --profile claude --agent claude
 lark-channel-bridge start --profile codex --agent codex
+lark-channel-bridge start --profile trae --agent trae
 ```
 
 For example, to restart only the Codex bot:
@@ -108,18 +110,19 @@ lark-channel-bridge status --profile codex
 ### Host CLI
 
 ```text
-lark-channel-bridge run [--profile <name>] [--agent claude|codex] [--workspace <path>] [-c <config>]
-lark-channel-bridge migrate [--profile <name>] [--agent claude|codex]
+lark-channel-bridge run [--profile <name>] [--agent claude|codex|trae] [--workspace <path>] [-c <config>]
+lark-channel-bridge migrate [--profile <name>] [--agent claude|codex|trae]
 lark-channel-bridge ps
 lark-channel-bridge kill <id|#>
 lark-channel-bridge --help
 ```
 
-`profile use <name>` changes the profile used by later default starts. Use these profile management commands when running separate Claude / Codex bots, connecting multiple PersonalAgent apps, or doing scripted deployment:
+`profile use <name>` changes the profile used by later default starts. Use these profile management commands when running separate Claude / Codex / Trae bots, connecting multiple PersonalAgent apps, or doing scripted deployment:
 
 ```bash
 lark-channel-bridge profile create claude --agent claude
 lark-channel-bridge profile create codex --agent codex
+lark-channel-bridge profile create trae --agent trae
 lark-channel-bridge profile list
 lark-channel-bridge profile use <name>
 lark-channel-bridge profile remove <name>
@@ -294,7 +297,7 @@ Cloud-doc comments do not need a separate workspace binding or document allowlis
 
 ## FAQ
 
-**The bot stays silent or the local CLI never replies.** Usually the local `claude` or `codex` CLI is not logged in, or the current session points to a working directory that no longer exists. Send `/status` to inspect; `/new` often fixes it by starting a fresh session.
+**The bot stays silent or the local CLI never replies.** Usually the local `claude`, `codex`, or `traecli` CLI is not logged in, or the current session points to a working directory that no longer exists. Send `/status` to inspect; `/new` often fixes it by starting a fresh session.
 
 **The agent subprocess looks frozen (card stuck on the last frame).** The bridge supports an idle watchdog: if the agent emits nothing for N minutes, the process is killed and the card is annotated with the auto-termination reason. Disabled by default. Enable with `/config` globally, or `/timeout 10` for the current session; `/timeout off` disables it for the session; `/timeout default` clears the session override.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,6 +1,6 @@
 # lark-channel-bridge
 
-把飞书 / Lark 消息和本地 Claude Code 或 Codex CLI 打通的轻量 bot。用一条命令启动，扫码绑定 PersonalAgent 应用，然后在飞书里和本机编程助手对话，让它读图、处理文件、改代码。
+把飞书 / Lark 消息和本地 Claude Code、Codex CLI 或 Trae CLI 打通的轻量 bot。用一条命令启动，扫码绑定 PersonalAgent 应用，然后在飞书里和本机编程助手对话，让它读图、处理文件、改代码。
 
 [English README](./README.md)
 
@@ -8,7 +8,7 @@
 
 ## 主要功能
 
-- 在飞书私聊直接发消息，或在群里 `@bot`，把任务转给本机 Claude Code / Codex CLI。
+- 在飞书私聊直接发消息，或在群里 `@bot`，把任务转给本机 Claude Code / Codex CLI / Trae CLI。
 - **流式卡片**：文本回复和工具调用实时更新在同一张卡片上。
 - **会话延续**：每个聊天、话题或文档评论有自己的会话，不会互相串。
 - **排队与消息合并**：短时间连续发送的消息会合并处理；任务运行中收到的普通消息会排队到下一轮，`/new`、`/cd`、`/ws use`、`/stop` 这类命令可以中断当前任务。
@@ -22,6 +22,7 @@
 - 本机至少安装并登录一个 agent：
   - Claude Code：`claude`，安装说明：https://docs.anthropic.com/en/docs/claude-code/quickstart
   - Codex CLI：`codex`，安装说明：https://developers.openai.com/codex/cli
+  - Trae CLI：`traecli`
 - 一个飞书 / Lark PersonalAgent 应用。首次启动的扫码向导可以帮你创建并绑定。
 
 ## 安装
@@ -87,13 +88,14 @@ lark-channel-bridge unregister [--profile <name>]
 
 daemon 日志在 `~/.lark-channel/profiles/<profile>/logs/daemon/`。
 
-### 多 profile：分别运行 Claude 和 Codex
+### 多 profile：分别运行 Claude、Codex 和 Trae
 
-默认情况下，bridge 使用当前激活的 profile；可以通过 `profile use <name>` 切换。每个 profile 会维护独立的应用凭据、会话、工作目录和日志。只有在需要同时连接多个 PersonalAgent 应用，或分别运行 Claude 和 Codex 时，才需要创建多个 profile：
+默认情况下，bridge 使用当前激活的 profile；可以通过 `profile use <name>` 切换。每个 profile 会维护独立的应用凭据、会话、工作目录和日志。只有在需要同时连接多个 PersonalAgent 应用，或分别运行 Claude、Codex 和 Trae 时，才需要创建多个 profile：
 
 ```bash
 lark-channel-bridge start --profile claude --agent claude
 lark-channel-bridge start --profile codex --agent codex
+lark-channel-bridge start --profile trae --agent trae
 ```
 
 例如只重启 Codex bot：
@@ -108,18 +110,19 @@ lark-channel-bridge status --profile codex
 ### 宿主 CLI
 
 ```text
-lark-channel-bridge run [--profile <name>] [--agent claude|codex] [--workspace <path>] [-c <config>]
-lark-channel-bridge migrate [--profile <name>] [--agent claude|codex]
+lark-channel-bridge run [--profile <name>] [--agent claude|codex|trae] [--workspace <path>] [-c <config>]
+lark-channel-bridge migrate [--profile <name>] [--agent claude|codex|trae]
 lark-channel-bridge ps
 lark-channel-bridge kill <id|#>
 lark-channel-bridge --help
 ```
 
-`profile use <name>` 会切换后续默认启动使用的 profile。需要同时跑 Claude / Codex 两个 bot、连接多套 PersonalAgent 应用，或做脚本化部署时，再使用这些 profile 管理命令：
+`profile use <name>` 会切换后续默认启动使用的 profile。需要同时跑 Claude / Codex / Trae 多个 bot、连接多套 PersonalAgent 应用，或做脚本化部署时，再使用这些 profile 管理命令：
 
 ```bash
 lark-channel-bridge profile create claude --agent claude
 lark-channel-bridge profile create codex --agent codex
+lark-channel-bridge profile create trae --agent trae
 lark-channel-bridge profile list
 lark-channel-bridge profile use <name>
 lark-channel-bridge profile remove <name>
@@ -294,7 +297,7 @@ grep '"event":"enter"' ~/.lark-channel/profiles/<profile>/logs/bridge-$(date +%Y
 
 ## 常见问题
 
-**bot 没反应 / agent 不回复**：通常是本机 `claude` 或 `codex` CLI 没登录，或者当前会话指向了不存在的工作目录。发 `/status` 看当前状态；`/new` 重开会话往往就好。
+**bot 没反应 / agent 不回复**：通常是本机 `claude`、`codex` 或 `traecli` CLI 没登录，或者当前会话指向了不存在的工作目录。发 `/status` 看当前状态；`/new` 重开会话往往就好。
 
 **agent 子进程假死（卡片停在最后一帧不动）**：支持 idle 探活。agent 一段时间没输出就会被 SIGTERM kill，卡片末尾会标出自动终止原因。默认关闭。开启方式：`/config` 设全局值（分钟），或 `/timeout 10` 只对当前会话生效；`/timeout off` 关掉当前会话的探活；`/timeout default` 清掉会话覆盖，回退到全局设置。
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,8 @@
     "claude",
     "claude-code",
     "codex",
+    "trae",
+    "traecli",
     "cli",
     "channel",
     "bridge"

--- a/src/agent/capability.ts
+++ b/src/agent/capability.ts
@@ -2,8 +2,8 @@ import type { AccessMode } from '../config/permissions';
 import type { ProfileConfig } from '../config/profile-schema';
 import { BRIDGE_SYSTEM_PROMPT } from './bridge-system-prompt';
 
-export type AgentCapabilityId = 'claude' | 'codex';
-export type AgentSessionKind = 'claude-session' | 'codex-thread';
+export type AgentCapabilityId = 'claude' | 'codex' | 'trae';
+export type AgentSessionKind = 'claude-session' | 'codex-thread' | 'trae-thread';
 export type PromptInjectionMode = 'append-system-prompt' | 'stdin-prefix';
 
 export interface AgentCapability {
@@ -44,6 +44,24 @@ export function codexCapability(profile: Pick<ProfileConfig, 'permissions'>): Ag
   return {
     agentId: 'codex',
     sessionKind: 'codex-thread',
+    promptInjection: 'stdin-prefix',
+    systemPrompt: BRIDGE_SYSTEM_PROMPT,
+    supportsNativeHistory: false,
+    callback: {
+      marker: '__bridge_cb',
+      legacyMarkers: [],
+    },
+    permissions: {
+      maxAccess,
+    },
+  };
+}
+
+export function traeCapability(profile: Pick<ProfileConfig, 'permissions'>): AgentCapability {
+  const maxAccess = profile.permissions.maxAccess;
+  return {
+    agentId: 'trae',
+    sessionKind: 'trae-thread',
     promptInjection: 'stdin-prefix',
     systemPrompt: BRIDGE_SYSTEM_PROMPT,
     supportsNativeHistory: false,

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,3 +1,4 @@
 export type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from './types';
 export { ClaudeAdapter } from './claude/adapter';
 export { CodexAdapter } from './codex/adapter';
+export { TraeAdapter } from './trae/adapter';

--- a/src/agent/lark-channel-env.ts
+++ b/src/agent/lark-channel-env.ts
@@ -11,6 +11,10 @@ export interface LarkChannelEnvContext {
 export function buildLarkChannelEnv(context?: LarkChannelEnvContext): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = {
     LARK_CHANNEL: '1',
+    LARK_CHANNEL_PROFILE: undefined,
+    LARK_CHANNEL_HOME: undefined,
+    LARK_CHANNEL_CONFIG: undefined,
+    LARKSUITE_CLI_CONFIG_DIR: undefined,
   };
   const profile = nonEmpty(context?.profile);
   if (profile) env.LARK_CHANNEL_PROFILE = profile;

--- a/src/agent/preflight.ts
+++ b/src/agent/preflight.ts
@@ -1,6 +1,6 @@
 import { spawnProcess } from '../platform/spawn';
 
-export type LocalAgentId = 'claude' | 'codex';
+export type LocalAgentId = 'claude' | 'codex' | 'trae';
 
 export type AgentPreflightErrorCode =
   | 'agent-binary-not-found'
@@ -279,7 +279,7 @@ export function isAgentPreflightDiagnostic(input: unknown): input is AgentPrefli
   return (
     typeof raw.code === 'string' &&
     raw.code.startsWith('agent-') &&
-    (raw.agentId === 'claude' || raw.agentId === 'codex') &&
+    (raw.agentId === 'claude' || raw.agentId === 'codex' || raw.agentId === 'trae') &&
     typeof raw.agentName === 'string' &&
     typeof raw.command === 'string'
   );

--- a/src/agent/trae/adapter.ts
+++ b/src/agent/trae/adapter.ts
@@ -1,0 +1,473 @@
+import { createInterface } from 'node:readline';
+import type { Readable, Writable } from 'node:stream';
+import { join } from 'node:path';
+import type { SandboxMode } from '../../config/profile-schema';
+import { log } from '../../core/logger';
+import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
+import { SpawnFailed } from '../../runtime/errors';
+import { prefixBridgeSystemPrompt } from '../bridge-system-prompt';
+import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel-env';
+import { checkAgentAvailability, type AgentAvailability } from '../preflight';
+import type {
+  AgentAdapter,
+  AgentBotIdentity,
+  AgentEvent,
+  AgentRun,
+  AgentRunOptions,
+} from '../types';
+import { CodexJsonlTranslator, type CodexFinishReason } from '../codex/jsonl';
+import { buildTraeArgs } from './argv';
+
+export interface TraeAdapterOptions {
+  binary: string;
+  profileStateDir: string;
+  traeHome?: string;
+  inheritTraeHome?: boolean;
+  ignoreUserConfig?: boolean;
+  ignoreRules?: boolean;
+  sandbox?: SandboxMode;
+  stopGraceMs?: number;
+  larkChannel?: LarkChannelEnvContext;
+}
+
+type TraeChild = SpawnedProcessByStdio<Writable, Readable, Readable>;
+
+export class TraeAdapter implements AgentAdapter {
+  readonly id = 'trae';
+  readonly displayName = 'Trae CLI';
+
+  private readonly binary: string;
+  private readonly profileStateDir: string;
+  private readonly traeHome: string | undefined;
+  private readonly inheritTraeHome: boolean;
+  private readonly ignoreUserConfig: boolean;
+  private readonly ignoreRules: boolean;
+  private readonly sandbox: SandboxMode;
+  private readonly defaultStopGraceMs: number;
+  private readonly larkChannel: LarkChannelEnvContext | undefined;
+  private botIdentity: AgentBotIdentity | undefined;
+
+  constructor(opts: TraeAdapterOptions) {
+    this.binary = opts.binary;
+    this.profileStateDir = opts.profileStateDir;
+    this.traeHome = opts.traeHome;
+    this.inheritTraeHome = opts.inheritTraeHome !== false;
+    this.ignoreUserConfig = opts.ignoreUserConfig === true;
+    this.ignoreRules = opts.ignoreRules !== false;
+    this.sandbox = opts.sandbox ?? 'danger-full-access';
+    this.defaultStopGraceMs = opts.stopGraceMs ?? 5000;
+    this.larkChannel = opts.larkChannel;
+  }
+
+  setBotIdentity(identity: AgentBotIdentity): void {
+    this.botIdentity = identity;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return (await this.checkAvailability()).ok;
+  }
+
+  async checkAvailability(): Promise<AgentAvailability> {
+    return checkAgentAvailability({
+      agentId: 'trae',
+      agentName: 'Trae CLI',
+      command: this.binary,
+      binaryPath: this.binary,
+    });
+  }
+
+  async prepareRun(): Promise<void> {
+    const availability = await this.checkAvailability();
+    if (!availability.ok) {
+      throw new SpawnFailed(
+        'trae binary check failed',
+        availability.error,
+        availability.diagnostic.code,
+        availability.diagnostic,
+      );
+    }
+  }
+
+  run(opts: AgentRunOptions): AgentRun {
+    if (!opts.cwd) {
+      throw new Error('cwd is required for TraeAdapter.run');
+    }
+
+    const args = buildTraeArgs({
+      cwd: opts.cwd,
+      sandbox: opts.sandbox ?? this.sandbox,
+      threadId: opts.threadId,
+      images: opts.images,
+      ignoreUserConfig: this.ignoreUserConfig,
+      ignoreRules: this.ignoreRules,
+    });
+    const envOverrides: NodeJS.ProcessEnv = buildLarkChannelEnv(this.larkChannel);
+    if (this.traeHome) {
+      envOverrides.TRAE_HOME = this.traeHome;
+    } else if (!this.inheritTraeHome) {
+      envOverrides.TRAE_HOME = join(this.profileStateDir, 'trae-home');
+    }
+    const child = spawnProcess(this.binary, args, {
+      cwd: opts.cwd,
+      env: mergeProcessEnv(process.env, envOverrides),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }) as TraeChild;
+
+    log.info('agent', 'spawn', {
+      pid: child.pid ?? null,
+      cwd: opts.cwd,
+      hasThread: Boolean(opts.threadId),
+      promptChars: opts.prompt.length,
+      images: opts.images?.length ?? 0,
+    });
+
+    const stderrChunks: Buffer[] = [];
+    let runtimeError: Error | null = null;
+    let stderrBuffer = '';
+    const threadCapture = new ThreadIdCapture(opts.threadId);
+    const handleStderrLine = (line: string): void => {
+      if (line.trim()) log.warn('agent', 'stderr', { line });
+      threadCapture.ingest(line);
+      if (isWindowsCommandNotFoundLine(line)) {
+        runtimeError = new Error(`failed to spawn trae: ${line.trim()}`);
+        child.stdout.destroy();
+        child.kill();
+      }
+    };
+    const flushStderrBuffer = (): void => {
+      if (!stderrBuffer) return;
+      const line = stderrBuffer;
+      stderrBuffer = '';
+      handleStderrLine(line);
+    };
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+      stderrBuffer += chunk.toString('utf8');
+      let nl = stderrBuffer.indexOf('\n');
+      while (nl !== -1) {
+        const line = stderrBuffer.slice(0, nl);
+        stderrBuffer = stderrBuffer.slice(nl + 1);
+        handleStderrLine(line);
+        nl = stderrBuffer.indexOf('\n');
+      }
+    });
+    child.stderr.once('end', flushStderrBuffer);
+
+    let stopReason: CodexFinishReason | undefined;
+    child.on('error', (err) => {
+      runtimeError = err;
+    });
+    child.on('exit', (code, signal) => {
+      log.info('agent', 'exit', { pid: child.pid ?? null, code, signal });
+      flushStderrBuffer();
+      threadCapture.close();
+    });
+    child.stdin.on('error', (err) => {
+      log.warn('agent', 'stdin-error', { message: err.message });
+    });
+    child.stdin.end(prefixBridgeSystemPrompt(opts.prompt, this.botIdentity), 'utf8');
+
+    const stopGraceMs = opts.stopGraceMs ?? this.defaultStopGraceMs;
+
+    return {
+      runId: opts.runId,
+      events: createEventStream(
+        child,
+        stderrChunks,
+        () => runtimeError,
+        () => stopReason,
+        threadCapture,
+        opts.runId,
+        opts.cwd,
+      ),
+      async stop() {
+        if (child.exitCode !== null || child.signalCode !== null) return;
+        stopReason = 'interrupted';
+        log.info('agent', 'stop-sigterm', { pid: child.pid ?? null, graceMs: stopGraceMs });
+        child.kill('SIGTERM');
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            if (child.exitCode === null && child.signalCode === null) {
+              log.warn('agent', 'stop-sigkill', {
+                pid: child.pid ?? null,
+                graceMs: stopGraceMs,
+                reason: 'grace-period-expired',
+              });
+              child.kill('SIGKILL');
+            }
+            resolve();
+          }, stopGraceMs);
+          child.once('exit', () => {
+            clearTimeout(timer);
+            resolve();
+          });
+        });
+      },
+      waitForExit(timeoutMs: number): Promise<boolean> {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          return Promise.resolve(true);
+        }
+        return new Promise<boolean>((resolve) => {
+          const onExit = (): void => {
+            clearTimeout(timer);
+            resolve(true);
+          };
+          const timer = setTimeout(() => {
+            child.removeListener('exit', onExit);
+            resolve(false);
+          }, timeoutMs);
+          child.once('exit', onExit);
+        });
+      },
+    };
+  }
+}
+
+async function* createEventStream(
+  child: TraeChild,
+  stderrChunks: Buffer[],
+  getError: () => Error | null,
+  getStopReason: () => CodexFinishReason | undefined,
+  threadCapture: ThreadIdCapture,
+  runId: string,
+  cwd: string,
+): AsyncGenerator<AgentEvent> {
+  const translator = new CodexJsonlTranslator();
+  let emittedThreadId = false;
+  let missingThreadIdWarned = false;
+  const filterTranslatedEvents = (events: AgentEvent[]): AgentEvent[] => {
+    const filtered: AgentEvent[] = [];
+    for (const event of events) {
+      if (event.type === 'system' && event.threadId) {
+        if (emittedThreadId) continue;
+        emittedThreadId = true;
+      }
+      filtered.push(event);
+    }
+    return filtered;
+  };
+  const translateCapturedThread = (): AgentEvent[] => {
+    const threadId = threadCapture.current();
+    if (!threadId || emittedThreadId) return [];
+    return filterTranslatedEvents(translator.translate({ type: 'thread.started', thread_id: threadId }));
+  };
+  const warnMissingThreadId = (): void => {
+    if (threadCapture.current() || missingThreadIdWarned) return;
+    missingThreadIdWarned = true;
+    log.warn('agent', 'trae-session-id-missing', {
+      runId,
+      cwd,
+      hint: 'Trae resume will be unavailable for this run',
+    });
+  };
+  if (!child.pid) {
+    const err = getError();
+    yield {
+      type: 'error',
+      message: err ? `failed to spawn trae: ${err.message}` : 'spawn returned no pid',
+      terminationReason: 'failed',
+    };
+    return;
+  }
+
+  const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  let sawStdout = false;
+  let waitedForThreadBeforeStdout = false;
+  let silentExitTimer: ReturnType<typeof setTimeout> | undefined;
+  const closeSilentStdout = (): void => {
+    silentExitTimer = setTimeout(() => {
+      if (!sawStdout && !child.stdout.readableEnded) child.stdout.destroy();
+    }, 50);
+  };
+  if (child.exitCode !== null || child.signalCode !== null) {
+    closeSilentStdout();
+  } else {
+    child.once('exit', closeSilentStdout);
+  }
+  try {
+    for await (const line of rl) {
+      sawStdout = true;
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      const isTraeSessionEvent = isTraeSessionStartedEvent(parsed);
+      threadCapture.ingestJsonl(parsed);
+      if (!emittedThreadId && !threadCapture.current() && !waitedForThreadBeforeStdout) {
+        waitedForThreadBeforeStdout = true;
+        await threadCapture.wait(2000);
+      }
+      yield* translateCapturedThread();
+      if (isTraeSessionEvent) continue;
+      if (isTerminalJsonlEvent(parsed) && !emittedThreadId) {
+        await threadCapture.wait(2000);
+        yield* translateCapturedThread();
+      }
+      yield* filterTranslatedEvents(translator.translate(parsed));
+    }
+  } finally {
+    if (silentExitTimer) clearTimeout(silentExitTimer);
+    child.removeListener('exit', closeSilentStdout);
+    rl.close();
+  }
+
+  const earlyRuntimeError = getError();
+  if (earlyRuntimeError && child.exitCode === null && child.signalCode === null) {
+    yield terminalError(`trae runtime error: ${earlyRuntimeError.message}`);
+    return;
+  }
+
+  const exitCode = await waitForExitCode(child);
+  const stopReason = getStopReason();
+  yield* translateCapturedThread();
+  if (stopReason) {
+    warnMissingThreadId();
+    yield* filterTranslatedEvents(translator.finish(stopReason));
+    return;
+  }
+  const runtimeError = getError();
+  if (exitCode !== 0 && exitCode !== null) {
+    if (!translator.terminalEmitted()) {
+      const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+      const detail = stderr ? `: ${stderr.slice(0, 500)}` : '';
+      yield terminalError(`trae exited with code ${exitCode}${detail}`);
+    }
+    return;
+  }
+  if (runtimeError) {
+    yield terminalError(`trae runtime error: ${runtimeError.message}`);
+    return;
+  }
+  warnMissingThreadId();
+  if (!translator.terminalEmitted()) {
+    yield* filterTranslatedEvents(translator.finish());
+  }
+}
+
+function waitForExitCode(child: TraeChild): Promise<number | null> {
+  return new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve(child.exitCode);
+      return;
+    }
+    child.once('exit', (code) => resolve(code));
+  });
+}
+
+function terminalError(message: string): AgentEvent {
+  return {
+    type: 'error',
+    message,
+    terminationReason: 'failed',
+  };
+}
+
+class ThreadIdCapture {
+  private threadId: string | undefined;
+  private closed = false;
+  private readonly waiters: Array<(value: string | undefined) => void> = [];
+
+  constructor(initialThreadId?: string) {
+    this.threadId = initialThreadId;
+  }
+
+  ingest(line: string): void {
+    if (this.threadId) return;
+    const threadId = extractTraeThreadId(line);
+    if (!threadId) return;
+    this.threadId = threadId;
+    this.resolve();
+  }
+
+  ingestJsonl(value: unknown): void {
+    if (this.threadId) return;
+    const threadId = extractTraeThreadIdFromRecord(value);
+    if (!threadId) return;
+    this.threadId = threadId;
+    this.resolve();
+  }
+
+  current(): string | undefined {
+    return this.threadId;
+  }
+
+  close(): void {
+    this.closed = true;
+    this.resolve();
+  }
+
+  wait(timeoutMs: number): Promise<string | undefined> {
+    if (this.threadId || this.closed) return Promise.resolve(this.threadId);
+    return new Promise((resolve) => {
+      let waiter: ((value: string | undefined) => void) | undefined;
+      const timer = setTimeout(() => {
+        if (waiter) this.removeWaiter(waiter);
+        resolve(this.threadId);
+      }, timeoutMs);
+      waiter = (value: string | undefined): void => {
+        clearTimeout(timer);
+        resolve(value);
+      };
+      this.waiters.push(waiter);
+    });
+  }
+
+  private resolve(): void {
+    const waiters = this.waiters.splice(0);
+    for (const waiter of waiters) waiter(this.threadId);
+  }
+
+  private removeWaiter(waiter: (value: string | undefined) => void): void {
+    const index = this.waiters.indexOf(waiter);
+    if (index >= 0) this.waiters.splice(index, 1);
+  }
+}
+
+function extractTraeThreadId(line: string): string | undefined {
+  const textMatch =
+    /\b(?:thread_id|threadId|session_id|sessionId)\s*[=:]\s*["']?([0-9a-fA-F-]{20,})\b/.exec(
+      line,
+    );
+  if (isTraeThreadId(textMatch?.[1])) return textMatch[1];
+
+  const jsonStart = line.indexOf('{');
+  if (jsonStart < 0) return undefined;
+  try {
+    return extractTraeThreadIdFromRecord(JSON.parse(line.slice(jsonStart)));
+  } catch {
+    return undefined;
+  }
+}
+
+function extractTraeThreadIdFromRecord(value: unknown): string | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const raw = value as Record<string, unknown>;
+  const id = raw.thread_id ?? raw.threadId ?? raw.session_id ?? raw.sessionId;
+  return isTraeThreadId(id) ? id : undefined;
+}
+
+function isTraeThreadId(value: unknown): value is string {
+  return typeof value === 'string' && /^[0-9a-fA-F-]{20,}$/.test(value);
+}
+
+function isTraeSessionStartedEvent(value: unknown): boolean {
+  return typeof value === 'object' &&
+    value !== null &&
+    (value as { type?: unknown }).type === 'session.started';
+}
+
+function isWindowsCommandNotFoundLine(line: string): boolean {
+  return process.platform === 'win32' &&
+    /is not recognized as an internal or external command|operable program or batch file/i.test(line);
+}
+
+function isTerminalJsonlEvent(value: unknown): boolean {
+  return typeof value === 'object' &&
+    value !== null &&
+    ((value as { type?: unknown }).type === 'turn.completed' ||
+      (value as { type?: unknown }).type === 'turn.failed');
+}

--- a/src/agent/trae/argv.ts
+++ b/src/agent/trae/argv.ts
@@ -1,0 +1,71 @@
+import type { SandboxMode } from '../../config/profile-schema';
+
+export type TraePermissionMode = 'plan' | 'default' | 'bypass_permissions';
+
+export interface BuildTraeArgsInput {
+  cwd: string;
+  sandbox: SandboxMode;
+  threadId?: string;
+  images?: readonly string[];
+  ignoreUserConfig?: boolean;
+  ignoreRules?: boolean;
+}
+
+export function buildTraeArgs(input: BuildTraeArgsInput): string[] {
+  if (
+    input.sandbox !== 'read-only' &&
+    input.sandbox !== 'workspace-write' &&
+    input.sandbox !== 'danger-full-access'
+  ) {
+    throw new Error(`unsafe sandbox mode: ${input.sandbox}`);
+  }
+
+  const commonFlags = [
+    '-c',
+    'approval_policy="never"',
+    '-c',
+    'shell_environment_policy.inherit="all"',
+    ...(input.ignoreUserConfig === true ? ['--ignore-user-config'] : []),
+    ...(input.ignoreRules === false ? [] : ['--ignore-rules']),
+    '--skip-git-repo-check',
+  ];
+  const imageFlags = (input.images ?? []).flatMap((path) => ['--image', path]);
+
+  if (input.threadId) {
+    return [
+      'exec',
+      'resume',
+      '--json',
+      '--permission-mode',
+      sandboxToTraePermissionMode(input.sandbox),
+      ...commonFlags,
+      ...imageFlags,
+      input.threadId,
+      '-',
+    ];
+  }
+
+  return [
+    'exec',
+    '--json',
+    '--permission-mode',
+    sandboxToTraePermissionMode(input.sandbox),
+    ...commonFlags,
+    '-C',
+    input.cwd,
+    ...imageFlags,
+    ...(imageFlags.length > 0 ? ['--'] : []),
+    '-',
+  ];
+}
+
+export function sandboxToTraePermissionMode(sandbox: SandboxMode): TraePermissionMode {
+  switch (sandbox) {
+    case 'read-only':
+      return 'plan';
+    case 'workspace-write':
+      return 'default';
+    case 'danger-full-access':
+      return 'bypass_permissions';
+  }
+}

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -5,7 +5,7 @@ import type {
 } from '@larksuite/channel';
 import { createLarkChannel } from '@larksuite/channel';
 import { dirname, join } from 'node:path';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { claudeCapability, codexCapability, traeCapability } from '../agent/capability';
 import {
   buildAgentPrompt,
   type BridgePromptInteractiveCard,
@@ -694,7 +694,9 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
   const capability =
     controls.profileConfig.agentKind === 'codex'
       ? codexCapability(controls.profileConfig)
-      : claudeCapability(controls.profileConfig);
+      : controls.profileConfig.agentKind === 'trae'
+        ? traeCapability(controls.profileConfig)
+        : claudeCapability(controls.profileConfig);
   const flow = await startRunFlow({
     scopeId: scope,
     scope: scopeContext,

--- a/src/bot/comments.ts
+++ b/src/bot/comments.ts
@@ -2,7 +2,8 @@ import { randomUUID } from 'node:crypto';
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { CommentEvent, LarkChannel } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { claudeCapability, codexCapability, traeCapability } from '../agent/capability';
+import type { AgentCapabilityId } from '../agent/capability';
 import type { AgentAdapter, AgentEvent } from '../agent/types';
 import { getAgentStopGraceMs } from '../config/schema';
 import type { Controls } from '../commands';
@@ -184,13 +185,31 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
     const capability =
       controls.profileConfig.agentKind === 'codex'
         ? codexCapability(controls.profileConfig)
-        : claudeCapability(controls.profileConfig);
+        : controls.profileConfig.agentKind === 'trae'
+          ? traeCapability(controls.profileConfig)
+          : claudeCapability(controls.profileConfig);
     const runTimeoutMs = commentRunTimeoutMs(sessions, runScopeId);
     const threadTimeoutMs = commentRunTimeoutMs(sessions, commentThreadScopeId);
     const commentTimeoutMs = runTimeoutMs !== undefined ? runTimeoutMs : threadTimeoutMs;
     if (typeof commentTimeoutMs === 'number') {
       log.info('comment', 'timeout-watchdog', { commentScopeId: runScopeId, timeoutMs: commentTimeoutMs });
     }
+    const activeAgentHome =
+      controls.profileConfig.agentKind === 'codex'
+        ? {
+            ...(controls.profileConfig.codex?.codexHome ? { agentHome: controls.profileConfig.codex.codexHome } : {}),
+            ...(controls.profileConfig.codex?.inheritCodexHome !== undefined
+              ? { inheritAgentHome: controls.profileConfig.codex.inheritCodexHome }
+              : {}),
+          }
+        : controls.profileConfig.agentKind === 'trae'
+          ? {
+              ...(controls.profileConfig.trae?.traeHome ? { agentHome: controls.profileConfig.trae.traeHome } : {}),
+              ...(controls.profileConfig.trae?.inheritTraeHome !== undefined
+                ? { inheritAgentHome: controls.profileConfig.trae.inheritTraeHome }
+                : {}),
+            }
+          : {};
     const policy = evaluateRunPolicy({
       scope: {
         source: 'comment',
@@ -206,8 +225,7 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
       capability,
       profileConfig: controls.profileConfig,
       now: Date.now(),
-      codexHome: controls.profileConfig.codex?.codexHome,
-      inheritCodexHome: controls.profileConfig.codex?.inheritCodexHome,
+      ...activeAgentHome,
       ...(typeof commentTimeoutMs === 'number' ? { ttlMs: commentTimeoutMs } : {}),
     });
     if (!policy.ok) {
@@ -242,7 +260,9 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
           ? sessions.resumeFor(docSessionScopeId, cwdRealpath) ??
             sessions.resumeFor(legacyDocSessionScopeId, cwdRealpath)
           : undefined;
-      const threadId = capability.agentId === 'codex' ? catalogEntry?.threadId : undefined;
+      const threadId = capability.agentId === 'codex' || capability.agentId === 'trae'
+        ? catalogEntry?.threadId
+        : undefined;
       log.info('comment', 'session', {
         commentScopeId: runScopeId,
         sessionScopeId: agentSessionScopeId,
@@ -377,7 +397,7 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
       }
 
       let reply = stripMarkdown(answer.trim());
-      if (errorMsg) reply = `⚠️ Claude 报错：${errorMsg}`;
+      if (errorMsg) reply = `⚠️ ${commentAgentLabel(capability.agentId)} 报错：${errorMsg}`;
       if (!reply) reply = '（无回复内容）';
       if (reply.length > REPLY_MAX_CHARS) reply = `${reply.slice(0, REPLY_MAX_CHARS - 1)}…`;
 
@@ -395,6 +415,17 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
     if (reactionAdded && ctx.targetReplyId) {
       await channel.comments.removeReaction(target, ctx.targetReplyId);
     }
+  }
+}
+
+function commentAgentLabel(agentId: AgentCapabilityId): string {
+  switch (agentId) {
+    case 'claude':
+      return 'Claude';
+    case 'codex':
+      return 'Codex CLI';
+    case 'trae':
+      return 'Trae CLI';
   }
 }
 

--- a/src/bot/run-flow.ts
+++ b/src/bot/run-flow.ts
@@ -88,6 +88,23 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
     };
   }
 
+  const activeAgentHome =
+    input.profileConfig.agentKind === 'codex'
+      ? {
+          ...(input.profileConfig.codex?.codexHome ? { agentHome: input.profileConfig.codex.codexHome } : {}),
+          ...(input.profileConfig.codex?.inheritCodexHome !== undefined
+            ? { inheritAgentHome: input.profileConfig.codex.inheritCodexHome }
+            : {}),
+        }
+      : input.profileConfig.agentKind === 'trae'
+        ? {
+            ...(input.profileConfig.trae?.traeHome ? { agentHome: input.profileConfig.trae.traeHome } : {}),
+            ...(input.profileConfig.trae?.inheritTraeHome !== undefined
+              ? { inheritAgentHome: input.profileConfig.trae.inheritTraeHome }
+              : {}),
+          }
+        : {};
+
   const policy = evaluateRunPolicy({
     scope: input.scope,
     attachments: input.attachments,
@@ -98,8 +115,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
     capability: input.capability,
     profileConfig: input.profileConfig,
     now: input.now,
-    codexHome: input.profileConfig.codex?.codexHome,
-    inheritCodexHome: input.profileConfig.codex?.inheritCodexHome,
+    ...activeAgentHome,
   });
   if (!policy.ok) {
     return {
@@ -122,7 +138,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
     if (catalogEntry?.agentId === 'claude') {
       sessionId = catalogEntry.sessionId;
       resumeFrom = sessionId;
-    } else if (catalogEntry?.agentId === 'codex') {
+    } else if (catalogEntry && (catalogEntry.agentId === 'codex' || catalogEntry.agentId === 'trae')) {
       threadId = catalogEntry.threadId;
       resumeFrom = threadId;
     }
@@ -144,7 +160,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
       sessionId,
       threadId,
       images:
-        input.capability.agentId === 'codex'
+        input.capability.agentId === 'codex' || input.capability.agentId === 'trae'
           ? policy.attachments
               .filter((attachment) => attachment.kind === 'image' && attachment.decision === 'accepted')
               .map((attachment) => attachment.path)
@@ -195,10 +211,10 @@ export function recordRunSessionEvent(input: RecordRunSessionEventInput): void {
     });
     return;
   }
-  if (input.capability.agentId === 'codex' && input.event.threadId) {
+  if ((input.capability.agentId === 'codex' || input.capability.agentId === 'trae') && input.event.threadId) {
     input.sessionCatalog?.upsertActive({
       scopeId: input.scopeId,
-      agentId: 'codex',
+      agentId: input.capability.agentId,
       cwdRealpath: input.policy.cwdRealpath,
       policyFingerprint: input.policy.policyFingerprint,
       threadId: input.event.threadId,

--- a/src/bot/session-catalog-identity.ts
+++ b/src/bot/session-catalog-identity.ts
@@ -1,5 +1,5 @@
 import type { NormalizedMessage } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { claudeCapability, codexCapability, traeCapability } from '../agent/capability';
 import type { Controls } from '../commands';
 import type { AccessDecision } from '../policy/access';
 import { evaluateRunPolicy } from '../policy/run-policy';
@@ -24,7 +24,29 @@ export async function commandSessionCatalogIdentity(input: {
   const capability =
     input.controls.profileConfig.agentKind === 'codex'
       ? codexCapability(input.controls.profileConfig)
-      : claudeCapability(input.controls.profileConfig);
+      : input.controls.profileConfig.agentKind === 'trae'
+        ? traeCapability(input.controls.profileConfig)
+        : claudeCapability(input.controls.profileConfig);
+  const activeAgentHome =
+    input.controls.profileConfig.agentKind === 'codex'
+      ? {
+          ...(input.controls.profileConfig.codex?.codexHome
+            ? { agentHome: input.controls.profileConfig.codex.codexHome }
+            : {}),
+          ...(input.controls.profileConfig.codex?.inheritCodexHome !== undefined
+            ? { inheritAgentHome: input.controls.profileConfig.codex.inheritCodexHome }
+            : {}),
+        }
+      : input.controls.profileConfig.agentKind === 'trae'
+        ? {
+            ...(input.controls.profileConfig.trae?.traeHome
+              ? { agentHome: input.controls.profileConfig.trae.traeHome }
+              : {}),
+            ...(input.controls.profileConfig.trae?.inheritTraeHome !== undefined
+              ? { inheritAgentHome: input.controls.profileConfig.trae.inheritTraeHome }
+              : {}),
+          }
+        : {};
   const policy = evaluateRunPolicy({
     scope: {
       source: 'im',
@@ -40,8 +62,7 @@ export async function commandSessionCatalogIdentity(input: {
     capability,
     profileConfig: input.controls.profileConfig,
     now: Date.now(),
-    codexHome: input.controls.profileConfig.codex?.codexHome,
-    inheritCodexHome: input.controls.profileConfig.codex?.inheritCodexHome,
+    ...activeAgentHome,
   });
   if (!policy.ok) return undefined;
   return {

--- a/src/cli/agent-detection.ts
+++ b/src/cli/agent-detection.ts
@@ -2,7 +2,7 @@ import { constants } from 'node:fs';
 import { access } from 'node:fs/promises';
 import { delimiter, extname, isAbsolute, join } from 'node:path';
 
-export type AgentKind = 'claude' | 'codex';
+export type AgentKind = 'claude' | 'codex' | 'trae';
 
 export interface DetectedAgent {
   kind: AgentKind;
@@ -48,6 +48,7 @@ export async function detectInstalledAgents(): Promise<DetectedAgent[]> {
   const candidates: Array<{ kind: AgentKind; command: string }> = [
     { kind: 'claude', command: process.env.LARK_CHANNEL_CLAUDE_BIN ?? 'claude' },
     { kind: 'codex', command: process.env.LARK_CHANNEL_CODEX_BIN ?? 'codex' },
+    { kind: 'trae', command: process.env.LARK_CHANNEL_TRAE_BIN ?? 'traecli' },
   ];
   const detected: DetectedAgent[] = [];
   for (const candidate of candidates) {

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, readdir, rename, rm, stat } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { createBootstrapCodexConfig } from '../profile-bootstrap';
+import { createBootstrapCodexConfig, createBootstrapTraeConfig } from '../profile-bootstrap';
 import { promptLine } from '../prompt';
 import { stopProcessEntry } from './ps';
 import {
@@ -12,7 +12,7 @@ import {
 } from '../../config/migrate-v2';
 import { legacyPaths, paths } from '../../config/paths';
 import { agentKindFromString } from '../../config/profile-store';
-import type { RootConfig } from '../../config/profile-schema';
+import type { AgentKind, RootConfig } from '../../config/profile-schema';
 import { isComplete, type AppCredentials, type AppConfig } from '../../config/schema';
 import { saveConfig } from '../../config/store';
 
@@ -43,7 +43,7 @@ export async function runMigrate(opts: MigrateOptions): Promise<void> {
   const configPath = opts.config ?? paths.configFile;
   await migrateLegacyPaths();
   await migrateConfigShape(configPath);
-  const agentKind = agentKindFromString(opts.agent) ?? (opts.profile === 'codex' ? 'codex' : undefined);
+  const agentKind = agentKindFromString(opts.agent) ?? agentKindFromProfileName(opts.profile);
   const needsV2Migration = await hasLegacyProfileConfig(configPath);
   const result = await migrateProfileV2WithActiveBridgePrompt({
     rootDir: dirname(configPath),
@@ -53,6 +53,9 @@ export async function runMigrate(opts: MigrateOptions): Promise<void> {
     ...(needsV2Migration && agentKind === 'codex'
       ? { codex: await createBootstrapCodexConfig(undefined) }
       : {}),
+    ...(needsV2Migration && agentKind === 'trae'
+      ? { trae: await createBootstrapTraeConfig(undefined) }
+      : {}),
   }, opts);
   if (!result) return;
   if (result.migrated) {
@@ -60,6 +63,11 @@ export async function runMigrate(opts: MigrateOptions): Promise<void> {
   } else {
     console.log(`✓ profile 目录结构已是最新：${result.profile}`);
   }
+}
+
+function agentKindFromProfileName(profile: string | undefined): AgentKind | undefined {
+  if (profile === 'claude' || profile === 'codex' || profile === 'trae') return profile;
+  return undefined;
 }
 
 async function migrateProfileV2WithActiveBridgePrompt(

--- a/src/cli/commands/secrets.ts
+++ b/src/cli/commands/secrets.ts
@@ -135,10 +135,13 @@ export async function resolveSecretAcrossProfiles(
   profile: string | undefined = process.env.LARK_CHANNEL_PROFILE,
 ): Promise<string | undefined> {
   if (profile) {
-    const appPaths = resolveAppPaths({ rootDir, profile });
-    const ids = await listSecretIds(appPaths);
-    if (!ids.includes(id)) return undefined;
-    return getSecret(id, appPaths);
+    const root = await loadRootConfig(resolveAppPaths({ rootDir }).configFile);
+    if (!root || root.profiles[profile]) {
+      const appPaths = resolveAppPaths({ rootDir, profile });
+      const ids = await listSecretIds(appPaths);
+      if (!ids.includes(id)) return undefined;
+      return getSecret(id, appPaths);
+    }
   }
 
   const profiles = await listSecretProfiles(rootDir);

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -469,7 +469,12 @@ async function maybeResolveProfileRuntime(
 }
 
 function agentDisplay(agentKind: ProcessEntry['agentKind']): { id: string; displayName: string } {
-  return agentKind === 'codex'
-    ? { id: 'codex', displayName: 'Codex CLI' }
-    : { id: 'claude', displayName: 'Claude Code' };
+  switch (agentKind) {
+    case 'codex':
+      return { id: 'codex', displayName: 'Codex CLI' };
+    case 'trae':
+      return { id: 'trae', displayName: 'Trae CLI' };
+    case 'claude':
+      return { id: 'claude', displayName: 'Claude Code' };
+  }
 }

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -4,6 +4,7 @@ import { createInterface } from 'node:readline';
 import pkg from '../../../package.json';
 import { ClaudeAdapter } from '../../agent/claude/adapter';
 import { CodexAdapter } from '../../agent/codex/adapter';
+import { TraeAdapter } from '../../agent/trae/adapter';
 import {
   AgentPreflightError,
   formatAgentPreflightDiagnostic,
@@ -374,9 +375,9 @@ async function checkRuntimeAgentAvailability(agent: AgentAdapter): Promise<Agent
   if (ok) return { ok: true };
   const diagnostic = {
     code: 'agent-binary-not-found' as const,
-    agentId: agent.id === 'codex' ? 'codex' as const : 'claude' as const,
+    agentId: agent.id === 'codex' ? 'codex' as const : agent.id === 'trae' ? 'trae' as const : 'claude' as const,
     agentName: agent.displayName,
-    command: agent.id === 'codex' ? 'codex' : 'claude',
+    command: agent.id === 'codex' ? 'codex' : agent.id === 'trae' ? 'traecli' : 'claude',
   };
   return {
     ok: false,
@@ -430,6 +431,22 @@ export function createRuntimeAgent(
       inheritCodexHome: codex.inheritCodexHome === true,
       ignoreUserConfig: codex.ignoreUserConfig === true,
       ignoreRules: codex.ignoreRules !== false,
+      sandbox: profileConfig.sandbox.defaultMode,
+      larkChannel,
+    });
+  }
+  if (profileConfig.agentKind === 'trae') {
+    const trae = profileConfig.trae;
+    if (!trae?.binaryPath) {
+      throw new Error('trae profile requires trae.binaryPath');
+    }
+    return new TraeAdapter({
+      binary: trae.binaryPath,
+      profileStateDir: appPaths.profileDir,
+      ...(trae.traeHome ? { traeHome: trae.traeHome } : {}),
+      inheritTraeHome: trae.inheritTraeHome === true,
+      ignoreUserConfig: trae.ignoreUserConfig === true,
+      ignoreRules: trae.ignoreRules !== false,
       sandbox: profileConfig.sandbox.defaultMode,
       larkChannel,
     });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -39,7 +39,7 @@ program
   .description('Run the bridge in the foreground (was `start` in older versions)')
   .option('-c, --config <path>', 'path to config file')
   .option('--profile <name>', 'profile name to run')
-  .option('--agent <kind>', 'agent kind for a new profile (claude or codex)')
+  .option('--agent <kind>', 'agent kind for a new profile (claude, codex, or trae)')
   .option('--workspace <path>', 'initial working directory for first-run profile bootstrap')
   .option('--app-id <id>', 'use an existing Lark/Feishu app instead of QR app creation')
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')
@@ -63,7 +63,7 @@ program
   .description('Migrate legacy bridge config/state into the current profile layout')
   .option('-c, --config <path>', 'path to config file')
   .option('--profile <name>', 'target profile name for legacy v1 config migration')
-  .option('--agent <kind>', 'agent kind for legacy v1 profile migration (claude or codex)')
+  .option('--agent <kind>', 'agent kind for legacy v1 profile migration (claude, codex, or trae)')
   .action(async (opts: { config?: string; profile?: string; agent?: string }) => {
     await runMigrate(opts);
   });
@@ -82,7 +82,7 @@ profile
 profile
   .command('create <name>')
   .description('Create a profile from QR registration or existing app credentials')
-  .option('--agent <kind>', 'agent kind (claude or codex)')
+  .option('--agent <kind>', 'agent kind (claude, codex, or trae)')
   .option('--workspace <path>', 'initial working directory for this profile')
   .option('--app-id <id>', 'use an existing Lark/Feishu app instead of QR app creation')
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')
@@ -154,7 +154,7 @@ program
   .command('start')
   .description('Install (if needed) and start the bridge as an OS-managed daemon')
   .option('--profile <name>', 'profile name (defaults to active profile)')
-  .option('--agent <kind>', 'agent kind for first-run profile bootstrap (claude or codex)')
+  .option('--agent <kind>', 'agent kind for first-run profile bootstrap (claude, codex, or trae)')
   .option('--workspace <path>', 'initial working directory for first-run profile bootstrap')
   .option('--app-id <id>', 'use an existing Lark/Feishu app instead of QR app creation')
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')

--- a/src/cli/profile-bootstrap.ts
+++ b/src/cli/profile-bootstrap.ts
@@ -1,7 +1,11 @@
 import { mkdir, realpath } from 'node:fs/promises';
 import { join } from 'node:path';
 import { AgentPreflightError } from '../agent/preflight';
-import { createDefaultProfileConfig, type AgentKind, type ProfileConfig } from '../config/profile-schema';
+import {
+  createDefaultProfileConfig,
+  type AgentKind,
+  type ProfileConfig,
+} from '../config/profile-schema';
 import type { AppConfig } from '../config/schema';
 import { resolveWorkingDirectory } from '../policy/workspace';
 import { resolveExecutablePath } from './agent-detection';
@@ -14,6 +18,7 @@ export interface BootstrapProfileInput {
   workspace?: string;
   defaultWorkspace?: string;
   codexBinaryPath?: string;
+  traeBinaryPath?: string;
   profileDir?: string;
 }
 
@@ -29,12 +34,17 @@ export async function createBootstrapProfileConfig(
     input.agentKind === 'codex'
       ? await createBootstrapCodexConfig(input.codexBinaryPath)
       : undefined;
+  const trae =
+    input.agentKind === 'trae'
+      ? await createBootstrapTraeConfig(input.traeBinaryPath)
+      : undefined;
   const profile = createDefaultProfileConfig({
     agentKind: input.agentKind,
     accounts: input.accounts,
     preferences: input.preferences,
     secrets: input.secrets,
     ...(codex ? { codex } : {}),
+    ...(trae ? { trae } : {}),
   });
   if (workspace) {
     profile.workspaces = {
@@ -44,6 +54,9 @@ export async function createBootstrapProfileConfig(
   }
   if (input.profileDir && profile.codex?.inheritCodexHome === false) {
     await mkdir(join(input.profileDir, 'codex-home'), { recursive: true });
+  }
+  if (input.profileDir && profile.trae?.inheritTraeHome === false) {
+    await mkdir(join(input.profileDir, 'trae-home'), { recursive: true });
   }
   return profile;
 }
@@ -70,6 +83,25 @@ export async function createBootstrapCodexConfig(binaryPath: string | undefined)
       code: codexBootstrapBinaryErrorCode(errno),
       agentId: 'codex',
       agentName: 'Codex CLI',
+      command,
+      binaryPath: command,
+      errno,
+    });
+  }
+  return { binaryPath: resolvedBinary };
+}
+
+export async function createBootstrapTraeConfig(binaryPath: string | undefined) {
+  const command = binaryPath ?? process.env.LARK_CHANNEL_TRAE_BIN ?? 'traecli';
+  let resolvedBinary: string;
+  try {
+    resolvedBinary = await resolveExecutablePath(command);
+  } catch (err) {
+    const errno = (err as NodeJS.ErrnoException).code;
+    throw new AgentPreflightError({
+      code: codexBootstrapBinaryErrorCode(errno),
+      agentId: 'trae',
+      agentName: 'Trae CLI',
       command,
       binaryPath: command,
       errno,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute } from 'node:path';
 import type { LarkChannel, NormalizedMessage } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { claudeCapability, codexCapability, traeCapability } from '../agent/capability';
 import type { AgentAdapter } from '../agent/types';
 import type { ActiveRuns } from '../bot/active-runs';
 import {
@@ -66,7 +66,7 @@ import {
   type CodexThreadHistoryEntry,
   type ListCodexThreadHistoryOptions,
 } from '../session/codex-history';
-import type { SessionCatalog, SessionCatalogIdentity } from '../session/catalog';
+import type { CatalogAgentId, SessionCatalog, SessionCatalogIdentity } from '../session/catalog';
 import { isAlive, readAndPrune, resolveTarget } from '../runtime/registry';
 import type { SessionStore } from '../session/store';
 import { resolveWorkingDirectory } from '../policy/workspace';
@@ -144,7 +144,7 @@ type Handler = (args: string, ctx: CommandContext) => Promise<void>;
 
 interface ResumeCandidate {
   scopeId: string;
-  agentId: 'claude' | 'codex';
+  agentId: CatalogAgentId;
   cwdRealpath: string;
   policyFingerprint: string;
   sessionId?: string;
@@ -537,13 +537,17 @@ async function handleResume(args: string, ctx: CommandContext): Promise<void> {
     return;
   }
 
-  if (ctx.controls.profileConfig.agentKind === 'codex') {
+  const agentKind = ctx.controls.profileConfig.agentKind;
+  if (agentKind === 'codex' || agentKind === 'trae') {
     const identity = ctx.sessionCatalogIdentity;
     const entry =
       ctx.sessionCatalog && identity
         ? ctx.sessionCatalog.activeFor(identity)
         : undefined;
-    const history = identity ? await listCodexResumeHistory(ctx, cwd, limit) : [];
+    const history = identity && agentKind === 'codex'
+      ? await listCodexResumeHistory(ctx, cwd, limit)
+      : [];
+    const agentLabel = threadAgentLabel(agentKind);
     if (history.length > 0 && identity) {
       const entries = history.map((thread) => {
         const nonce = issueResumeCandidate(identity, { threadId: thread.threadId });
@@ -551,7 +555,7 @@ async function handleResume(args: string, ctx: CommandContext): Promise<void> {
           sessionId: nonce,
           preview: thread.name || thread.preview,
           relTime: formatRelTime(thread.updatedAtMs),
-          detail: `Codex · ${thread.source}`,
+          detail: `${agentLabel} · ${thread.source}`,
           current: thread.threadId === entry?.threadId,
         };
       });
@@ -563,7 +567,7 @@ async function handleResume(args: string, ctx: CommandContext): Promise<void> {
       const nonce = issueResumeCandidate(identity, { threadId: entry.threadId });
       await reply(
         ctx,
-        `当前 Codex thread 可恢复。\n使用 \`/resume use ${nonce}\` 恢复（10 分钟内有效）。`,
+        `当前 ${agentLabel} thread 可恢复。\n使用 \`/resume use ${nonce}\` 恢复（10 分钟内有效）。`,
       );
       return;
     }
@@ -595,10 +599,10 @@ async function applyResume(sessionId: string, ctx: CommandContext): Promise<void
     const resolved = consumeResumeCandidate(sessionId, ctx.sessionCatalogIdentity);
     if (resolved) {
       ctx.activeRuns.interrupt(ctx.scope);
-      if (ctx.sessionCatalogIdentity.agentId === 'codex') {
+      if (ctx.sessionCatalogIdentity.agentId === 'codex' || ctx.sessionCatalogIdentity.agentId === 'trae') {
         ctx.sessionCatalog.upsertActive({
           scopeId: ctx.sessionCatalogIdentity.scopeId,
-          agentId: 'codex',
+          agentId: ctx.sessionCatalogIdentity.agentId,
           cwdRealpath: ctx.sessionCatalogIdentity.cwdRealpath,
           policyFingerprint: ctx.sessionCatalogIdentity.policyFingerprint,
           threadId: resolved.threadId!,
@@ -616,7 +620,7 @@ async function applyResume(sessionId: string, ctx: CommandContext): Promise<void
       await reply(ctx, RESUME_APPLIED_REPLY);
       return;
     }
-    if (ctx.sessionCatalogIdentity.agentId === 'codex') {
+    if (ctx.sessionCatalogIdentity.agentId === 'codex' || ctx.sessionCatalogIdentity.agentId === 'trae') {
       await reply(ctx, '当前上下文不可恢复这个会话，请先用 `/resume` 重新生成恢复候选。');
       return;
     }
@@ -633,8 +637,9 @@ async function applyResume(sessionId: string, ctx: CommandContext): Promise<void
     return;
   }
 
-  if (ctx.controls.profileConfig.agentKind === 'codex') {
-    await reply(ctx, '当前上下文没有可恢复的 Codex thread，请先在当前工作区完成一次运行。');
+  const agentKind = ctx.controls.profileConfig.agentKind;
+  if (agentKind === 'codex' || agentKind === 'trae') {
+    await reply(ctx, `当前上下文没有可恢复的 ${threadAgentLabel(agentKind)} thread，请先在当前工作区完成一次运行。`);
     return;
   }
 
@@ -680,11 +685,22 @@ function consumeResumeCandidate(
     candidate.cwdRealpath !== identity.cwdRealpath ||
     candidate.policyFingerprint !== identity.policyFingerprint ||
     (identity.agentId === 'claude' && !candidate.sessionId) ||
-    (identity.agentId === 'codex' && !candidate.threadId)
+    ((identity.agentId === 'codex' || identity.agentId === 'trae') && !candidate.threadId)
   ) {
     return undefined;
   }
   return candidate;
+}
+
+function threadAgentLabel(agentKind: ProfileConfig['agentKind']): string {
+  switch (agentKind) {
+    case 'codex':
+      return 'Codex';
+    case 'trae':
+      return 'Trae CLI';
+    case 'claude':
+      return 'Claude';
+  }
 }
 
 function pruneResumeCandidates(now = Date.now()): void {
@@ -792,17 +808,18 @@ async function larkCliStatus(ctx: CommandContext): Promise<'app' | 'user-ready' 
 async function handleStatus(_args: string, ctx: CommandContext): Promise<void> {
   const cwd = effectiveWorkspaceCwd(ctx);
   const sess = ctx.sessions.getRaw(ctx.scope);
-  const isCodex = ctx.controls.profileConfig.agentKind === 'codex';
+  const isThreadAgent =
+    ctx.controls.profileConfig.agentKind === 'codex' || ctx.controls.profileConfig.agentKind === 'trae';
   const catalogEntry =
-    isCodex && ctx.sessionCatalog && ctx.sessionCatalogIdentity
+    isThreadAgent && ctx.sessionCatalog && ctx.sessionCatalogIdentity
       ? ctx.sessionCatalog.activeFor(ctx.sessionCatalogIdentity)
       : undefined;
   const card = statusCard({
     profileName: ctx.controls.profile,
     cwd,
-    sessionId: isCodex ? catalogEntry?.threadId : sess?.sessionId,
-    emptySessionText: isCodex ? '(未建立)' : undefined,
-    sessionStale: !isCodex && Boolean(cwd && sess && sess.cwd !== cwd),
+    sessionId: isThreadAgent ? catalogEntry?.threadId : sess?.sessionId,
+    emptySessionText: isThreadAgent ? '(未建立)' : undefined,
+    sessionStale: !isThreadAgent && Boolean(cwd && sess && sess.cwd !== cwd),
     agentName: ctx.agent.displayName,
     runtimeAccess: runtimeAccessStatus(ctx.controls.profileConfig),
     larkCliStatus: await larkCliStatus(ctx),
@@ -1109,7 +1126,9 @@ async function handleDoctor(args: string, ctx: CommandContext): Promise<void> {
   const capability =
     ctx.controls.profileConfig.agentKind === 'codex'
       ? codexCapability(ctx.controls.profileConfig)
-      : claudeCapability(ctx.controls.profileConfig);
+      : ctx.controls.profileConfig.agentKind === 'trae'
+        ? traeCapability(ctx.controls.profileConfig)
+        : claudeCapability(ctx.controls.profileConfig);
   const policy = evaluateRunPolicy({
     scope: {
       source: 'im',

--- a/src/config/migrate-v2.ts
+++ b/src/config/migrate-v2.ts
@@ -14,6 +14,7 @@ import {
   type AgentKind,
   type CodexConfig,
   type RootConfig,
+  type TraeConfig,
 } from './profile-schema';
 import { markPermissionDefaultsMigration, saveRootConfig } from './profile-store';
 import type { AppConfig } from './schema';
@@ -27,6 +28,7 @@ export interface MigrateV2Options {
   workspace?: string;
   agentKind?: AgentKind;
   codex?: CodexConfig;
+  trae?: TraeConfig;
 }
 
 export interface MigrateV2Result {
@@ -129,6 +131,7 @@ export async function migrateV1ToV2(opts: MigrateV2Options = {}): Promise<Migrat
       requireMentionInGroup: legacy.preferences?.requireMentionInGroup,
     },
     ...(agentKind === 'codex' && opts.codex ? { codex: opts.codex } : {}),
+    ...(agentKind === 'trae' && opts.trae ? { trae: opts.trae } : {}),
   });
   if (legacyDefaultWorkspace) {
     profileConfig.workspaces = {
@@ -200,7 +203,9 @@ function activeProcessFromRegistryEntry(entry: RegistryEntry): ActiveBridgeMigra
   if (typeof entry.appId === 'string') active.appId = entry.appId;
   if (typeof entry.tenant === 'string') active.tenant = entry.tenant;
   if (typeof entry.profileName === 'string') active.profileName = entry.profileName;
-  if (entry.agentKind === 'claude' || entry.agentKind === 'codex') active.agentKind = entry.agentKind;
+  if (entry.agentKind === 'claude' || entry.agentKind === 'codex' || entry.agentKind === 'trae') {
+    active.agentKind = entry.agentKind;
+  }
   if (typeof entry.configPath === 'string') active.configPath = entry.configPath;
   if (typeof entry.startedAt === 'string') active.startedAt = entry.startedAt;
   if (typeof entry.version === 'string') active.version = entry.version;

--- a/src/config/profile-schema.ts
+++ b/src/config/profile-schema.ts
@@ -13,7 +13,7 @@ import {
   type PermissionSource,
 } from './permissions';
 
-export type AgentKind = 'claude' | 'codex';
+export type AgentKind = 'claude' | 'codex' | 'trae';
 export type SandboxMode = CodexSandboxMode;
 export type { AccessMode, PermissionConfig, PermissionSource };
 
@@ -40,6 +40,19 @@ export interface CodexConfig {
   mode?: number;
   codexHome?: string;
   inheritCodexHome?: boolean;
+  ignoreUserConfig?: boolean;
+  ignoreRules?: boolean;
+}
+
+export interface TraeConfig {
+  binaryPath: string;
+  realpath?: string;
+  version?: string;
+  sha256?: string;
+  owner?: number;
+  mode?: number;
+  traeHome?: string;
+  inheritTraeHome?: boolean;
   ignoreUserConfig?: boolean;
   ignoreRules?: boolean;
 }
@@ -90,6 +103,7 @@ export interface ProfileConfig {
   permissions: PermissionConfig;
   permissionSource?: PermissionSource;
   codex?: CodexConfig;
+  trae?: TraeConfig;
   attachments: AttachmentConfig;
   comments: CommentConfig;
   larkCli: LarkCliConfig;
@@ -116,6 +130,7 @@ export interface CreateDefaultProfileConfigInput {
   sandbox?: Partial<SandboxConfig>;
   permissions?: Partial<PermissionConfig>;
   codex?: CodexConfig;
+  trae?: TraeConfig;
   secrets?: SecretsConfig;
 }
 
@@ -150,6 +165,7 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
     sandbox?: Partial<SandboxConfig>;
     permissions?: Partial<PermissionConfig>;
     codex?: CodexConfig & { flags?: unknown };
+    trae?: TraeConfig & { flags?: unknown };
     attachments?: Partial<AttachmentConfig>;
     comments?: unknown;
     larkCli?: unknown;
@@ -158,12 +174,15 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
   if (raw.schemaVersion !== 2) {
     throw new Error('profile schemaVersion must be 2');
   }
-  if (raw.agentKind !== 'claude' && raw.agentKind !== 'codex') {
-    throw new Error('agentKind must be claude or codex');
+  if (raw.agentKind !== 'claude' && raw.agentKind !== 'codex' && raw.agentKind !== 'trae') {
+    throw new Error('agentKind must be claude, codex, or trae');
   }
   const accounts = normalizeAccounts(raw.accounts);
   if (raw.agentKind === 'codex' && !raw.codex) {
     throw new Error('codex profile requires codex configuration');
+  }
+  if (raw.agentKind === 'trae' && !raw.trae) {
+    throw new Error('trae profile requires trae configuration');
   }
 
   const preferences = normalizePreferences(raw.preferences);
@@ -192,6 +211,7 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
     permissions,
     permissionSource,
     ...(raw.codex ? { codex: normalizeCodex(raw.codex) } : {}),
+    ...(raw.trae ? { trae: normalizeTrae(raw.trae) } : {}),
     attachments: {
       maxCount: numberOr(raw.attachments?.maxCount, 10),
       maxBytes: numberOr(raw.attachments?.maxBytes, 100 * 1024 * 1024),
@@ -283,6 +303,22 @@ function normalizeCodex(input: CodexConfig & { flags?: unknown }): CodexConfig {
     ignoreRules: input.ignoreRules !== false,
   };
   return codex;
+}
+
+function normalizeTrae(input: TraeConfig & { flags?: unknown }): TraeConfig {
+  const trae: TraeConfig = {
+    binaryPath: input.binaryPath,
+    ...(typeof input.realpath === 'string' ? { realpath: input.realpath } : {}),
+    ...(typeof input.version === 'string' ? { version: input.version } : {}),
+    ...(typeof input.sha256 === 'string' ? { sha256: input.sha256 } : {}),
+    ...(typeof input.owner === 'number' ? { owner: input.owner } : {}),
+    ...(typeof input.mode === 'number' ? { mode: input.mode } : {}),
+    ...(typeof input.traeHome === 'string' ? { traeHome: input.traeHome } : {}),
+    inheritTraeHome: input.inheritTraeHome !== false,
+    ignoreUserConfig: input.ignoreUserConfig === true,
+    ignoreRules: input.ignoreRules !== false,
+  };
+  return trae;
 }
 
 function normalizeComments(_input: unknown): CommentConfig {

--- a/src/config/profile-store.ts
+++ b/src/config/profile-store.ts
@@ -56,6 +56,7 @@ type StoredProfileConfig = Pick<
   | 'workspaces'
   | 'permissions'
   | 'codex'
+  | 'trae'
   | 'attachments'
   | 'comments'
   | 'larkCli'
@@ -93,6 +94,7 @@ function serializeProfileConfig(profile: ProfileConfig): StoredProfileConfig {
     workspaces: profile.workspaces,
     permissions: profile.permissions,
     ...(profile.codex ? { codex: profile.codex } : {}),
+    ...(profile.trae ? { trae: profile.trae } : {}),
     attachments: profile.attachments,
     comments: {},
     larkCli: profile.larkCli,
@@ -292,7 +294,7 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 export function agentKindFromString(value: string | undefined): AgentKind | undefined {
-  if (value === 'claude' || value === 'codex') return value;
+  if (value === 'claude' || value === 'codex' || value === 'trae') return value;
   if (value === undefined) return undefined;
   throw new Error(`unsupported agent: ${value}`);
 }

--- a/src/policy/run-policy.ts
+++ b/src/policy/run-policy.ts
@@ -52,6 +52,8 @@ export interface RunPolicyInput {
   capability: AgentCapability;
   profileConfig: ProfileConfig;
   now: number;
+  agentHome?: string;
+  inheritAgentHome?: boolean;
   codexHome?: string;
   inheritCodexHome?: boolean;
   ttlMs?: number;
@@ -144,8 +146,8 @@ export function evaluateRunPolicy(input: RunPolicyInput): RunPolicyResult {
       accessPolicyDigest: accessDigest,
       resourceScopeDigest: resourceDigest,
       attachmentPolicyShapeDigest: attachmentDigest,
-      codexHome: input.codexHome,
-      inheritCodexHome: input.inheritCodexHome ?? false,
+      codexHome: input.agentHome ?? input.codexHome,
+      inheritCodexHome: input.inheritAgentHome ?? input.inheritCodexHome ?? false,
     }),
   };
 }

--- a/src/runtime/locks.ts
+++ b/src/runtime/locks.ts
@@ -178,7 +178,7 @@ function isRuntimeLockMeta(value: unknown): value is RuntimeLockMeta {
     (meta.kind === 'profile' || meta.kind === 'app') &&
     typeof meta.target === 'string' &&
     typeof meta.profile === 'string' &&
-    (meta.agentKind === 'claude' || meta.agentKind === 'codex') &&
+    (meta.agentKind === 'claude' || meta.agentKind === 'codex' || meta.agentKind === 'trae') &&
     typeof meta.pid === 'number' &&
     typeof meta.startedAt === 'string' &&
     (meta.appId === undefined || typeof meta.appId === 'string')

--- a/src/runtime/profile-runtime.ts
+++ b/src/runtime/profile-runtime.ts
@@ -6,6 +6,7 @@ import { detectInstalledAgents, type DetectedAgent } from '../cli/agent-detectio
 import {
   createBootstrapCodexConfig,
   createBootstrapProfileConfig,
+  createBootstrapTraeConfig,
   resolveBootstrapWorkspace,
 } from '../cli/profile-bootstrap';
 import { promptPassword } from '../cli/prompt';
@@ -36,7 +37,7 @@ import {
   type RootConfig,
 } from '../config/profile-schema';
 import { permissionsToLegacySandbox } from '../config/permissions';
-import type { AppConfig, SecretInput, TenantBrand } from '../config/schema';
+import type { AppConfig, SecretInput, SecretsConfig, TenantBrand } from '../config/schema';
 import { isComplete, isSecretRef, secretKeyForApp } from '../config/schema';
 import { resolveAppSecret } from '../config/secret-resolver';
 import {
@@ -90,6 +91,9 @@ export function createRuntimeProfileConfig(
     ...(input.agentKind === 'codex'
       ? { codex: input.codex ?? { binaryPath: process.env.LARK_CHANNEL_CODEX_BIN ?? 'codex' } }
       : {}),
+    ...(input.agentKind === 'trae'
+      ? { trae: input.trae ?? { binaryPath: process.env.LARK_CHANNEL_TRAE_BIN ?? 'traecli' } }
+      : {}),
   });
 }
 
@@ -108,7 +112,7 @@ export async function resolveProfileRuntime(
   if (!profile && opts.allowBootstrap) {
     const detected = await detectInstalledAgents();
     if (detected.length === 0) {
-      throw new Error('no supported local agent found; install claude or codex first');
+      throw new Error('no supported local agent found; install claude, codex, or traecli first');
     }
     if (detected.length > 1) {
       const selected = await selectDetectedAgent(detected, opts.selectAgent);
@@ -137,6 +141,9 @@ export async function resolveProfileRuntime(
     ...(migrationAgent ? { agentKind: migrationAgent } : {}),
     ...(needsMigration && migrationAgent === 'codex'
       ? { codex: await createBootstrapCodexConfig(undefined) }
+      : {}),
+    ...(needsMigration && migrationAgent === 'trae'
+      ? { trae: await createBootstrapTraeConfig(undefined) }
       : {}),
   }, opts.handleActiveBridgeMigrationConflict);
 
@@ -189,7 +196,7 @@ export async function resolveProfileRuntime(
     assertBootstrapAppMatchesExistingConfig(opts, profile, existing);
     const cfg = await maybeMigratePlaintextSecret(existing, configPath, appPaths);
     const profileConfig = createRuntimeProfileConfig({
-      agentKind: requestedAgent ?? 'claude',
+      agentKind: resolveBootstrapAgent(requestedAgent, profile) ?? 'claude',
       accounts: cfg.accounts,
       preferences: cfg.preferences,
       secrets: cfg.secrets,
@@ -246,11 +253,10 @@ async function bootstrapProfileIntoExistingRoot(args: {
     defaultWorkspace: appPaths.defaultWorkspaceDir,
     profileDir: appPaths.profileDir,
   });
+  const nextSecrets = mergeSecretsConfig(rootConfig.secrets, encrypted.secrets);
   const nextRoot: RootConfig = {
     ...rootConfig,
-    ...(rootConfig.secrets ?? encrypted.secrets
-      ? { secrets: rootConfig.secrets ?? encrypted.secrets }
-      : {}),
+    ...(nextSecrets ? { secrets: nextSecrets } : {}),
     profiles: {
       ...rootConfig.profiles,
       [profile]: {
@@ -395,7 +401,12 @@ function resolveBootstrapAgent(
   requestedAgent: AgentKind | undefined,
   profile: string | undefined,
 ): AgentKind | undefined {
-  return requestedAgent ?? (profile === 'codex' ? 'codex' : undefined);
+  return requestedAgent ?? agentKindFromProfileName(profile);
+}
+
+function agentKindFromProfileName(profile: string | undefined): AgentKind | undefined {
+  if (profile === 'claude' || profile === 'codex' || profile === 'trae') return profile;
+  return undefined;
 }
 
 async function hasLegacyConfig(configPath: string): Promise<boolean> {
@@ -568,7 +579,7 @@ function formatAmbiguousAgentSelectionError(
 ): string {
   const lines = detected.map((agent) => `  - ${agent.kind}: ${agent.binaryPath}`);
   return [
-    '检测到多个本地 agent，请使用 --agent <claude|codex> 指定要初始化哪一个。',
+    '检测到多个本地 agent，请使用 --agent <claude|codex|trae> 指定要初始化哪一个。',
     '已检测到：',
     ...lines,
   ].join('\n');
@@ -613,7 +624,30 @@ class UserCancelledError extends Error {
 }
 
 function displayAgentKind(kind: AgentKind): string {
-  return kind === 'claude' ? 'Claude Code' : 'Codex CLI';
+  switch (kind) {
+    case 'claude':
+      return 'Claude Code';
+    case 'codex':
+      return 'Codex CLI';
+    case 'trae':
+      return 'Trae CLI';
+  }
+}
+
+function mergeSecretsConfig(
+  existing: SecretsConfig | undefined,
+  incoming: SecretsConfig | undefined,
+): SecretsConfig | undefined {
+  if (!existing) return incoming;
+  if (!incoming) return existing;
+  return {
+    ...(existing.defaults ?? incoming.defaults
+      ? { defaults: { ...incoming.defaults, ...existing.defaults } }
+      : {}),
+    ...(existing.providers ?? incoming.providers
+      ? { providers: { ...incoming.providers, ...existing.providers } }
+      : {}),
+  };
 }
 
 async function maybeMigrateRootPlaintextSecret(

--- a/src/runtime/registry.ts
+++ b/src/runtime/registry.ts
@@ -64,7 +64,7 @@ function isValidEntry(e: unknown): e is ProcessEntry {
     typeof x.appId === 'string' &&
     (x.tenant === 'feishu' || x.tenant === 'lark') &&
     typeof x.profileName === 'string' &&
-    (x.agentKind === 'claude' || x.agentKind === 'codex') &&
+    (x.agentKind === 'claude' || x.agentKind === 'codex' || x.agentKind === 'trae') &&
     typeof x.configPath === 'string' &&
     typeof x.startedAt === 'string' &&
     typeof x.version === 'string'

--- a/src/session/catalog.ts
+++ b/src/session/catalog.ts
@@ -214,7 +214,7 @@ function normalizeEntry(input: unknown): SessionCatalogEntry | undefined {
   if (
     typeof raw.key !== 'string' ||
     typeof raw.scopeId !== 'string' ||
-    (raw.agentId !== 'claude' && raw.agentId !== 'codex') ||
+    (raw.agentId !== 'claude' && raw.agentId !== 'codex' && raw.agentId !== 'trae') ||
     typeof raw.cwdRealpath !== 'string' ||
     typeof raw.policyFingerprint !== 'string' ||
     (raw.status !== 'active' && raw.status !== 'archived') ||
@@ -259,6 +259,6 @@ function assertAgentIdentity(input: UpsertSessionCatalogInput): void {
     return;
   }
   if (!input.threadId || input.sessionId) {
-    throw new Error('Codex catalog entries require threadId and must not include sessionId');
+    throw new Error('Thread-based catalog entries require threadId and must not include sessionId');
   }
 }

--- a/tests/integration/cli/first-run-profile.test.ts
+++ b/tests/integration/cli/first-run-profile.test.ts
@@ -90,6 +90,31 @@ describe('first-run profile bootstrap', () => {
     });
   });
 
+  it('creates a Trae profile with a default workspace and inherited user Trae home', async () => {
+    const root = await makeRoot();
+    const workspace = join(root, 'workspace');
+    const profileDir = join(root, 'profiles', 'trae-dev');
+    await mkdir(workspace, { recursive: true });
+    const trae = await writeVersionExecutable(root, 'traecli', 'traecli 0.200.13');
+
+    const profile = await createBootstrapProfileConfig({
+      agentKind: 'trae',
+      accounts: { app: { id: 'cli_trae', secret: '${APP_SECRET}', tenant: 'feishu' } },
+      workspace,
+      traeBinaryPath: trae,
+      profileDir,
+    });
+
+    const workspaceRealpath = await realpath(workspace);
+    expect(profile.agentKind).toBe('trae');
+    expect(profile.workspaces).toEqual({ default: workspaceRealpath });
+    expect(profile.trae).toMatchObject({
+      binaryPath: trae,
+      inheritTraeHome: true,
+    });
+    await expect(stat(join(profileDir, 'trae-home'))).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
   it('fails closed when a requested bootstrap workspace is not a directory', async () => {
     const root = await makeRoot();
     const file = join(root, 'not-a-dir');
@@ -135,9 +160,11 @@ describe('first-run profile bootstrap', () => {
     const oldPath = process.env.PATH;
     const oldClaude = process.env.LARK_CHANNEL_CLAUDE_BIN;
     const oldCodex = process.env.LARK_CHANNEL_CODEX_BIN;
+    const oldTrae = process.env.LARK_CHANNEL_TRAE_BIN;
     process.env.PATH = root;
     process.env.LARK_CHANNEL_CLAUDE_BIN = 'missing-claude';
     process.env.LARK_CHANNEL_CODEX_BIN = process.platform === 'win32' ? codex : 'codex';
+    process.env.LARK_CHANNEL_TRAE_BIN = 'missing-trae';
     try {
       await expect(detectInstalledAgents()).resolves.toEqual([
         { kind: 'codex', binaryPath: codex },
@@ -153,6 +180,11 @@ describe('first-run profile bootstrap', () => {
         delete process.env.LARK_CHANNEL_CODEX_BIN;
       } else {
         process.env.LARK_CHANNEL_CODEX_BIN = oldCodex;
+      }
+      if (oldTrae === undefined) {
+        delete process.env.LARK_CHANNEL_TRAE_BIN;
+      } else {
+        process.env.LARK_CHANNEL_TRAE_BIN = oldTrae;
       }
     }
   });

--- a/tests/integration/comments/comment-run-flow.test.ts
+++ b/tests/integration/comments/comment-run-flow.test.ts
@@ -116,6 +116,23 @@ describe('comment run flow', () => {
     expect(h.inThreadReplies).toEqual(['first final', 'second final']);
   });
 
+
+  it('uses the Trae agent label when a Trae comment run fails', async () => {
+    const h = await createHarness({
+      agentKind: 'trae',
+      agentEventRuns: [
+        [
+          { type: 'system', threadId: 'thread-one' },
+          { type: 'error', message: 'trae failed', terminationReason: 'failed' },
+        ],
+      ],
+    });
+
+    await handleCommentMention(h.deps(event({ commentId: 'comment-1', replyId: 'reply-1' })));
+
+    expect(h.inThreadReplies).toEqual(['⚠️ Trae CLI 报错：trae failed']);
+  });
+
   it('does not reuse an existing Codex thread while another document comment run is active', async () => {
     const h = await createBlockingHarness({
       agentKind: 'codex',
@@ -191,7 +208,7 @@ describe('comment run flow', () => {
 });
 
 async function createHarness(options: {
-  agentKind?: 'claude' | 'codex';
+  agentKind?: 'claude' | 'codex' | 'trae';
   agentTexts?: string[];
   agentEventRuns?: AgentEvent[][];
   sessionIds?: string[];
@@ -221,7 +238,7 @@ async function createHarness(options: {
     agentTexts.map((text, index) => [
       {
         type: 'system',
-        ...(agentKind === 'codex'
+        ...(agentKind === 'codex' || agentKind === 'trae'
           ? { threadId: threadIds[index] ?? `thread-${index}` }
           : { sessionId: sessionIds[index] ?? `session-${index}` }),
         cwd: tmp.workspace,
@@ -229,7 +246,7 @@ async function createHarness(options: {
       { type: 'text', delta: text },
       {
         type: 'done',
-        ...(agentKind === 'codex'
+        ...(agentKind === 'codex' || agentKind === 'trae'
           ? { threadId: threadIds[index] ?? `thread-${index}` }
           : { sessionId: sessionIds[index] ?? `session-${index}` }),
         terminationReason: 'normal',
@@ -518,13 +535,14 @@ async function waitFor(predicate: () => boolean): Promise<void> {
   throw new Error('timed out waiting for condition');
 }
 
-function profile(defaultWorkspace: string, agentKind: 'claude' | 'codex' = 'claude'): ProfileConfig {
+function profile(defaultWorkspace: string, agentKind: 'claude' | 'codex' | 'trae' = 'claude'): ProfileConfig {
   const config = createDefaultProfileConfig({
     agentKind,
     accounts: { app: { id: 'cli_test', secret: '${APP_SECRET}', tenant: 'feishu' } },
     access: { allowedUsers: ['ou-user'] },
     sandbox: { defaultMode: 'read-only', maxMode: 'workspace-write' },
     ...(agentKind === 'codex' ? { codex: { binaryPath: 'codex' } } : {}),
+    ...(agentKind === 'trae' ? { trae: { binaryPath: 'traecli' } } : {}),
   });
   config.workspaces.default = defaultWorkspace;
   return config;

--- a/tests/process/trae-adapter.test.ts
+++ b/tests/process/trae-adapter.test.ts
@@ -1,0 +1,345 @@
+import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TraeAdapter } from '../../src/agent/trae/adapter.js';
+import { buildTraeArgs } from '../../src/agent/trae/argv.js';
+import type { AgentEvent } from '../../src/agent/types.js';
+
+interface FakeBinary {
+  path: string;
+  dir: string;
+  recordPath: string;
+}
+
+describe('TraeAdapter process contract', () => {
+  const cleanup: string[] = [];
+  const oldTraeHome = process.env.TRAE_HOME;
+
+  afterEach(async () => {
+    if (oldTraeHome === undefined) {
+      delete process.env.TRAE_HOME;
+    } else {
+      process.env.TRAE_HOME = oldTraeHome;
+    }
+    await Promise.all(
+      cleanup.splice(0).map((dir) =>
+        rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 25 }),
+      ),
+    );
+  });
+
+  it('spawns Trae JSON runs with prompt on stdin and captures thread id from stderr', async () => {
+    process.env.TRAE_HOME = '/outer/trae-home';
+    const fake = await createFakeTrae({
+      lines: [
+        { type: 'item.completed', item: { id: 'msg-1', type: 'agent_message', text: 'hello' } },
+        { type: 'turn.completed' },
+      ],
+      stderr: 'INFO session_loop{thread_id=019ef7db-d096-7490-8aba-d7eeafd4f2da}: start\n',
+    });
+    cleanup.push(fake.dir);
+    const cwd = await realpath(fake.dir);
+
+    const run = new TraeAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+      sandbox: 'read-only',
+    }).run({
+      runId: 'run-trae',
+      prompt: 'hello from lark',
+      cwd,
+    });
+
+    expect(await collect(run.events)).toEqual([
+      { type: 'system', threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da' },
+      { type: 'text', delta: 'hello' },
+      {
+        type: 'done',
+        threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da',
+        terminationReason: 'normal',
+      },
+    ]);
+    const record = await readRecord(fake.recordPath);
+
+    expect(await realpath(record.cwd)).toBe(cwd);
+    expect(record.argv).toEqual(buildTraeArgs({ cwd, sandbox: 'read-only' }));
+    expect(record.stdin).toContain('lark-channel-bridge 运行约定');
+    expect(record.stdin).toContain('hello from lark');
+    expect(record.env).toMatchObject({
+      LARK_CHANNEL: '1',
+      TRAE_HOME: '/outer/trae-home',
+    });
+  });
+
+  it('passes resume thread, image flags, and profile-local Trae home', async () => {
+    const fake = await createFakeTrae({
+      lines: [{ type: 'turn.completed' }],
+    });
+    cleanup.push(fake.dir);
+    const cwd = await realpath(fake.dir);
+    const image = join(fake.dir, 'image.png');
+
+    const run = new TraeAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+      inheritTraeHome: false,
+      sandbox: 'workspace-write',
+    }).run({
+      runId: 'run-resume',
+      prompt: 'continue',
+      cwd,
+      threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da',
+      images: [image],
+    });
+
+    expect(await collect(run.events)).toEqual([
+      { type: 'system', threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da' },
+      {
+        type: 'done',
+        threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da',
+        terminationReason: 'normal',
+      },
+    ]);
+    const record = await readRecord(fake.recordPath);
+    expect(record.argv).toEqual(
+      buildTraeArgs({
+        cwd,
+        sandbox: 'workspace-write',
+        threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da',
+        images: [image],
+      }),
+    );
+    expect(record.env.TRAE_HOME).toBe(join(fake.dir, 'trae-home'));
+  });
+
+  it('captures thread id from stderr even when the line is not newline-terminated', async () => {
+    const fake = await createFakeTrae({
+      lines: [{ type: 'turn.completed' }],
+      stderr: 'INFO session_loop{thread_id=019ef7db-d096-7490-8aba-d7eeafd4f2da}: start',
+    });
+    cleanup.push(fake.dir);
+    const cwd = await realpath(fake.dir);
+
+    const run = new TraeAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+      sandbox: 'read-only',
+    }).run({
+      runId: 'run-trae',
+      prompt: 'hello from lark',
+      cwd,
+    });
+
+    expect(await collect(run.events)).toEqual([
+      { type: 'system', threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da' },
+      {
+        type: 'done',
+        threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da',
+        terminationReason: 'normal',
+      },
+    ]);
+  });
+
+  it('captures thread id that arrives after the initial stderr wait', async () => {
+    const fake = await createFakeTrae({
+      lines: [{ type: 'turn.completed' }],
+      stderr: 'INFO session_loop{thread_id=019ef7db-d096-7490-8aba-d7eeafd4f2da}: start\n',
+      stderrDelayMs: 2100,
+    });
+    cleanup.push(fake.dir);
+    const cwd = await realpath(fake.dir);
+
+    const run = new TraeAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+      sandbox: 'read-only',
+    }).run({
+      runId: 'run-trae-late-thread',
+      prompt: 'hello from lark',
+      cwd,
+    });
+
+    expect(await collect(run.events)).toEqual([
+      { type: 'system', threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da' },
+      {
+        type: 'done',
+        threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da',
+        terminationReason: 'normal',
+      },
+    ]);
+  });
+
+  it('captures thread id from alternate stderr keys and json logs', async () => {
+    const cases = [
+      'INFO threadId=019ef7db-d096-7490-8aba-d7eeafd4f2da',
+      '{"type":"session.started","session_id":"019ef7db-d096-7490-8aba-d7eeafd4f2da"}',
+    ];
+
+    for (const stderr of cases) {
+      const fake = await createFakeTrae({
+        lines: [{ type: 'turn.completed' }],
+        stderr,
+      });
+      cleanup.push(fake.dir);
+      const cwd = await realpath(fake.dir);
+
+      const run = new TraeAdapter({
+        binary: fake.path,
+        profileStateDir: fake.dir,
+        sandbox: 'read-only',
+      }).run({
+        runId: 'run-trae-alt-thread',
+        prompt: 'hello from lark',
+        cwd,
+      });
+
+      expect(await collect(run.events)).toEqual([
+        { type: 'system', threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da' },
+        {
+          type: 'done',
+          threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da',
+          terminationReason: 'normal',
+        },
+      ]);
+    }
+  });
+
+  it('captures thread id from Trae stdout session events', async () => {
+    const fake = await createFakeTrae({
+      lines: [
+        { type: 'session.started', session_id: '019ef7db-d096-7490-8aba-d7eeafd4f2da' },
+        { type: 'turn.completed' },
+      ],
+    });
+    cleanup.push(fake.dir);
+    const cwd = await realpath(fake.dir);
+
+    const run = new TraeAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+      sandbox: 'read-only',
+    }).run({
+      runId: 'run-trae-session-started',
+      prompt: 'hello from lark',
+      cwd,
+    });
+
+    expect(await collect(run.events)).toEqual([
+      { type: 'system', threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da' },
+      {
+        type: 'done',
+        threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da',
+        terminationReason: 'normal',
+      },
+    ]);
+  });
+
+  it('warns when a fresh Trae run finishes without a resumable thread id', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const fake = await createFakeTrae({
+      lines: [
+        { type: 'item.completed', item: { id: 'msg-1', type: 'agent_message', text: 'hello' } },
+        { type: 'turn.completed' },
+      ],
+    });
+    cleanup.push(fake.dir);
+    const cwd = await realpath(fake.dir);
+
+    try {
+      const run = new TraeAdapter({
+        binary: fake.path,
+        profileStateDir: fake.dir,
+        sandbox: 'read-only',
+      }).run({
+        runId: 'run-trae-no-thread',
+        prompt: 'hello from lark',
+        cwd,
+      });
+
+      expect(await collect(run.events)).toEqual([
+        { type: 'text', delta: 'hello' },
+        {
+          type: 'done',
+          threadId: undefined,
+          terminationReason: 'normal',
+        },
+      ]);
+      const warning = warn.mock.calls.map((call) => call.join(' ')).join('\n');
+      expect(warning).toContain('agent.trae-session-id-missing');
+      expect(warning).toContain('runId=run-trae-no-thread');
+      expect(warning).toContain('Trae resume will be unavailable for this run');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});
+
+async function collect(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const out: AgentEvent[] = [];
+  for await (const event of events) out.push(event);
+  return out;
+}
+
+async function createFakeTrae(options: {
+  lines: unknown[];
+  stderr?: string;
+  stderrDelayMs?: number;
+  exitCode?: number;
+}): Promise<FakeBinary> {
+  const dir = await mkdtemp(join(tmpdir(), 'trae-adapter-test-'));
+  const path = join(dir, 'fake-trae.mjs');
+  const recordPath = join(dir, 'argv.json');
+  await writeFile(
+    path,
+    [
+      '#!/usr/bin/env node',
+      'import { writeFileSync } from "node:fs";',
+      'let stdin = "";',
+      'process.stdin.setEncoding("utf8");',
+      'process.stdin.on("data", (chunk) => { stdin += chunk; });',
+      'process.stdin.on("end", () => {',
+      `  writeFileSync(${JSON.stringify(recordPath)}, JSON.stringify({`,
+      '    argv: process.argv.slice(2),',
+      '    cwd: process.cwd(),',
+      '    stdin,',
+      '    env: {',
+      '      LARK_CHANNEL: process.env.LARK_CHANNEL,',
+      '      TRAE_HOME: process.env.TRAE_HOME,',
+      '    },',
+      '  }));',
+      options.stderr
+        ? options.stderrDelayMs
+          ? `  setTimeout(() => process.stderr.write(${JSON.stringify(options.stderr)}), ${options.stderrDelayMs});`
+          : `  process.stderr.write(${JSON.stringify(options.stderr)});`
+        : '',
+      `  const lines = ${JSON.stringify(options.lines)};`,
+      '  for (const line of lines) console.log(JSON.stringify(line));',
+      `  setTimeout(() => process.exit(${options.exitCode ?? 0}), ${Math.max(0, options.stderrDelayMs ?? 0)});`,
+      '});',
+    ].filter(Boolean).join('\n'),
+    'utf8',
+  );
+  await chmod(path, 0o755);
+  return { path, dir, recordPath };
+}
+
+async function readRecord(path: string): Promise<{
+  argv: string[];
+  cwd: string;
+  stdin: string;
+  env: {
+    LARK_CHANNEL?: string;
+    TRAE_HOME?: string;
+  };
+}> {
+  return JSON.parse(await readFile(path, 'utf8')) as {
+    argv: string[];
+    cwd: string;
+    stdin: string;
+    env: {
+      LARK_CHANNEL?: string;
+      TRAE_HOME?: string;
+    };
+  };
+}

--- a/tests/unit/agent/capability.test.ts
+++ b/tests/unit/agent/capability.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { BRIDGE_SYSTEM_PROMPT } from '../../../src/agent/bridge-system-prompt';
-import { claudeCapability, codexCapability } from '../../../src/agent/capability';
+import {
+  claudeCapability,
+  codexCapability,
+  traeCapability,
+} from '../../../src/agent/capability';
 import { createDefaultProfileConfig } from '../../../src/config/profile-schema';
 
 describe('agent capability contract', () => {
@@ -71,5 +75,36 @@ describe('agent capability contract', () => {
     });
 
     expect(codexCapability(profile).permissions.maxAccess).toBe('read-only');
+  });
+
+  it('defines Trae capability as a thread-based stdin agent', () => {
+    const profile = createDefaultProfileConfig({
+      agentKind: 'trae',
+      accounts: {
+        app: {
+          id: 'cli_test',
+          secret: '${APP_SECRET}',
+          tenant: 'feishu',
+        },
+      },
+      trae: {
+        binaryPath: '/usr/local/bin/traecli',
+      },
+      permissions: {
+        defaultAccess: 'workspace',
+        maxAccess: 'workspace',
+      },
+    });
+
+    expect(traeCapability(profile)).toMatchObject({
+      agentId: 'trae',
+      sessionKind: 'trae-thread',
+      promptInjection: 'stdin-prefix',
+      supportsNativeHistory: false,
+      systemPrompt: BRIDGE_SYSTEM_PROMPT,
+      permissions: {
+        maxAccess: 'workspace',
+      },
+    });
   });
 });

--- a/tests/unit/agent/trae-argv.test.ts
+++ b/tests/unit/agent/trae-argv.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+import { buildTraeArgs, sandboxToTraePermissionMode } from '../../../src/agent/trae/argv.js';
+
+describe('Trae argv contract', () => {
+  it('builds fresh exec argv with the prompt on stdin', () => {
+    expect(buildTraeArgs({ cwd: '/repo', sandbox: 'read-only' })).toEqual([
+      'exec',
+      '--json',
+      '--permission-mode',
+      'plan',
+      '-c',
+      'approval_policy="never"',
+      '-c',
+      'shell_environment_policy.inherit="all"',
+      '--ignore-rules',
+      '--skip-git-repo-check',
+      '-C',
+      '/repo',
+      '-',
+    ]);
+  });
+
+  it('uses the Trae resume subcommand for thread continuation', () => {
+    expect(
+      buildTraeArgs({
+        cwd: '/repo',
+        sandbox: 'workspace-write',
+        threadId: '019ef7db-d096-7490-8aba-d7eeafd4f2da',
+      }),
+    ).toEqual([
+      'exec',
+      'resume',
+      '--json',
+      '--permission-mode',
+      'default',
+      '-c',
+      'approval_policy="never"',
+      '-c',
+      'shell_environment_policy.inherit="all"',
+      '--ignore-rules',
+      '--skip-git-repo-check',
+      '019ef7db-d096-7490-8aba-d7eeafd4f2da',
+      '-',
+    ]);
+  });
+
+  it('passes image flags before the stdin prompt marker', () => {
+    expect(
+      buildTraeArgs({
+        cwd: '/repo',
+        sandbox: 'workspace-write',
+        images: ['/tmp/image.png'],
+      }),
+    ).toEqual([
+      'exec',
+      '--json',
+      '--permission-mode',
+      'default',
+      '-c',
+      'approval_policy="never"',
+      '-c',
+      'shell_environment_policy.inherit="all"',
+      '--ignore-rules',
+      '--skip-git-repo-check',
+      '-C',
+      '/repo',
+      '--image',
+      '/tmp/image.png',
+      '--',
+      '-',
+    ]);
+  });
+
+  it('can explicitly isolate Trae from the user config', () => {
+    expect(
+      buildTraeArgs({
+        cwd: '/repo',
+        sandbox: 'read-only',
+        ignoreUserConfig: true,
+      }),
+    ).toContain('--ignore-user-config');
+  });
+
+  it('does not combine Trae permission mode with sandbox mode', () => {
+    const args = buildTraeArgs({ cwd: '/repo', sandbox: 'danger-full-access' });
+
+    expect(args).toContain('--permission-mode');
+    expect(args).not.toContain('--sandbox');
+  });
+
+  it('maps bridge sandbox policy to Trae resume permission mode', () => {
+    expect(sandboxToTraePermissionMode('read-only')).toBe('plan');
+    expect(sandboxToTraePermissionMode('workspace-write')).toBe('default');
+    expect(sandboxToTraePermissionMode('danger-full-access')).toBe('bypass_permissions');
+  });
+});

--- a/tests/unit/cli/start-agent-factory.test.ts
+++ b/tests/unit/cli/start-agent-factory.test.ts
@@ -69,6 +69,20 @@ describe('start runtime agent factory', () => {
     expect(profile.codex?.binaryPath).toBe('codex');
   });
 
+  it('creates a Trae runtime agent and seeds the default binary', () => {
+    const profile = createRuntimeProfileConfig({
+      agentKind: 'trae',
+      accounts: appAccount(),
+    });
+    const agent = createRuntimeAgent(profile, {
+      profileDir: '/tmp/lark-channel-bridge/profiles/trae-e2e',
+    });
+
+    expect(profile.trae?.binaryPath).toBe('traecli');
+    expect(agent.id).toBe('trae');
+    expect(agent.displayName).toBe('Trae CLI');
+  });
+
   it('updates the process registry before releasing the old app lock during reconnect', async () => {
     const source = await readFile(join(process.cwd(), 'src/cli/commands/start.ts'), 'utf8');
     const restartStart = source.indexOf('async restart()');

--- a/tests/unit/config/profile-schema.test.ts
+++ b/tests/unit/config/profile-schema.test.ts
@@ -50,6 +50,17 @@ describe('profile schema', () => {
     });
   });
 
+  it('preserves profile-level secret provider configuration', () => {
+    const cfg = normalizeProfileConfig({
+      schemaVersion: 2,
+      agentKind: 'claude',
+      accounts: { app },
+      secrets: { defaults: { env: 'profileEnv' } },
+    });
+
+    expect(cfg.secrets).toEqual({ defaults: { env: 'profileEnv' } });
+  });
+
   it('requires codex configuration when agentKind is codex', () => {
     expect(() =>
       normalizeProfileConfig({
@@ -286,6 +297,50 @@ describe('profile schema', () => {
     });
 
     expect(cfg.codex?.inheritCodexHome).toBe(false);
+  });
+
+  it('keeps Trae binary metadata and user-home defaults without keeping public flags', () => {
+    const cfg = normalizeProfileConfig({
+      schemaVersion: 2,
+      agentKind: 'trae',
+      accounts: { app },
+      trae: {
+        binaryPath: '/usr/local/bin/traecli',
+        realpath: '/opt/trae/bin/traecli',
+        version: 'traecli 0.200.13',
+        sha256: 'abc123',
+        owner: 501,
+        mode: 0o755,
+        flags: ['--sandbox', 'workspace-write'],
+      },
+    });
+
+    expect(cfg.trae).toMatchObject({
+      binaryPath: '/usr/local/bin/traecli',
+      realpath: '/opt/trae/bin/traecli',
+      version: 'traecli 0.200.13',
+      sha256: 'abc123',
+      owner: 501,
+      mode: 0o755,
+      inheritTraeHome: true,
+      ignoreUserConfig: false,
+      ignoreRules: true,
+    });
+    expect(cfg.trae).not.toHaveProperty('flags');
+  });
+
+  it('preserves explicit Trae home isolation when configured', () => {
+    const cfg = normalizeProfileConfig({
+      schemaVersion: 2,
+      agentKind: 'trae',
+      accounts: { app },
+      trae: {
+        binaryPath: '/usr/local/bin/traecli',
+        inheritTraeHome: false,
+      },
+    });
+
+    expect(cfg.trae?.inheritTraeHome).toBe(false);
   });
 
   it('defaults Claude permissions to full/full and derives legacy sandbox for runtime compatibility', () => {

--- a/tests/unit/runtime/profile-runtime.test.ts
+++ b/tests/unit/runtime/profile-runtime.test.ts
@@ -238,9 +238,11 @@ describe('profile runtime resolver', () => {
     const oldPath = process.env.PATH;
     const oldClaude = process.env.LARK_CHANNEL_CLAUDE_BIN;
     const oldCodex = process.env.LARK_CHANNEL_CODEX_BIN;
+    const oldTrae = process.env.LARK_CHANNEL_TRAE_BIN;
     process.env.PATH = bin;
     delete process.env.LARK_CHANNEL_CLAUDE_BIN;
     delete process.env.LARK_CHANNEL_CODEX_BIN;
+    delete process.env.LARK_CHANNEL_TRAE_BIN;
 
     try {
       let error: Error | undefined;
@@ -262,7 +264,7 @@ describe('profile runtime resolver', () => {
       expect(message).toContain(claude);
       expect(message).toContain('codex');
       expect(message).toContain(codex);
-      expect(message).toContain('--agent <claude|codex>');
+      expect(message).toContain('--agent <claude|codex|trae>');
     } finally {
       process.env.PATH = oldPath;
       if (oldClaude === undefined) {
@@ -275,6 +277,11 @@ describe('profile runtime resolver', () => {
       } else {
         process.env.LARK_CHANNEL_CODEX_BIN = oldCodex;
       }
+      if (oldTrae === undefined) {
+        delete process.env.LARK_CHANNEL_TRAE_BIN;
+      } else {
+        process.env.LARK_CHANNEL_TRAE_BIN = oldTrae;
+      }
     }
   });
 
@@ -286,9 +293,11 @@ describe('profile runtime resolver', () => {
     const oldPath = process.env.PATH;
     const oldClaude = process.env.LARK_CHANNEL_CLAUDE_BIN;
     const oldCodex = process.env.LARK_CHANNEL_CODEX_BIN;
+    const oldTrae = process.env.LARK_CHANNEL_TRAE_BIN;
     process.env.PATH = bin;
     delete process.env.LARK_CHANNEL_CLAUDE_BIN;
     delete process.env.LARK_CHANNEL_CODEX_BIN;
+    delete process.env.LARK_CHANNEL_TRAE_BIN;
 
     try {
       const runtime = await withTty(true, true, () =>
@@ -316,6 +325,11 @@ describe('profile runtime resolver', () => {
         delete process.env.LARK_CHANNEL_CODEX_BIN;
       } else {
         process.env.LARK_CHANNEL_CODEX_BIN = oldCodex;
+      }
+      if (oldTrae === undefined) {
+        delete process.env.LARK_CHANNEL_TRAE_BIN;
+      } else {
+        process.env.LARK_CHANNEL_TRAE_BIN = oldTrae;
       }
     }
   });
@@ -475,6 +489,122 @@ describe('profile runtime resolver', () => {
         delete process.env.LARK_CHANNEL_HOME;
       } else {
         process.env.LARK_CHANNEL_HOME = oldHome;
+      }
+    }
+  });
+
+  it('infers Trae agent kind from an explicit legacy profile name', async () => {
+    const root = await tmpRoot();
+    const bin = join(root, 'bin');
+    const trae = await writeExecutable(bin, 'traecli');
+    const oldTrae = process.env.LARK_CHANNEL_TRAE_BIN;
+    process.env.LARK_CHANNEL_TRAE_BIN = trae;
+    await writeFile(
+      join(root, 'config.json'),
+      `${JSON.stringify({
+        accounts: { app },
+        preferences: {},
+      }, null, 2)}\n`,
+    );
+
+    try {
+      const runtime = await resolveProfileRuntime({
+        config: join(root, 'config.json'),
+        profile: 'trae',
+        allowBootstrap: true,
+      });
+      const saved = JSON.parse(await readFile(join(root, 'config.json'), 'utf8')) as {
+        profiles: Record<string, { agentKind: string; trae?: { binaryPath?: string } }>;
+      };
+
+      expect(runtime.profile).toBe('trae');
+      expect(runtime.profileConfig.agentKind).toBe('trae');
+      expect(runtime.profileConfig.trae?.binaryPath).toBe(trae);
+      expect(saved.profiles.trae?.agentKind).toBe('trae');
+      expect(saved.profiles.trae?.trae?.binaryPath).toBe(trae);
+    } finally {
+      if (oldTrae === undefined) {
+        delete process.env.LARK_CHANNEL_TRAE_BIN;
+      } else {
+        process.env.LARK_CHANNEL_TRAE_BIN = oldTrae;
+      }
+    }
+  });
+
+  it('preserves existing root secret providers when bootstrapping a Trae profile into a root config', async () => {
+    const root = await tmpRoot();
+    const bin = join(root, 'bin');
+    const trae = await writeExecutable(bin, 'traecli');
+    const oldTrae = process.env.LARK_CHANNEL_TRAE_BIN;
+    process.env.LARK_CHANNEL_TRAE_BIN = trae;
+    await writeProfileRoot(
+      root,
+      'claude',
+      {
+        claude: createDefaultProfileConfig({
+          agentKind: 'claude',
+          accounts: { app },
+        }),
+      },
+      {
+        secrets: {
+          providers: {
+            existing: {
+              source: 'env',
+              env: 'EXISTING_SECRET',
+            },
+          },
+          defaults: {
+            env: 'existing',
+          },
+        },
+      },
+    );
+
+    try {
+      const runtime = await resolveProfileRuntime({
+        config: join(root, 'config.json'),
+        profile: 'trae',
+        allowBootstrap: true,
+        appId: 'cli_trae',
+        appSecret: 'trae-secret',
+        tenant: 'feishu',
+      } as Parameters<typeof resolveProfileRuntime>[0] & {
+        appId: string;
+        appSecret: string;
+        tenant: 'feishu';
+      });
+      const saved = JSON.parse(await readFile(join(root, 'config.json'), 'utf8')) as {
+        profiles: Record<string, {
+          agentKind: string;
+          accounts: { app: { secret: unknown } };
+          trae?: { binaryPath?: string };
+        }>;
+        secrets?: {
+          providers?: Record<string, { source?: string; command?: string; env?: string }>;
+          defaults?: { env?: string };
+        };
+      };
+
+      expect(runtime.profileConfig.agentKind).toBe('trae');
+      expect(saved.profiles.trae?.agentKind).toBe('trae');
+      expect(saved.profiles.trae?.trae?.binaryPath).toBe(trae);
+      expect(saved.profiles.trae?.accounts.app.secret).toEqual({
+        source: 'exec',
+        provider: 'bridge',
+        id: 'app-cli_trae',
+      });
+      expect(saved.secrets?.providers?.existing).toEqual({
+        source: 'env',
+        env: 'EXISTING_SECRET',
+      });
+      expect(saved.secrets?.providers?.bridge?.command).toBe(expectedSecretsGetter(root));
+      expect(saved.secrets?.defaults?.env).toBe('existing');
+    } finally {
+      if (oldTrae === undefined) {
+        delete process.env.LARK_CHANNEL_TRAE_BIN;
+      } else {
+        process.env.LARK_CHANNEL_TRAE_BIN = oldTrae;
       }
     }
   });

--- a/tests/unit/session/catalog.test.ts
+++ b/tests/unit/session/catalog.test.ts
@@ -25,7 +25,7 @@ describe('agent-aware session catalog', () => {
     ).toBe('chat-1\x1fclaude\x1f/repo\x1ffp-1');
   });
 
-  it('stores Claude sessions and Codex threads in isolated active entries', async () => {
+  it('stores Claude sessions and thread-based agent entries in isolated active entries', async () => {
     const catalog = new SessionCatalog(await path());
 
     catalog.upsertActive({
@@ -44,6 +44,14 @@ describe('agent-aware session catalog', () => {
       threadId: 'thread-1',
       now: 2000,
     });
+    catalog.upsertActive({
+      scopeId: 'chat-1',
+      agentId: 'trae',
+      cwdRealpath: '/repo',
+      policyFingerprint: 'fp-1',
+      threadId: 'thread-trae',
+      now: 3000,
+    });
 
     expect(
       catalog.activeFor({
@@ -61,6 +69,14 @@ describe('agent-aware session catalog', () => {
         policyFingerprint: 'fp-1',
       }),
     ).toMatchObject({ threadId: 'thread-1', agentId: 'codex' });
+    expect(
+      catalog.activeFor({
+        scopeId: 'chat-1',
+        agentId: 'trae',
+        cwdRealpath: '/repo',
+        policyFingerprint: 'fp-1',
+      }),
+    ).toMatchObject({ threadId: 'thread-trae', agentId: 'trae' });
     await catalog.flush();
   });
 
@@ -86,7 +102,7 @@ describe('agent-aware session catalog', () => {
         sessionId: 'sess-wrong',
         now: 1000,
       }),
-    ).toThrow(/Codex.*threadId/i);
+    ).toThrow(/threadId/i);
 
     await catalog.replaceForTest([
       {


### PR DESCRIPTION
## Summary

Add first-class Trae CLI support to `lark-channel-bridge`.

This lets users run the bridge with `agentKind=trae` / `--agent trae`, using local `traecli` as the coding agent backend alongside Claude Code and Codex CLI.

## Changes

- Add `TraeAdapter` and argv builder for `traecli exec --json` and `traecli exec resume --json`.
- Add profile schema, bootstrap, runtime factory, registry, lock, migration, and CLI command support for `agentKind=trae`.
- Handle Trae as a Codex-like thread agent in run flow, `/resume`, `/status`, IM runs, and comment runs.
- Map bridge sandbox policy to Trae `--permission-mode`.
- Support `TRAE_HOME`, profile-local Trae home isolation, and `LARK_CHANNEL_TRAE_BIN`.
- Capture Trae thread/session ids from stdout JSONL first, with compatible stderr fallback formats.
- Avoid unsafe implicit resume when Trae does not emit a session/thread id; log a warning instead.
- Preserve profile-level secrets and harden lark-channel env handling against inherited profile env leakage.
- Add Trae process/unit tests and Claude/Codex regression coverage.

## Validation

- `npm run typecheck`
- `npm run test -- --cache=false`
- `git diff --check`
- `/tmp` clean build check via `npm install`
- Local smoke test with Feishu bot + Trae CLI profile