### PR TITLE
feat(resume): label sessions by conversation title, not first message

### DIFF
--- a/src/session/history.ts
+++ b/src/session/history.ts
@@ -62,11 +62,34 @@ async function summarize(path: string): Promise<{ preview: string; lineCount: nu
   const stream = createReadStream(path, { encoding: 'utf8' });
   const rl = createInterface({ input: stream });
   let preview = '';
+  let customTitle = '';
+  let aiTitle = '';
   let lineCount = 0;
   try {
     for await (const line of rl) {
       lineCount++;
-      if (!preview && line.includes('"type":"user"')) {
+      // Prefer the conversation's title for the label — Claude Code records
+      // `custom-title` (user-set) and `ai-title` (auto-generated). Keep the
+      // latest of each; fall back to the first user message below.
+      if (line.includes('"customTitle"')) {
+        try {
+          const obj = JSON.parse(line) as { type?: string; customTitle?: unknown };
+          if (obj.type === 'custom-title' && typeof obj.customTitle === 'string') {
+            customTitle = obj.customTitle.trim();
+          }
+        } catch {
+          /* malformed line */
+        }
+      } else if (line.includes('"aiTitle"')) {
+        try {
+          const obj = JSON.parse(line) as { type?: string; aiTitle?: unknown };
+          if (obj.type === 'ai-title' && typeof obj.aiTitle === 'string') {
+            aiTitle = obj.aiTitle.trim();
+          }
+        } catch {
+          /* malformed line */
+        }
+      } else if (!preview && line.includes('"type":"user"')) {
         try {
           const obj = JSON.parse(line) as { type?: string; message?: { content?: unknown } };
           if (obj.type === 'user' && obj.message) {
@@ -84,7 +107,8 @@ async function summarize(path: string): Promise<{ preview: string; lineCount: nu
     rl.close();
     stream.destroy();
   }
-  return { preview: preview || '(空会话)', lineCount };
+  // Title first (most readable), then first user message, then placeholder.
+  return { preview: customTitle || aiTitle || preview || '(空会话)', lineCount };
 }
 
 function extractUserText(content: unknown): string {

--- a/tests/unit/session/history.test.ts
+++ b/tests/unit/session/history.test.ts
@@ -84,4 +84,56 @@ describe('Claude local session history', () => {
 
     expect(sessions[0]?.preview).toBe('真实用户问题 第二行');
   });
+
+  it('prefers the conversation title over the first user message', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'claude-history-home-'));
+    cleanup.push(home);
+    vi.doMock('node:os', async () => {
+      const actual = await vi.importActual<typeof import('node:os')>('node:os');
+      return { ...actual, homedir: () => home };
+    });
+    const { listRecentSessions } = await import('../../../src/session/history.js');
+
+    const cwd = '/repo';
+    const projectDir = join(home, '.claude', 'projects', '-repo');
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(
+      join(projectDir, 'session-a.jsonl'),
+      `${[
+        JSON.stringify({ type: 'user', message: { content: 'OK read and understand my wiki' } }),
+        JSON.stringify({ type: 'ai-title', aiTitle: 'Automated Content Pipeline' }),
+        JSON.stringify({ type: 'custom-title', customTitle: 'My Pipeline' }),
+      ].join('\n')}\n`,
+      'utf8',
+    );
+
+    const sessions = await listRecentSessions(cwd, 5);
+    // custom-title beats ai-title beats the first user message.
+    expect(sessions[0]?.preview).toBe('My Pipeline');
+  });
+
+  it('falls back to ai-title when there is no custom-title', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'claude-history-home-'));
+    cleanup.push(home);
+    vi.doMock('node:os', async () => {
+      const actual = await vi.importActual<typeof import('node:os')>('node:os');
+      return { ...actual, homedir: () => home };
+    });
+    const { listRecentSessions } = await import('../../../src/session/history.js');
+
+    const cwd = '/repo';
+    const projectDir = join(home, '.claude', 'projects', '-repo');
+    await mkdir(projectDir, { recursive: true });
+    await writeFile(
+      join(projectDir, 'session-a.jsonl'),
+      `${[
+        JSON.stringify({ type: 'user', message: { content: 'first message' } }),
+        JSON.stringify({ type: 'ai-title', aiTitle: 'Retrieve attendance data using lark CLI' }),
+      ].join('\n')}\n`,
+      'utf8',
+    );
+
+    const sessions = await listRecentSessions(cwd, 5);
+    expect(sessions[0]?.preview).toBe('Retrieve attendance data using lark CLI');
+  });
 });


### PR DESCRIPTION
## Problem
`/resume` labels each session by its **first user message** — often a long
prompt or a bare URL — so the picker is hard to scan and frequently shows the
raw session id. Real example from `~/.claude/projects`:

| Current (first message)                       | This PR (conversation title)            |
|-----------------------------------------------|-----------------------------------------|
| `OK read and understand my wiki to understa…` | **Automated Content Pipeline**          |
| `Can you use lark cli to get the attendance…` | **Retrieve attendance data using lark CLI** |
| `Are you able to access this? https://payro…` | **AutoCount-Lark Integration**          |

## Fix
Claude Code already records readable titles in the transcript — `custom-title`
(user-set) and `ai-title` (auto-generated). Prefer those for the label, falling
back to the first user message (existing behavior) when a session has no title.

- Single-function change in `summarize()` — no API or card changes.
- Precedence: `custom-title` → `ai-title` → first user message → `(空会话)`.
- Backward compatible: sessions without title records render exactly as before.

## Tests
- Existing history tests unchanged and passing.
- Added two tests: title precedence and ai-title fallback.
- `tsc --noEmit` clean; `vitest` green.