### PR TITLE
feat: isolate sessions per thread, including plain-group "convert to topic"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lark-channel-bridge",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Bridge Feishu/Lark messenger with local CLI coding agents",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -58,6 +58,7 @@ import { commandSessionCatalogIdentity } from './session-catalog-identity';
 import { startKeepalive } from './keepalive';
 import { PendingQueue } from './pending-queue';
 import { ProcessPool } from './process-pool';
+import { isThreadedScope, scopeForMessage } from './scope';
 import { fetchQuotedContext, type QuotedContext } from './quote';
 import { addWorkingReaction, removeReaction } from './reaction';
 import { fetchKnownChats } from './lark-info';
@@ -253,7 +254,6 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
     void withTrace({ chatId: firstMsg.chatId }, async () => {
       log.info('flush', 'start', { scope, batchSize: batch.length });
       try {
-        const mode = await chatModeCache.resolve(channel, firstMsg.chatId);
         await runAgentBatch({
           channel,
           executor,
@@ -266,7 +266,6 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
           callbackAuth,
           activePolicyFingerprints,
           scope,
-          mode,
         });
       } catch (err) {
         log.fail('flush', err);
@@ -513,9 +512,9 @@ async function intakeMessage(deps: IntakeDeps): Promise<void> {
   // Resolve scope (and underlying chat mode) once at intake — every
   // downstream consumer keys off these.
   const chatMode = await chatModeCache.resolve(channel, msg.chatId);
-  const scope = chatMode === 'topic' && msg.threadId
-    ? `${msg.chatId}:${msg.threadId}`
-    : msg.chatId;
+  // Scope keys off thread membership (Feishu `thread_id`), not chat mode, so a
+  // "convert to topic" thread inside a plain group also gets its own session.
+  const scope = await scopeForMessage(channel, msg, chatModeCache);
   log.info('intake', 'enter', {
     scope,
     chatType: msg.chatType,
@@ -571,7 +570,6 @@ async function intakeMessage(deps: IntakeDeps): Promise<void> {
     sessionCatalogIdentity: await commandSessionCatalogIdentity({
       msg,
       scope,
-      mode: chatMode,
       workspaces,
       controls,
       access: accessDecision,
@@ -602,7 +600,6 @@ interface RunBatchDeps {
   callbackAuth?: CallbackAuth;
   activePolicyFingerprints: Map<string, string>;
   scope: string;
-  mode: ChatMode;
 }
 
 async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
@@ -618,7 +615,6 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     callbackAuth,
     activePolicyFingerprints,
     scope,
-    mode,
   } = deps;
   if (batch.length === 0) return;
   const firstMsg = batch[0];
@@ -653,7 +649,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
   const quoteTargets = [
     ...new Set(
       batch
-        .map((m) => replyQuoteTargetForMessage(m, mode))
+        .map((m) => replyQuoteTargetForMessage(m))
         .filter((id): id is string => Boolean(id) && !batchIds.has(id!)),
     ),
   ];
@@ -673,12 +669,13 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
   const prompt = buildPrompt(batch, attachments, quotes, channel.botIdentity);
   log.info('prompt', 'built', { promptChars: prompt.length, quotes: quotes.length });
 
-  // For topic groups: thread the reply so it lands in the same topic as the
+  // For any threaded message (topic-group topic, or a plain-group "convert to
+  // topic" thread): thread the reply so it lands in the same topic as the
   // user's message. Otherwise the SDK posts at top level and the user's
   // topic discussion breaks visually.
   const sendOpts = {
     replyTo: lastMsg.messageId,
-    ...(mode === 'topic' && threadId ? { replyInThread: true } : {}),
+    ...(threadId ? { replyInThread: true } : {}),
   };
 
   const accessDecision =
@@ -1234,16 +1231,14 @@ function mergeMentions(batch: NormalizedMessage[]): BridgePromptMention[] {
   return out;
 }
 
-function replyQuoteTargetForMessage(
-  msg: NormalizedMessage,
-  mode: ChatMode,
-): string | undefined {
+function replyQuoteTargetForMessage(msg: NormalizedMessage): string | undefined {
   const replyTo = msg.replyToMessageId;
   if (!replyTo) return undefined;
 
-  // Feishu topic messages use root_id/parent_id as the topic root anchor even
-  // for ordinary in-topic messages. Treat that as structure, not a quote.
-  if (mode === 'topic' && msg.threadId && msg.rootId && replyTo === msg.rootId) {
+  // Any threaded message (topic-group topic, or a plain-group "convert to
+  // topic" thread) uses root_id/parent_id as the topic root anchor even for
+  // ordinary in-topic messages. Treat that as structure, not a quote.
+  if (msg.threadId && msg.rootId && replyTo === msg.rootId) {
     return undefined;
   }
   return replyTo;

--- a/src/bot/scope.ts
+++ b/src/bot/scope.ts
@@ -2,17 +2,32 @@ import type { LarkChannel, NormalizedMessage } from '@larksuite/channel';
 import type { ChatModeCache } from './chat-mode-cache';
 
 /**
+ * A message belongs to an isolated thread iff Feishu gave it a `thread_id`.
+ *
+ * Empirically (verified against live intake logs) `thread_id` is populated
+ * **only** when a message lives in a Feishu thread — both topic-group topics
+ * and "convert to topic" threads started inside a plain group carry an
+ * `omt_…` thread_id. Ordinary messages and quote-replies (which only carry
+ * `root_id` / `parent_id`) do not. So thread membership — not the chat's mode
+ * — is the right axis for session isolation: each thread becomes its own
+ * conversation (own session / cwd / pending queue), and everything else
+ * shares the chat-level session.
+ */
+export function isThreadedScope(threadId: string | undefined): threadId is string {
+  return Boolean(threadId);
+}
+
+/**
  * Compute the **session scope** for a message.
  *
- *  - **p2p / group**: scope = `chatId`. Replies in regular groups thread the
- *    UI but share the chat's session (matches user expectation).
- *  - **topic group**: scope = `${chatId}:${threadId}` — each topic is an
- *    independent conversation with its own session / cwd / pending queue.
- *    Topic-group top-level messages (no threadId, rare) fall back to chatId.
+ *  - **threaded** (topic-group topic, or a plain-group "convert to topic"
+ *    thread): scope = `${chatId}:${threadId}` — an independent conversation.
+ *  - **everything else** (p2p, plain group top-level, quote-reply): scope =
+ *    `chatId`. Quote-replies thread the UI but share the chat's session.
  *
- * Async because chat mode requires an API lookup (cached after first hit).
- * Callers typically await this once at intake/cardAction entry and pass
- * the resolved scope through.
+ * Async because chat mode requires an API lookup (cached after first hit);
+ * the mode is still resolved so callers can warm the cache, but scope keys
+ * off thread membership alone.
  */
 export async function scopeFor(
   channel: LarkChannel,
@@ -20,11 +35,9 @@ export async function scopeFor(
   threadId: string | undefined,
   cache: ChatModeCache,
 ): Promise<string> {
-  const mode = await cache.resolve(channel, chatId);
-  if (mode === 'topic' && threadId) {
-    return `${chatId}:${threadId}`;
-  }
-  return chatId;
+  // Resolve (and cache) chat mode so downstream consumers stay warm.
+  await cache.resolve(channel, chatId);
+  return isThreadedScope(threadId) ? `${chatId}:${threadId}` : chatId;
 }
 
 /** Convenience overload from a NormalizedMessage. */

--- a/src/bot/session-catalog-identity.ts
+++ b/src/bot/session-catalog-identity.ts
@@ -6,12 +6,10 @@ import { evaluateRunPolicy } from '../policy/run-policy';
 import { resolveWorkingDirectory } from '../policy/workspace';
 import type { SessionCatalogIdentity } from '../session/catalog';
 import type { WorkspaceStore } from '../workspace/store';
-import type { ChatMode } from './chat-mode-cache';
 
 export async function commandSessionCatalogIdentity(input: {
   msg: NormalizedMessage;
   scope: string;
-  mode: ChatMode;
   workspaces: WorkspaceStore;
   controls: Controls;
   access: AccessDecision;
@@ -30,7 +28,7 @@ export async function commandSessionCatalogIdentity(input: {
       source: 'im',
       chatId: input.msg.chatId,
       actorId: input.msg.senderId,
-      ...(input.mode === 'topic' && input.msg.threadId ? { threadId: input.msg.threadId } : {}),
+      ...(input.msg.threadId ? { threadId: input.msg.threadId } : {}),
     },
     attachments: [],
     prompt: '',

--- a/src/card/dispatcher.ts
+++ b/src/card/dispatcher.ts
@@ -99,7 +99,6 @@ export async function handleCardAction(deps: CardDispatchDeps): Promise<void> {
       sessionCatalogIdentity: await commandSessionCatalogIdentity({
         msg,
         scope,
-        mode,
         workspaces: deps.workspaces,
         controls: deps.controls,
         access: accessDecision,

--- a/tests/unit/bot/scope.test.ts
+++ b/tests/unit/bot/scope.test.ts
@@ -1,0 +1,89 @@
+import type { LarkChannel, NormalizedMessage } from '@larksuite/channel';
+import { describe, expect, it, vi } from 'vitest';
+import { ChatModeCache, type ChatMode } from '../../../src/bot/chat-mode-cache.js';
+import { isThreadedScope, scopeFor, scopeForMessage } from '../../../src/bot/scope.js';
+
+/** Minimal fake channel that only implements getChatMode, counting calls. */
+function fakeChannel(mode: ChatMode): {
+  channel: LarkChannel;
+  getChatMode: ReturnType<typeof vi.fn>;
+} {
+  const getChatMode = vi.fn(async () => mode);
+  return { channel: { getChatMode } as unknown as LarkChannel, getChatMode };
+}
+
+function msg(overrides: Partial<NormalizedMessage>): NormalizedMessage {
+  return {
+    messageId: 'om_1',
+    chatId: 'oc_chat',
+    chatType: 'group',
+    senderId: 'ou_sender',
+    content: 'hi',
+    rawContentType: 'text',
+    resources: [],
+    mentions: [],
+    mentionAll: false,
+    mentionedBot: false,
+    createTime: 0,
+    ...overrides,
+  };
+}
+
+describe('isThreadedScope', () => {
+  it('is true only when a thread_id is present', () => {
+    expect(isThreadedScope('omt_abc')).toBe(true);
+    expect(isThreadedScope(undefined)).toBe(false);
+    expect(isThreadedScope('')).toBe(false);
+  });
+});
+
+describe('scopeFor', () => {
+  it('isolates a "convert to topic" thread inside a plain group', async () => {
+    const { channel } = fakeChannel('group');
+    const scope = await scopeFor(channel, 'oc_chat', 'omt_abc', new ChatModeCache());
+    expect(scope).toBe('oc_chat:omt_abc');
+  });
+
+  it('shares the chat session for a quote-reply (no thread_id) in a plain group', async () => {
+    const { channel } = fakeChannel('group');
+    const scope = await scopeFor(channel, 'oc_chat', undefined, new ChatModeCache());
+    expect(scope).toBe('oc_chat');
+  });
+
+  it('shares the chat session for an ordinary plain-group message', async () => {
+    const { channel } = fakeChannel('group');
+    const scope = await scopeFor(channel, 'oc_chat', undefined, new ChatModeCache());
+    expect(scope).toBe('oc_chat');
+  });
+
+  it('keeps topic-group topics isolated (regression)', async () => {
+    const { channel } = fakeChannel('topic');
+    const scope = await scopeFor(channel, 'oc_chat', 'omt_xyz', new ChatModeCache());
+    expect(scope).toBe('oc_chat:omt_xyz');
+  });
+
+  it('uses chatId for p2p chats', async () => {
+    const { channel } = fakeChannel('p2p');
+    const scope = await scopeFor(channel, 'oc_dm', undefined, new ChatModeCache());
+    expect(scope).toBe('oc_dm');
+  });
+
+  it('warms the chat-mode cache once per chat (one API call)', async () => {
+    const { channel, getChatMode } = fakeChannel('group');
+    const cache = new ChatModeCache();
+    await scopeFor(channel, 'oc_chat', undefined, cache);
+    await scopeFor(channel, 'oc_chat', 'omt_abc', cache);
+    expect(getChatMode).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('scopeForMessage', () => {
+  it('derives scope from the message chatId/threadId', async () => {
+    const { channel } = fakeChannel('group');
+    const cache = new ChatModeCache();
+    expect(await scopeForMessage(channel, msg({ threadId: 'omt_abc' }), cache)).toBe(
+      'oc_chat:omt_abc',
+    );
+    expect(await scopeForMessage(channel, msg({}), cache)).toBe('oc_chat');
+  });
+});


### PR DESCRIPTION
## What

Session isolation now keys off Feishu **`thread_id` membership** rather than the chat's mode. A "convert to topic" thread started inside a *plain* group now gets its own session (own cwd / pending queue) and can run in parallel — while quote-replies and ordinary messages still share the chat-level session.

Previously the isolation check was `mode === 'topic' && threadId`, so a plain group's "convert to topic" thread was ignored and folded into the single chat-level session.

## Why

`thread_id` is the signal that uniquely identifies a Feishu thread. Verified against live intake:

| message type | thread_id | root_id | parent_id |
|---|:--:|:--:|:--:|
| convert to topic | ✅ `omt_…` | ✅ | ✅ |
| quote reply | ❌ | ✅ | ✅ |
| ordinary message | ❌ | ❌ | ❌ |

So keying on `thread_id` precisely targets threads with no collateral: convert-to-topic → isolated & parallel; quote-reply → still shares the chat session; ordinary → still shares.

## Changes

- **`scope.ts`**: add `isThreadedScope(threadId)`; `scopeFor` keys off `thread_id`, not chat mode.
- **`channel.ts`**: reuse `scopeForMessage` at intake; thread the bot reply for any threaded message (not just topic-group chats); treat a threaded message's `root_id` as topic structure, not a quote target.
- Remove now-dead `mode` plumbing from `commandSessionCatalogIdentity`, `runAgentBatch`, `replyQuoteTargetForMessage`, and callers.
- **`tests/unit/bot/scope.test.ts`** (new, 8 cases): `isThreadedScope` / `scopeFor` / `scopeForMessage` across topic, convert-to-topic, quote-reply, plain, p2p, and chat-mode cache warm-once.

## Verification

`tsc --noEmit` clean; `vitest run` green (full suite 520 passing locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)