### PR TITLE
fix(card): filter leaked thinking tags from streamed text cards

### DIFF
--- a/src/card/run-state.ts
+++ b/src/card/run-state.ts
@@ -1,4 +1,10 @@
 import type { AgentEvent } from '../agent/types';
+import {
+  emptyThinkingTextFilter,
+  filterThinkingTextDelta,
+  sanitizeThinkingText,
+  type ThinkingTextFilter,
+} from './thinking-text-filter';
 
 export type ToolStatus = 'running' | 'done' | 'error';
 
@@ -26,6 +32,7 @@ export interface RunState {
   /** Set when terminal === 'idle_timeout' — how long claude was idle before
    * the watchdog gave up (so the message can say "N 分钟无响应"). */
   idleTimeoutMinutes?: number;
+  textFilter?: ThinkingTextFilter;
 }
 
 export const initialState: RunState = {
@@ -33,33 +40,51 @@ export const initialState: RunState = {
   reasoning: { content: '', active: false },
   footer: 'thinking',
   terminal: 'running',
+  textFilter: emptyThinkingTextFilter(),
 };
 
 function closeStreamingText(blocks: Block[]): Block[] {
   return blocks.map((b) =>
-    b.kind === 'text' && b.streaming ? { ...b, streaming: false } : b,
+    b.kind === 'text'
+      ? {
+          ...b,
+          streaming: false,
+          content: sanitizeThinkingText(b.content),
+        }
+      : b,
   );
+}
+
+function appendVisibleText(state: RunState, delta: string): RunState {
+  const filter = { ...(state.textFilter ?? emptyThinkingTextFilter()) };
+  const { output, clearPriorInBlock } = filterThinkingTextDelta(filter, delta);
+  const base: RunState = { ...state, textFilter: filter };
+  const last = base.blocks[base.blocks.length - 1];
+
+  if (last && last.kind === 'text' && last.streaming) {
+    const content = clearPriorInBlock ? output : last.content + output;
+    return {
+      ...base,
+      blocks: [...base.blocks.slice(0, -1), { ...last, content }],
+      reasoning: { ...base.reasoning, active: false },
+      footer: 'streaming',
+    };
+  }
+
+  if (!output) return base;
+
+  return {
+    ...base,
+    blocks: [...base.blocks, { kind: 'text', content: output, streaming: true }],
+    reasoning: { ...base.reasoning, active: false },
+    footer: 'streaming',
+  };
 }
 
 export function reduce(state: RunState, evt: AgentEvent): RunState {
   switch (evt.type) {
     case 'text': {
-      const last = state.blocks[state.blocks.length - 1];
-      if (last && last.kind === 'text' && last.streaming) {
-        const next: Block = { ...last, content: last.content + evt.delta };
-        return {
-          ...state,
-          blocks: [...state.blocks.slice(0, -1), next],
-          reasoning: { ...state.reasoning, active: false },
-          footer: 'streaming',
-        };
-      }
-      return {
-        ...state,
-        blocks: [...state.blocks, { kind: 'text', content: evt.delta, streaming: true }],
-        reasoning: { ...state.reasoning, active: false },
-        footer: 'streaming',
-      };
+      return appendVisibleText(state, evt.delta);
     }
 
     case 'thinking': {
@@ -82,6 +107,7 @@ export function reduce(state: RunState, evt: AgentEvent): RunState {
         blocks: [...closeStreamingText(state.blocks), { kind: 'tool', tool }],
         reasoning: { ...state.reasoning, active: false },
         footer: 'tool_running',
+        textFilter: emptyThinkingTextFilter(),
       };
     }
 

--- a/src/card/thinking-text-filter.ts
+++ b/src/card/thinking-text-filter.ts
@@ -1,0 +1,117 @@
+export type ThinkingTextFilter = {
+  carry: string;
+  mode: 'visible' | 'thinking';
+};
+
+const RT = 'redacted_' + 'thinking';
+const THINKING_CLOSE_TAGS = ['</thinking>', '</' + RT + '>'] as const;
+const THINKING_TAG_PREFIXES = [
+  '<thinking',
+  '<' + RT,
+  '</thinking>',
+  '</' + RT + '>',
+] as const;
+const RT_GROUP = '(thinking|' + RT + ')';
+const RT_CLOSE_GROUP = '(?:thinking|' + RT + ')';
+
+export function emptyThinkingTextFilter(): ThinkingTextFilter {
+  return { carry: '', mode: 'visible' };
+}
+
+function longestPartialTagSuffix(s: string): number {
+  let max = 0;
+  for (const tag of THINKING_TAG_PREFIXES) {
+    const lowerTag = tag.toLowerCase();
+    for (let i = 1; i <= Math.min(s.length, lowerTag.length - 1); i++) {
+      if (lowerTag.startsWith(s.slice(-i).toLowerCase())) {
+        max = Math.max(max, i);
+      }
+    }
+  }
+  return max;
+}
+
+function findThinkingOpen(input: string): { idx: number; len: number } {
+  const re = new RegExp('<(' + RT_GROUP + ')\b[^>]*>', 'i');
+  const match = input.match(re);
+  if (!match || match.index === undefined) return { idx: -1, len: 0 };
+  return { idx: match.index, len: match[0].length };
+}
+
+function findEarliestCloseTag(input: string): { idx: number; len: number } {
+  const lower = input.toLowerCase();
+  let best = { idx: -1, len: 0 };
+  for (const tag of THINKING_CLOSE_TAGS) {
+    const idx = lower.indexOf(tag.toLowerCase());
+    if (idx !== -1 && (best.idx === -1 || idx < best.idx)) {
+      best = { idx, len: tag.length };
+    }
+  }
+  return best;
+}
+
+export function filterThinkingTextDelta(
+  filter: ThinkingTextFilter,
+  delta: string,
+): { output: string; clearPriorInBlock: boolean } {
+  let input = filter.carry + delta;
+  filter.carry = '';
+  let output = '';
+  let clearPriorInBlock = false;
+
+  while (input.length > 0) {
+    if (filter.mode === 'thinking') {
+      const close = findEarliestCloseTag(input);
+      if (close.idx !== -1) {
+        input = input.slice(close.idx + close.len);
+        filter.mode = 'visible';
+        continue;
+      }
+      const keep = longestPartialTagSuffix(input);
+      if (keep > 0) {
+        filter.carry = input.slice(-keep);
+        input = input.slice(0, -keep);
+      }
+      break;
+    }
+
+    const open = findThinkingOpen(input);
+    const close = findEarliestCloseTag(input);
+    if (open.idx !== -1 && (close.idx === -1 || open.idx <= close.idx)) {
+      output += input.slice(0, open.idx);
+      input = input.slice(open.idx + open.len);
+      filter.mode = 'thinking';
+      continue;
+    }
+    if (close.idx !== -1) {
+      output = '';
+      clearPriorInBlock = true;
+      input = input.slice(close.idx + close.len);
+      continue;
+    }
+
+    const keep = longestPartialTagSuffix(input);
+    if (keep > 0) {
+      output += input.slice(0, -keep);
+      filter.carry = input.slice(-keep);
+    } else {
+      output += input;
+    }
+    break;
+  }
+
+  return { output, clearPriorInBlock };
+}
+
+export function sanitizeThinkingText(text: string): string {
+  let s = text;
+  const blockRe = new RegExp('<(' + RT_GROUP + ')\\b[^>]*>[\\s\\S]*?</\\1>', 'gi');
+  const openTailRe = new RegExp('<(' + RT_GROUP + ')\\b[^>]*>[\\s\\S]*$', 'gi');
+  const orphanCloseRe = new RegExp('^[\\s\\S]*?</' + RT_CLOSE_GROUP + '>', 'gi');
+  const tickCloseRe = new RegExp('`?</' + RT + '>`?', 'gi');
+  s = s.replace(blockRe, '');
+  s = s.replace(openTailRe, '');
+  s = s.replace(orphanCloseRe, '');
+  s = s.replace(tickCloseRe, '');
+  return s;
+}

--- a/tests/unit/card/thinking-text-filter.test.ts
+++ b/tests/unit/card/thinking-text-filter.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  emptyThinkingTextFilter,
+  filterThinkingTextDelta,
+  sanitizeThinkingText,
+} from '../../../src/card/thinking-text-filter';
+import { initialState, reduce } from '../../../src/card/run-state';
+
+const RT = 'redacted_' + 'thinking';
+const RT_CLOSE = '</' + RT + '>';
+
+describe('thinking-text-filter', () => {
+  it('strips orphaned closing tag and keeps visible answer', () => {
+    const filter = emptyThinkingTextFilter();
+    const chunks = [
+      "Let me proceed with the rewrite. I'll be efficient by using Edit",
+      ' with substantial old_string replacements.',
+      RT_CLOSE,
+      '我对 PDF 里的 Table 1-6 实际结构有清楚了。现在开始按 PDF 的真实表格结构重写。',
+    ];
+
+    let content = '';
+    for (const chunk of chunks) {
+      const { output, clearPriorInBlock } = filterThinkingTextDelta(filter, chunk);
+      content = clearPriorInBlock ? output : content + output;
+    }
+
+    expect(content).not.toContain('Let me proceed');
+    expect(content).toContain('我对 PDF');
+  });
+
+  it('sanitizeThinkingText removes full thinking blocks', () => {
+    const text = '<thinking>secret</thinking>visible tail';
+    expect(sanitizeThinkingText(text)).toBe('visible tail');
+    expect(sanitizeThinkingText('prefix' + RT_CLOSE + 'suffix')).toBe('suffix');
+  });
+
+  it('reduce keeps only visible answer when thinking tags leak into text events', () => {
+    let state = initialState;
+    state = reduce(state, {
+      type: 'text',
+      delta: "Let me proceed with the rewrite. I'll be efficient by using Edit",
+    });
+    state = reduce(state, {
+      type: 'text',
+      delta: ' with substantial old_string replacements.',
+    });
+    state = reduce(state, { type: 'text', delta: RT_CLOSE });
+    state = reduce(state, {
+      type: 'text',
+      delta: '我对 PDF 里的 Table 1-6 实际结构有清楚了。现在开始按 PDF 的真实表格结构重写。',
+    });
+    state = reduce(state, { type: 'done', terminationReason: 'normal' });
+
+    const textBlock = state.blocks.find((b) => b.kind === 'text');
+    expect(textBlock?.kind).toBe('text');
+    if (textBlock?.kind === 'text') {
+      expect(textBlock.content).not.toContain('Let me proceed');
+      expect(textBlock.content).toContain('我对 PDF');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Claude Code sometimes emits thinking fragments and closing tags inside **`text` stream deltas** rather than dedicated `thinking` events. The card reducer was appending these deltas verbatim, so Feishu cards briefly showed English planning text and raw closing tags before the final answer.

This PR adds a streaming `thinking-text-filter` and wires it into `run-state.ts` so only visible answer text reaches the card.

Fixes #147

## Changes

- Add `src/card/thinking-text-filter.ts` — streaming state machine + final sanitization
- Update `src/card/run-state.ts` — use `appendVisibleText()`, reset filter on tool blocks
- Add `tests/unit/card/thinking-text-filter.test.ts` — regression tests (3 cases)

## Test plan

- [x] `npx vitest run tests/unit/card/thinking-text-filter.test.ts` (3/3 pass)
- [ ] Manual: send a Claude Code task via Feishu bot and confirm no English thinking leak in streaming card

## Notes

Repro case: text deltas ending with `</think>` followed by the user-facing answer in Chinese. The existing `case "thinking"` path does not cover tags embedded in `text` events.

Made with [Cursor](https://cursor.com)