### PR TITLE
fix(claude): pass prompt via stdin to avoid Windows cmd.exe argument …

### DIFF
--- a/src/agent/claude/adapter.ts
+++ b/src/agent/claude/adapter.ts
@@ -1,5 +1,8 @@
+import { unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { createInterface } from 'node:readline';
-import type { Readable } from 'node:stream';
+import type { Readable, Writable } from 'node:stream';
 import { log } from '../../core/logger';
 import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
 import { buildBridgeSystemPrompt } from '../bridge-system-prompt';
@@ -20,7 +23,7 @@ export interface ClaudeAdapterOptions {
   larkChannel?: LarkChannelEnvContext;
 }
 
-type ClaudeChild = SpawnedProcessByStdio<null, Readable, Readable>;
+type ClaudeChild = SpawnedProcessByStdio<Writable, Readable, Readable>;
 
 export class ClaudeAdapter implements AgentAdapter {
   readonly id = 'claude';
@@ -57,16 +60,29 @@ export class ClaudeAdapter implements AgentAdapter {
       throw new Error('cwd is required for ClaudeAdapter.run');
     }
 
+    // Windows: cross-spawn invokes `claude.cmd` through `cmd.exe /d /s /c`,
+    // which treats `<` and `>` in argv as I/O redirect operators and silently
+    // strips them. The bridge prompt contains `<bridge_context>` XML, so the
+    // argv-passed prompt arrives at claude effectively empty and claude
+    // responds with its default greeting. Route the user prompt through
+    // stdin and the append-system-prompt through a temp file to avoid the
+    // cmd.exe argument parser entirely. This mirrors the Codex adapter's
+    // existing stdin pattern (see src/agent/codex/adapter.ts).
+    const sysPromptFile = join(
+      tmpdir(),
+      `lcb-claude-sys-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.txt`,
+    );
+    writeFileSync(sysPromptFile, buildBridgeSystemPrompt(this.botIdentity), 'utf8');
+
     const args = [
       '-p',
-      opts.prompt,
       '--output-format',
       'stream-json',
       '--verbose',
       '--permission-mode',
       opts.permissionMode ?? CLAUDE_DEFAULT_PERMISSION_MODE,
-      '--append-system-prompt',
-      buildBridgeSystemPrompt(this.botIdentity),
+      '--append-system-prompt-file',
+      sysPromptFile,
     ];
     if (opts.sessionId) args.push('--resume', opts.sessionId);
     if (opts.model) args.push('--model', opts.model);
@@ -74,8 +90,23 @@ export class ClaudeAdapter implements AgentAdapter {
     const child = spawnProcess(this.binary, args, {
       cwd: opts.cwd,
       env: mergeProcessEnv(process.env, buildLarkChannelEnv(this.larkChannel)),
-      stdio: ['ignore', 'pipe', 'pipe'],
+      stdio: ['pipe', 'pipe', 'pipe'],
     }) as ClaudeChild;
+
+    try {
+      child.stdin.end(opts.prompt, 'utf8');
+    } catch (e) {
+      log.warn('agent', 'stdin-write-failed', {
+        error: (e as Error)?.message ?? String(e),
+      });
+    }
+    child.once('exit', () => {
+      try {
+        unlinkSync(sysPromptFile);
+      } catch {
+        /* best-effort cleanup */
+      }
+    });
 
     log.info('agent', 'spawn', {
       pid: child.pid ?? null,

--- a/tests/process/claude-adapter.test.ts
+++ b/tests/process/claude-adapter.test.ts
@@ -43,22 +43,26 @@ describe('ClaudeAdapter process contract', () => {
 
     expect(await realpath(record.cwd)).toBe(await realpath(fake.dir));
     expect(record.env.LARK_CHANNEL).toBe('1');
-    expect(record.argv.slice(0, 8)).toEqual([
+    expect(record.argv.slice(0, 7)).toEqual([
       '-p',
-      'hello',
       '--output-format',
       'stream-json',
       '--verbose',
       '--permission-mode',
       'acceptEdits',
-      '--append-system-prompt',
+      '--append-system-prompt-file',
     ]);
-    expect(record.argv[8]).toContain('lark-channel-bridge 运行约定');
-    expect(record.argv[8]).toContain('__bridge_cb');
-    expect(record.argv[8]).toContain('LARK_CHANNEL_PROFILE');
-    expect(record.argv[8]).toContain('LARKSUITE_CLI_CONFIG_DIR');
-    expect(record.argv[8]).not.toContain('lark-cli config bind --source lark-channel');
-    expect(record.argv[8]).not.toContain('__claude_cb');
+    expect(record.argv).not.toContain('hello');
+    expect(record.argv).not.toContain('--append-system-prompt');
+    expect(record.stdin).toBe('hello');
+    const sysPromptFilePath = record.argv[7];
+    expect(sysPromptFilePath).toBeTruthy();
+    expect(record.sysPromptFileContent).toContain('lark-channel-bridge 运行约定');
+    expect(record.sysPromptFileContent).toContain('__bridge_cb');
+    expect(record.sysPromptFileContent).toContain('LARK_CHANNEL_PROFILE');
+    expect(record.sysPromptFileContent).toContain('LARKSUITE_CLI_CONFIG_DIR');
+    expect(record.sysPromptFileContent).not.toContain('lark-cli config bind --source lark-channel');
+    expect(record.sysPromptFileContent).not.toContain('__claude_cb');
     expect(record.argv).not.toContain('--resume');
     expect(record.argv).not.toContain('--model');
   });
@@ -120,7 +124,7 @@ describe('ClaudeAdapter process contract', () => {
     const record = await readRecord(fake.recordPath);
 
     expect(record.argv.slice(-4)).toEqual(['--resume', 'sess-old', '--model', 'sonnet']);
-    expect(record.argv[6]).toBe('bypassPermissions');
+    expect(record.argv[5]).toBe('bypassPermissions');
   });
 
   it('includes stderr when the process exits non-zero', async () => {
@@ -228,22 +232,36 @@ async function createFakeClaude(options: {
     path,
     [
       '#!/usr/bin/env node',
-      'import { writeFileSync } from "node:fs";',
-      `writeFileSync(${JSON.stringify(recordPath)}, JSON.stringify({`,
-      '  argv: process.argv.slice(2),',
-      '  cwd: process.cwd(),',
-      '  env: {',
-      '    LARK_CHANNEL: process.env.LARK_CHANNEL,',
-      '    LARK_CHANNEL_PROFILE: process.env.LARK_CHANNEL_PROFILE,',
-      '    LARK_CHANNEL_HOME: process.env.LARK_CHANNEL_HOME,',
-      '    LARK_CHANNEL_CONFIG: process.env.LARK_CHANNEL_CONFIG,',
-      '    LARKSUITE_CLI_CONFIG_DIR: process.env.LARKSUITE_CLI_CONFIG_DIR,',
-      '  },',
-      '}));',
-      `const lines = ${JSON.stringify(options.lines)};`,
-      'for (const line of lines) console.log(JSON.stringify(line));',
-      options.stderr ? `process.stderr.write(${JSON.stringify(options.stderr)});` : '',
-      `setTimeout(() => process.exit(${options.exitCode ?? 0}), ${options.exitDelayMs ?? 0});`,
+      'import { readFileSync, writeFileSync } from "node:fs";',
+      'const argv = process.argv.slice(2);',
+      'const sysFlagIdx = argv.indexOf("--append-system-prompt-file");',
+      'const sysPromptFileContent = sysFlagIdx >= 0 && argv[sysFlagIdx + 1]',
+      '  ? (() => { try { return readFileSync(argv[sysFlagIdx + 1], "utf8"); } catch { return ""; } })()',
+      '  : "";',
+      'let stdinBuf = "";',
+      'process.stdin.setEncoding("utf8");',
+      'process.stdin.on("data", (c) => { stdinBuf += c; });',
+      'process.stdin.on("end", () => finish());',
+      'if (process.stdin.isTTY) finish();',
+      'function finish() {',
+      `  writeFileSync(${JSON.stringify(recordPath)}, JSON.stringify({`,
+      '    argv,',
+      '    stdin: stdinBuf,',
+      '    sysPromptFileContent,',
+      '    cwd: process.cwd(),',
+      '    env: {',
+      '      LARK_CHANNEL: process.env.LARK_CHANNEL,',
+      '      LARK_CHANNEL_PROFILE: process.env.LARK_CHANNEL_PROFILE,',
+      '      LARK_CHANNEL_HOME: process.env.LARK_CHANNEL_HOME,',
+      '      LARK_CHANNEL_CONFIG: process.env.LARK_CHANNEL_CONFIG,',
+      '      LARKSUITE_CLI_CONFIG_DIR: process.env.LARKSUITE_CLI_CONFIG_DIR,',
+      '    },',
+      '  }));',
+      `  const lines = ${JSON.stringify(options.lines)};`,
+      '  for (const line of lines) console.log(JSON.stringify(line));',
+      options.stderr ? `  process.stderr.write(${JSON.stringify(options.stderr)});` : '',
+      `  setTimeout(() => process.exit(${options.exitCode ?? 0}), ${options.exitDelayMs ?? 0});`,
+      '}',
     ].filter(Boolean).join('\n'),
     'utf8',
   );
@@ -253,6 +271,8 @@ async function createFakeClaude(options: {
 
 async function readRecord(path: string): Promise<{
   argv: string[];
+  stdin: string;
+  sysPromptFileContent: string;
   cwd: string;
   env: {
     LARK_CHANNEL?: string;
@@ -264,6 +284,8 @@ async function readRecord(path: string): Promise<{
 }> {
   return JSON.parse(await readFile(path, 'utf8')) as {
     argv: string[];
+    stdin: string;
+    sysPromptFileContent: string;
     cwd: string;
     env: {
       LARK_CHANNEL?: string;

--- a/tests/unit/agent/adapter-system-prompt-wiring.test.ts
+++ b/tests/unit/agent/adapter-system-prompt-wiring.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events';
+import { readFileSync } from 'node:fs';
 import { PassThrough } from 'node:stream';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -45,7 +46,7 @@ beforeEach(() => {
 });
 
 describe('ClaudeAdapter system prompt wiring', () => {
-  it('appends the identity-aware bridge system prompt after setBotIdentity', () => {
+  it('writes the identity-aware bridge system prompt to the file referenced by --append-system-prompt-file after setBotIdentity', () => {
     spawnMock.spawnProcess.mockReturnValue(fakeChild());
     const adapter = new ClaudeAdapter();
     adapter.setBotIdentity({ openId: 'ou_bot_self', name: 'Bridge' });
@@ -53,9 +54,11 @@ describe('ClaudeAdapter system prompt wiring', () => {
     adapter.run({ runId: 'r1', prompt: 'hi', cwd: '/tmp' });
 
     const args = spawnMock.spawnProcess.mock.calls[0]?.[1] as string[];
-    const flagIndex = args.indexOf('--append-system-prompt');
+    const flagIndex = args.indexOf('--append-system-prompt-file');
     expect(flagIndex).toBeGreaterThan(-1);
-    expect(args[flagIndex + 1]).toBe(
+    const filePath = args[flagIndex + 1];
+    if (!filePath) throw new Error('--append-system-prompt-file path missing');
+    expect(readFileSync(filePath, 'utf8')).toBe(
       buildBridgeSystemPrompt({ openId: 'ou_bot_self', name: 'Bridge' }),
     );
   });
@@ -67,8 +70,23 @@ describe('ClaudeAdapter system prompt wiring', () => {
     adapter.run({ runId: 'r1', prompt: 'hi', cwd: '/tmp' });
 
     const args = spawnMock.spawnProcess.mock.calls[0]?.[1] as string[];
-    const flagIndex = args.indexOf('--append-system-prompt');
-    expect(args[flagIndex + 1]).toBe(buildBridgeSystemPrompt(undefined));
+    const flagIndex = args.indexOf('--append-system-prompt-file');
+    const filePath = args[flagIndex + 1];
+    if (!filePath) throw new Error('--append-system-prompt-file path missing');
+    expect(readFileSync(filePath, 'utf8')).toBe(buildBridgeSystemPrompt(undefined));
+  });
+
+  it('routes the user prompt through stdin instead of argv to avoid Windows cmd.exe argument mangling', async () => {
+    const child = fakeChild();
+    spawnMock.spawnProcess.mockReturnValue(child);
+    const adapter = new ClaudeAdapter();
+
+    adapter.run({ runId: 'r1', prompt: 'hi from stdin', cwd: '/tmp' });
+
+    const args = spawnMock.spawnProcess.mock.calls[0]?.[1] as string[];
+    expect(args).not.toContain('hi from stdin');
+    const stdin = await readAll(child.stdin);
+    expect(stdin).toBe('hi from stdin');
   });
 });
 


### PR DESCRIPTION
Fixes #142

  ## 问题

  Windows 上 claude 子进程通过 `claude.cmd` shim 启动，cross-spawn 绕一层 `cmd.exe /d /s /c`，
  prompt 中的 `<bridge_context>` XML 被 cmd.exe 当 I/O 重定向符吃掉，
  导致 claude 收到空 prompt 后回礼貌问候，bridge 显示 "no content"。

  详情见 #142。

  ## 改动

  `src/agent/claude/adapter.ts` `ClaudeAdapter.run()`：

  1. **prompt → stdin**：移除 `-p <prompt>` 的位置参数，
     `stdio[0]` 从 `'ignore'` 改为 `'pipe'`，spawn 后 `child.stdin.end(opts.prompt, 'utf8')`。
     与 Codex adapter 已有做法（`src/agent/codex/adapter.ts:113,154`）对齐。

  2. **`--append-system-prompt <text>` → `--append-system-prompt-file <path>`**：
     把 system prompt 写到 `os.tmpdir()` 下的临时文件，
     传文件路径（路径无特殊字符，cmd.exe 不会吃）。
     子进程 `exit` 时清理临时文件。

  3. **类型**：`ClaudeChild` 的 stdin slot 从 `null` 改为 `Writable`。

  ## 测试

  更新两个失败的契约测试以匹配新行为，新增 1 个 test 显式断言"prompt 不出现在 argv、必须从 stdin 来"：

  - `tests/process/claude-adapter.test.ts`：fake-claude 现在同时捕获 stdin 与 `--append-system-prompt-file` 的文件内容
  - `tests/unit/agent/adapter-system-prompt-wiring.test.ts`：通过 `readFileSync` 读临时文件验证 system prompt 内容；新加 stdin 路由测试

  **本地（Windows）全绿**：
  - `pnpm typecheck` ✅
  - `pnpm test` ✅ 87 files / 513 tests passed
  - `pnpm build` ✅

  **飞书侧实测**：打 patch 后，文字消息从 "no content" 恢复正常 stream-json 输出；斜杠命令、卡片回调、工作目录切换均无回归。

  ## 影响范围

  - ✅ Windows：从坏到好
  - ✅ macOS / Linux：spawn 模式从 argv 改为 stdin 不影响 POSIX 行为，已被新增测试覆盖
  - 临时文件开销：每次 run 一次写 + 一次删，<1KB

  ## 不在本 PR 范围内

  - Codex adapter 已是 stdin 模式，不需改
  - 旧的 `silentExitTimer` stdout 兜底逻辑保留不变