### PR TITLE
feat: add OpenCode agent support

### DIFF
--- a/src/agent/capability.ts
+++ b/src/agent/capability.ts
@@ -2,8 +2,8 @@ import type { AccessMode } from '../config/permissions';
 import type { ProfileConfig } from '../config/profile-schema';
 import { BRIDGE_SYSTEM_PROMPT } from './bridge-system-prompt';
 
-export type AgentCapabilityId = 'claude' | 'codex';
-export type AgentSessionKind = 'claude-session' | 'codex-thread';
+export type AgentCapabilityId = 'claude' | 'codex' | 'opencode';
+export type AgentSessionKind = 'claude-session' | 'codex-thread' | 'opencode-session';
 export type PromptInjectionMode = 'append-system-prompt' | 'stdin-prefix';
 
 export interface AgentCapability {
@@ -47,6 +47,24 @@ export function codexCapability(profile: Pick<ProfileConfig, 'permissions'>): Ag
     promptInjection: 'stdin-prefix',
     systemPrompt: BRIDGE_SYSTEM_PROMPT,
     supportsNativeHistory: false,
+    callback: {
+      marker: '__bridge_cb',
+      legacyMarkers: [],
+    },
+    permissions: {
+      maxAccess,
+    },
+  };
+}
+
+export function opencodeCapability(profile?: Pick<ProfileConfig, 'permissions'>): AgentCapability {
+  const maxAccess = profile?.permissions.maxAccess ?? 'full';
+  return {
+    agentId: 'opencode',
+    sessionKind: 'opencode-session',
+    promptInjection: 'stdin-prefix',
+    systemPrompt: BRIDGE_SYSTEM_PROMPT,
+    supportsNativeHistory: true,
     callback: {
       marker: '__bridge_cb',
       legacyMarkers: [],

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,3 +1,4 @@
 export type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from './types';
 export { ClaudeAdapter } from './claude/adapter';
 export { CodexAdapter } from './codex/adapter';
+export { OpenCodeAdapter } from './opencode/adapter';

--- a/src/agent/opencode/adapter.ts
+++ b/src/agent/opencode/adapter.ts
@@ -1,0 +1,270 @@
+import { createInterface } from 'node:readline';
+import type { Readable, Writable } from 'node:stream';
+import { log } from '../../core/logger';
+import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
+import { SpawnFailed } from '../../runtime/errors';
+import { prefixBridgeSystemPrompt } from '../bridge-system-prompt';
+import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel-env';
+import { checkAgentAvailability, type AgentAvailability } from '../preflight';
+import type {
+  AgentAdapter,
+  AgentBotIdentity,
+  AgentEvent,
+  AgentRun,
+  AgentRunOptions,
+} from '../types';
+import { buildOpenCodeArgs } from './argv';
+import { OpenCodeJsonlTranslator, type OpenCodeFinishReason } from './jsonl';
+
+export interface OpenCodeAdapterOptions {
+  binary: string;
+  autoApprove?: boolean;
+  stopGraceMs?: number;
+  larkChannel?: LarkChannelEnvContext;
+}
+
+type OpenCodeChild = SpawnedProcessByStdio<Writable, Readable, Readable>;
+
+export class OpenCodeAdapter implements AgentAdapter {
+  readonly id = 'opencode';
+  readonly displayName = 'OpenCode';
+
+  private readonly binary: string;
+  private readonly autoApprove: boolean;
+  private readonly defaultStopGraceMs: number;
+  private readonly larkChannel: LarkChannelEnvContext | undefined;
+  private botIdentity: AgentBotIdentity | undefined;
+
+  constructor(opts: OpenCodeAdapterOptions) {
+    this.binary = opts.binary;
+    this.autoApprove = opts.autoApprove === true;
+    this.defaultStopGraceMs = opts.stopGraceMs ?? 5000;
+    this.larkChannel = opts.larkChannel;
+  }
+
+  setBotIdentity(identity: AgentBotIdentity): void {
+    this.botIdentity = identity;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return (await this.checkAvailability()).ok;
+  }
+
+  async checkAvailability(): Promise<AgentAvailability> {
+    return checkAgentAvailability({
+      agentId: 'opencode',
+      agentName: 'OpenCode',
+      command: this.binary,
+      binaryPath: this.binary,
+    });
+  }
+
+  async prepareRun(): Promise<void> {
+    const availability = await this.checkAvailability();
+    if (!availability.ok) {
+      throw new SpawnFailed(
+        'opencode binary check failed',
+        availability.error,
+        availability.diagnostic.code,
+        availability.diagnostic,
+      );
+    }
+  }
+
+  run(opts: AgentRunOptions): AgentRun {
+    if (!opts.cwd) {
+      throw new Error('cwd is required for OpenCodeAdapter.run');
+    }
+
+    const args = buildOpenCodeArgs({
+      cwd: opts.cwd,
+      sessionId: opts.sessionId,
+      autoApprove: this.autoApprove,
+    });
+    const child = spawnProcess(this.binary, args, {
+      cwd: opts.cwd,
+      env: mergeProcessEnv(process.env, buildLarkChannelEnv(this.larkChannel)),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }) as OpenCodeChild;
+
+    log.info('agent', 'spawn', {
+      pid: child.pid ?? null,
+      cwd: opts.cwd,
+      hasSession: Boolean(opts.sessionId),
+      promptChars: opts.prompt.length,
+    });
+
+    const stderrChunks: Buffer[] = [];
+    let runtimeError: Error | null = null;
+    let stderrBuffer = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+      stderrBuffer += chunk.toString('utf8');
+      let nl = stderrBuffer.indexOf('\n');
+      while (nl !== -1) {
+        const line = stderrBuffer.slice(0, nl);
+        stderrBuffer = stderrBuffer.slice(nl + 1);
+        if (line.trim()) log.warn('agent', 'stderr', { line });
+        if (isWindowsCommandNotFoundLine(line)) {
+          runtimeError = new Error(`failed to spawn opencode: ${line.trim()}`);
+          child.stdout.destroy();
+          child.kill();
+        }
+        nl = stderrBuffer.indexOf('\n');
+      }
+    });
+
+    let stopReason: OpenCodeFinishReason | undefined;
+    child.on('error', (err) => {
+      runtimeError = err;
+    });
+    child.on('exit', (code, signal) => {
+      log.info('agent', 'exit', { pid: child.pid ?? null, code, signal });
+    });
+    child.stdin.on('error', (err) => {
+      log.warn('agent', 'stdin-error', { message: err.message });
+    });
+    child.stdin.end(prefixBridgeSystemPrompt(opts.prompt, this.botIdentity), 'utf8');
+
+    const stopGraceMs = opts.stopGraceMs ?? this.defaultStopGraceMs;
+
+    return {
+      runId: opts.runId,
+      events: createEventStream(child, stderrChunks, () => runtimeError, () => stopReason),
+      async stop() {
+        if (child.exitCode !== null || child.signalCode !== null) return;
+        stopReason = 'interrupted';
+        log.info('agent', 'stop-sigterm', { pid: child.pid ?? null, graceMs: stopGraceMs });
+        child.kill('SIGTERM');
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            if (child.exitCode === null && child.signalCode === null) {
+              log.warn('agent', 'stop-sigkill', {
+                pid: child.pid ?? null,
+                graceMs: stopGraceMs,
+                reason: 'grace-period-expired',
+              });
+              child.kill('SIGKILL');
+            }
+            resolve();
+          }, stopGraceMs);
+          child.once('exit', () => {
+            clearTimeout(timer);
+            resolve();
+          });
+        });
+      },
+      waitForExit(timeoutMs: number): Promise<boolean> {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          return Promise.resolve(true);
+        }
+        return new Promise<boolean>((resolve) => {
+          const onExit = (): void => {
+            clearTimeout(timer);
+            resolve(true);
+          };
+          const timer = setTimeout(() => {
+            child.removeListener('exit', onExit);
+            resolve(false);
+          }, timeoutMs);
+          child.once('exit', onExit);
+        });
+      },
+    };
+  }
+}
+
+async function* createEventStream(
+  child: OpenCodeChild,
+  stderrChunks: Buffer[],
+  getError: () => Error | null,
+  getStopReason: () => OpenCodeFinishReason | undefined,
+): AsyncGenerator<AgentEvent> {
+  const translator = new OpenCodeJsonlTranslator();
+  if (!child.pid) {
+    const err = getError();
+    yield {
+      type: 'error',
+      message: err ? `failed to spawn opencode: ${err.message}` : 'spawn returned no pid',
+      terminationReason: 'failed',
+    };
+    return;
+  }
+
+  const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  let sawStdout = false;
+  let silentExitTimer: ReturnType<typeof setTimeout> | undefined;
+  const closeSilentStdout = (): void => {
+    silentExitTimer = setTimeout(() => {
+      if (!sawStdout && !child.stdout.readableEnded) child.stdout.destroy();
+    }, 50);
+  };
+  child.once('exit', closeSilentStdout);
+  try {
+    for await (const line of rl) {
+      sawStdout = true;
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      yield* translator.translate(parsed);
+    }
+  } finally {
+    if (silentExitTimer) clearTimeout(silentExitTimer);
+    child.removeListener('exit', closeSilentStdout);
+    rl.close();
+  }
+
+  const earlyRuntimeError = getError();
+  if (earlyRuntimeError && child.exitCode === null && child.signalCode === null) {
+    yield terminalError(`opencode runtime error: ${earlyRuntimeError.message}`);
+    return;
+  }
+
+  const exitCode = await waitForExitCode(child);
+  const stopReason = getStopReason();
+  if (stopReason) {
+    yield* translator.finish(stopReason);
+    return;
+  }
+
+  const runtimeError = getError();
+  if (exitCode !== 0 && exitCode !== null) {
+    if (!translator.terminalEmitted()) {
+      const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+      const detail = stderr ? `: ${stderr.slice(0, 500)}` : '';
+      yield terminalError(`opencode exited with code ${exitCode}${detail}`);
+    }
+    return;
+  }
+  if (runtimeError && !translator.terminalEmitted()) {
+    yield terminalError(`opencode runtime error: ${runtimeError.message}`);
+    return;
+  }
+
+  yield* translator.finish();
+}
+
+function terminalError(message: string): AgentEvent {
+  return {
+    type: 'error',
+    message,
+    terminationReason: 'failed',
+  };
+}
+
+function waitForExitCode(child: OpenCodeChild): Promise<number | null> {
+  if (child.exitCode !== null) return Promise.resolve(child.exitCode);
+  if (child.signalCode !== null) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    child.once('exit', (code) => resolve(code));
+  });
+}
+
+function isWindowsCommandNotFoundLine(line: string): boolean {
+  return /is not recognized as an internal or external command/i.test(line);
+}

--- a/src/agent/opencode/argv.ts
+++ b/src/agent/opencode/argv.ts
@@ -1,0 +1,17 @@
+export interface BuildOpenCodeArgsInput {
+  cwd: string;
+  sessionId?: string;
+  autoApprove?: boolean;
+}
+
+export function buildOpenCodeArgs(input: BuildOpenCodeArgsInput): string[] {
+  const args = ['run'];
+  if (input.sessionId) {
+    args.push('--session', input.sessionId);
+  }
+  if (input.autoApprove === true) {
+    args.push('--auto');
+  }
+  args.push('--format', 'json', '--dir', input.cwd, '-');
+  return args;
+}

--- a/src/agent/opencode/jsonl.ts
+++ b/src/agent/opencode/jsonl.ts
@@ -1,0 +1,138 @@
+import type { AgentEvent } from '../types';
+
+export type OpenCodeFinishReason = 'failed' | 'interrupted' | 'timeout';
+
+export class OpenCodeJsonlTranslator {
+  private sessionId: string | undefined;
+  private terminal = false;
+
+  translate(raw: unknown): AgentEvent[] {
+    if (this.terminal) return [];
+    if (!isRecord(raw) || typeof raw.type !== 'string') return [];
+    const sessionEvent = this.captureSessionId(raw);
+
+    switch (raw.type) {
+      case 'session.started':
+      case 'step_start':
+        return sessionEvent;
+      case 'text':
+        return [...sessionEvent, ...this.translateText(raw)];
+      case 'tool_use':
+        return [...sessionEvent, ...this.translateToolUse(raw)];
+      case 'tool_result':
+        return [...sessionEvent, ...this.translateToolResult(raw)];
+      case 'step_finish':
+        return [...sessionEvent, ...this.translateStepFinish(raw)];
+      default:
+        return sessionEvent;
+    }
+  }
+
+  finish(reason: OpenCodeFinishReason = 'failed'): AgentEvent[] {
+    if (this.terminal) return [];
+    this.terminal = true;
+    if (reason === 'failed') {
+      return [
+        {
+          type: 'error',
+          message: 'opencode stream ended before a terminal event',
+          terminationReason: 'failed',
+        },
+      ];
+    }
+    return [
+      {
+        type: 'done',
+        terminationReason: reason,
+        ...(this.sessionId ? { sessionId: this.sessionId } : {}),
+      },
+    ];
+  }
+
+  terminalEmitted(): boolean {
+    return this.terminal;
+  }
+
+  private captureSessionId(raw: Record<string, unknown>): AgentEvent[] {
+    const sessionId = stringValue(raw.session_id ?? raw.sessionId ?? raw.sessionID);
+    if (!sessionId || sessionId === this.sessionId) return [];
+    this.sessionId = sessionId;
+    return [{ type: 'system', sessionId }];
+  }
+
+  private translateText(raw: Record<string, unknown>): AgentEvent[] {
+    const text = stringValue(raw.text) ?? stringValue(recordValue(raw.part)?.text);
+    return text ? [{ type: 'text', delta: text }] : [];
+  }
+
+  private translateToolUse(raw: Record<string, unknown>): AgentEvent[] {
+    const part = recordValue(raw.part);
+    const tool = stringValue(raw.tool) ?? stringValue(part?.tool) ?? stringValue(part?.name);
+    if (!tool) return [];
+    const id =
+      stringValue(raw.callID ?? raw.callId ?? raw.id ?? part?.callID ?? part?.callId ?? part?.id) ??
+      tool;
+    const state = recordValue(raw.state) ?? recordValue(part?.state);
+    const input = raw.input ?? part?.input ?? state?.input ?? {};
+    const events: AgentEvent[] = [{ type: 'tool_use', id, name: tool, input }];
+
+    const status = stringValue(raw.status ?? part?.status ?? state?.status);
+    const output = stringValue(raw.output ?? part?.output ?? state?.output);
+    if (status === 'completed') {
+      events.push({
+        type: 'tool_result',
+        id,
+        output: output ?? fallbackToolOutput(state),
+        isError: false,
+      });
+    }
+    return events;
+  }
+
+  private translateToolResult(raw: Record<string, unknown>): AgentEvent[] {
+    const id = stringValue(raw.callID ?? raw.callId ?? raw.id);
+    if (!id) return [];
+    return [
+      {
+        type: 'tool_result',
+        id,
+        output: stringValue(raw.output) ?? '',
+        isError: raw.error === true,
+      },
+    ];
+  }
+
+  private translateStepFinish(raw: Record<string, unknown>): AgentEvent[] {
+    const part = recordValue(raw.part);
+    const reason = stringValue(raw.reason ?? part?.reason);
+    if (reason === 'tool-calls') return [];
+    this.terminal = true;
+    return [
+      {
+        type: 'done',
+        terminationReason: 'normal',
+        ...(this.sessionId ? { sessionId: this.sessionId } : {}),
+      },
+    ];
+  }
+}
+
+function fallbackToolOutput(state: Record<string, unknown> | undefined): string {
+  if (!state) return '';
+  const title = stringValue(state.title);
+  if (title) return title;
+  const metadata = recordValue(state.metadata);
+  return stringValue(metadata?.filepath) ?? '';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}

--- a/src/agent/preflight.ts
+++ b/src/agent/preflight.ts
@@ -1,6 +1,6 @@
 import { spawnProcess } from '../platform/spawn';
 
-export type LocalAgentId = 'claude' | 'codex';
+export type LocalAgentId = 'claude' | 'codex' | 'opencode';
 
 export type AgentPreflightErrorCode =
   | 'agent-binary-not-found'

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -5,7 +5,7 @@ import type {
 } from '@larksuite/channel';
 import { createLarkChannel } from '@larksuite/channel';
 import { dirname, join } from 'node:path';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { claudeCapability, codexCapability, opencodeCapability } from '../agent/capability';
 import { modelLabel, normalizeModelSelection, resolveModelArg } from '../agent/models';
 import {
   buildAgentPrompt,
@@ -856,6 +856,8 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
   const capability =
     controls.profileConfig.agentKind === 'codex'
       ? codexCapability(controls.profileConfig)
+      : controls.profileConfig.agentKind === 'opencode'
+        ? opencodeCapability(controls.profileConfig)
       : claudeCapability(controls.profileConfig);
   const flow = await startRunFlow({
     scopeId: scope,

--- a/src/bot/comments.ts
+++ b/src/bot/comments.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { CommentEvent, LarkChannel } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { claudeCapability, codexCapability, opencodeCapability } from '../agent/capability';
 import type { AgentAdapter, AgentEvent } from '../agent/types';
 import { getAgentStopGraceMs } from '../config/schema';
 import type { Controls } from '../commands';
@@ -189,6 +189,8 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
     const capability =
       controls.profileConfig.agentKind === 'codex'
         ? codexCapability(controls.profileConfig)
+        : controls.profileConfig.agentKind === 'opencode'
+          ? opencodeCapability(controls.profileConfig)
         : claudeCapability(controls.profileConfig);
     const runTimeoutMs = commentRunTimeoutMs(sessions, runScopeId);
     const threadTimeoutMs = commentRunTimeoutMs(sessions, commentThreadScopeId);

--- a/src/bot/run-flow.ts
+++ b/src/bot/run-flow.ts
@@ -120,7 +120,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
       cwdRealpath: workspace.cwdRealpath,
       policyFingerprint: policy.policyFingerprint,
     });
-    if (catalogEntry?.agentId === 'claude') {
+    if (catalogEntry?.agentId === 'claude' || catalogEntry?.agentId === 'opencode') {
       sessionId = catalogEntry.sessionId;
       resumeFrom = sessionId;
     } else if (catalogEntry?.agentId === 'codex') {
@@ -194,6 +194,17 @@ export function recordRunSessionEvent(input: RecordRunSessionEventInput): void {
     input.sessionCatalog?.upsertActive({
       scopeId: input.scopeId,
       agentId: 'claude',
+      cwdRealpath,
+      policyFingerprint: input.policy.policyFingerprint,
+      sessionId: input.event.sessionId,
+    });
+    return;
+  }
+  if (input.capability.agentId === 'opencode' && input.event.sessionId) {
+    const cwdRealpath = input.event.cwd ?? input.policy.cwdRealpath;
+    input.sessionCatalog?.upsertActive({
+      scopeId: input.scopeId,
+      agentId: 'opencode',
       cwdRealpath,
       policyFingerprint: input.policy.policyFingerprint,
       sessionId: input.event.sessionId,

--- a/src/bot/session-catalog-identity.ts
+++ b/src/bot/session-catalog-identity.ts
@@ -1,5 +1,5 @@
 import type { NormalizedMessage } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { claudeCapability, codexCapability, opencodeCapability } from '../agent/capability';
 import type { Controls } from '../commands';
 import type { AccessDecision } from '../policy/access';
 import { evaluateRunPolicy } from '../policy/run-policy';
@@ -24,6 +24,8 @@ export async function commandSessionCatalogIdentity(input: {
   const capability =
     input.controls.profileConfig.agentKind === 'codex'
       ? codexCapability(input.controls.profileConfig)
+      : input.controls.profileConfig.agentKind === 'opencode'
+        ? opencodeCapability(input.controls.profileConfig)
       : claudeCapability(input.controls.profileConfig);
   const policy = evaluateRunPolicy({
     scope: {

--- a/src/cli/agent-detection.ts
+++ b/src/cli/agent-detection.ts
@@ -2,7 +2,7 @@ import { constants } from 'node:fs';
 import { access } from 'node:fs/promises';
 import { delimiter, extname, isAbsolute, join } from 'node:path';
 
-export type AgentKind = 'claude' | 'codex';
+export type AgentKind = 'claude' | 'codex' | 'opencode';
 
 export interface DetectedAgent {
   kind: AgentKind;
@@ -48,6 +48,7 @@ export async function detectInstalledAgents(): Promise<DetectedAgent[]> {
   const candidates: Array<{ kind: AgentKind; command: string }> = [
     { kind: 'claude', command: process.env.LARK_CHANNEL_CLAUDE_BIN ?? 'claude' },
     { kind: 'codex', command: process.env.LARK_CHANNEL_CODEX_BIN ?? 'codex' },
+    { kind: 'opencode', command: process.env.LARK_CHANNEL_OPENCODE_BIN ?? 'opencode' },
   ];
   const detected: DetectedAgent[] = [];
   for (const candidate of candidates) {

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, readdir, rename, rm, stat } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { createBootstrapCodexConfig } from '../profile-bootstrap';
+import { createBootstrapCodexConfig, createBootstrapOpenCodeConfig } from '../profile-bootstrap';
 import { promptLine } from '../prompt';
 import { stopProcessEntry } from './ps';
 import {
@@ -43,7 +43,9 @@ export async function runMigrate(opts: MigrateOptions): Promise<void> {
   const configPath = opts.config ?? paths.configFile;
   await migrateLegacyPaths();
   await migrateConfigShape(configPath);
-  const agentKind = agentKindFromString(opts.agent) ?? (opts.profile === 'codex' ? 'codex' : undefined);
+  const agentKind =
+    agentKindFromString(opts.agent) ??
+    (opts.profile === 'codex' || opts.profile === 'opencode' ? opts.profile : undefined);
   const needsV2Migration = await hasLegacyProfileConfig(configPath);
   const result = await migrateProfileV2WithActiveBridgePrompt({
     rootDir: dirname(configPath),
@@ -52,6 +54,9 @@ export async function runMigrate(opts: MigrateOptions): Promise<void> {
     ...(agentKind ? { agentKind } : {}),
     ...(needsV2Migration && agentKind === 'codex'
       ? { codex: await createBootstrapCodexConfig(undefined) }
+      : {}),
+    ...(needsV2Migration && agentKind === 'opencode'
+      ? { opencode: await createBootstrapOpenCodeConfig(undefined) }
       : {}),
   }, opts);
   if (!result) return;

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -469,7 +469,7 @@ async function maybeResolveProfileRuntime(
 }
 
 function agentDisplay(agentKind: ProcessEntry['agentKind']): { id: string; displayName: string } {
-  return agentKind === 'codex'
-    ? { id: 'codex', displayName: 'Codex CLI' }
-    : { id: 'claude', displayName: 'Claude Code' };
+  if (agentKind === 'codex') return { id: 'codex', displayName: 'Codex CLI' };
+  if (agentKind === 'opencode') return { id: 'opencode', displayName: 'OpenCode' };
+  return { id: 'claude', displayName: 'Claude Code' };
 }

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -4,6 +4,7 @@ import { createInterface } from 'node:readline';
 import pkg from '../../../package.json';
 import { ClaudeAdapter } from '../../agent/claude/adapter';
 import { CodexAdapter } from '../../agent/codex/adapter';
+import { OpenCodeAdapter } from '../../agent/opencode/adapter';
 import {
   AgentPreflightError,
   formatAgentPreflightDiagnostic,
@@ -431,6 +432,17 @@ export function createRuntimeAgent(
       ignoreUserConfig: codex.ignoreUserConfig === true,
       ignoreRules: codex.ignoreRules !== false,
       sandbox: profileConfig.sandbox.defaultMode,
+      larkChannel,
+    });
+  }
+  if (profileConfig.agentKind === 'opencode') {
+    const opencode = profileConfig.opencode;
+    if (!opencode?.binaryPath) {
+      throw new Error('opencode profile requires opencode.binaryPath');
+    }
+    return new OpenCodeAdapter({
+      binary: opencode.binaryPath,
+      autoApprove: opencode.autoApprove === true,
       larkChannel,
     });
   }

--- a/src/cli/profile-bootstrap.ts
+++ b/src/cli/profile-bootstrap.ts
@@ -14,6 +14,7 @@ export interface BootstrapProfileInput {
   workspace?: string;
   defaultWorkspace?: string;
   codexBinaryPath?: string;
+  opencodeBinaryPath?: string;
   profileDir?: string;
 }
 
@@ -29,12 +30,17 @@ export async function createBootstrapProfileConfig(
     input.agentKind === 'codex'
       ? await createBootstrapCodexConfig(input.codexBinaryPath)
       : undefined;
+  const opencode =
+    input.agentKind === 'opencode'
+      ? await createBootstrapOpenCodeConfig(input.opencodeBinaryPath)
+      : undefined;
   const profile = createDefaultProfileConfig({
     agentKind: input.agentKind,
     accounts: input.accounts,
     preferences: input.preferences,
     secrets: input.secrets,
     ...(codex ? { codex } : {}),
+    ...(opencode ? { opencode } : {}),
   });
   if (workspace) {
     profile.workspaces = {
@@ -78,10 +84,36 @@ export async function createBootstrapCodexConfig(binaryPath: string | undefined)
   return { binaryPath: resolvedBinary };
 }
 
+export async function createBootstrapOpenCodeConfig(binaryPath: string | undefined) {
+  const command = binaryPath ?? process.env.LARK_CHANNEL_OPENCODE_BIN ?? 'opencode';
+  let resolvedBinary: string;
+  try {
+    resolvedBinary = await resolveExecutablePath(command);
+  } catch (err) {
+    const errno = (err as NodeJS.ErrnoException).code;
+    throw new AgentPreflightError({
+      code: codexBootstrapBinaryErrorCode(errno),
+      agentId: 'opencode',
+      agentName: 'OpenCode',
+      command,
+      binaryPath: command,
+      errno,
+    });
+  }
+  return {
+    binaryPath: resolvedBinary,
+    autoApprove: envFlag(process.env.LARK_CHANNEL_OPENCODE_AUTO_APPROVE),
+  };
+}
+
 function codexBootstrapBinaryErrorCode(errno: string | undefined) {
   if (errno === 'EACCES' || errno === 'EPERM') return 'agent-binary-not-executable';
   if (errno === 'ELOOP' || errno === 'ENOTDIR' || errno === 'EINVAL') {
     return 'agent-binary-resolve-failed';
   }
   return 'agent-binary-not-found';
+}
+
+function envFlag(value: string | undefined): boolean {
+  return value === '1' || value?.toLowerCase() === 'true' || value?.toLowerCase() === 'yes';
 }

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute } from 'node:path';
 import type { LarkChannel, NormalizedMessage } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { claudeCapability, codexCapability, opencodeCapability } from '../agent/capability';
 import { DEFAULT_MODEL, normalizeModelSelection, supportedModels } from '../agent/models';
 import type { AgentAdapter } from '../agent/types';
 import type { ActiveRuns } from '../bot/active-runs';
@@ -146,7 +146,7 @@ type Handler = (args: string, ctx: CommandContext) => Promise<void>;
 
 interface ResumeCandidate {
   scopeId: string;
-  agentId: 'claude' | 'codex';
+  agentId: 'claude' | 'codex' | 'opencode';
   cwdRealpath: string;
   policyFingerprint: string;
   sessionId?: string;
@@ -581,6 +581,25 @@ async function handleResume(args: string, ctx: CommandContext): Promise<void> {
     return;
   }
 
+  if (ctx.controls.profileConfig.agentKind === 'opencode') {
+    const identity = ctx.sessionCatalogIdentity;
+    const entry =
+      ctx.sessionCatalog && identity
+        ? ctx.sessionCatalog.activeFor(identity)
+        : undefined;
+    if (entry?.sessionId && identity) {
+      const nonce = issueResumeCandidate(identity, { sessionId: entry.sessionId });
+      await reply(
+        ctx,
+        `当前 OpenCode session 可恢复。\n使用 \`/resume use ${nonce}\` 恢复（10 分钟内有效）。`,
+      );
+      return;
+    }
+    const card = resumeCard(cwd, []);
+    await ctx.channel.send(ctx.msg.chatId, { card }, commandReplyOptions(ctx));
+    return;
+  }
+
   const sessions = await listClaudeResumeHistory(ctx, cwd, limit);
   const currentSession = ctx.sessions.getRaw(ctx.scope);
   const identity = ctx.sessionCatalogIdentity;
@@ -615,12 +634,14 @@ async function applyResume(sessionId: string, ctx: CommandContext): Promise<void
       } else {
         ctx.sessionCatalog.upsertActive({
           scopeId: ctx.sessionCatalogIdentity.scopeId,
-          agentId: 'claude',
+          agentId: ctx.sessionCatalogIdentity.agentId,
           cwdRealpath: ctx.sessionCatalogIdentity.cwdRealpath,
           policyFingerprint: ctx.sessionCatalogIdentity.policyFingerprint,
           sessionId: resolved.sessionId!,
         });
-        ctx.sessions.set(ctx.scope, resolved.sessionId!, ctx.sessionCatalogIdentity.cwdRealpath);
+        if (ctx.sessionCatalogIdentity.agentId === 'claude') {
+          ctx.sessions.set(ctx.scope, resolved.sessionId!, ctx.sessionCatalogIdentity.cwdRealpath);
+        }
       }
       await reply(ctx, RESUME_APPLIED_REPLY);
       return;
@@ -644,6 +665,10 @@ async function applyResume(sessionId: string, ctx: CommandContext): Promise<void
 
   if (ctx.controls.profileConfig.agentKind === 'codex') {
     await reply(ctx, '当前上下文没有可恢复的 Codex thread，请先在当前工作区完成一次运行。');
+    return;
+  }
+  if (ctx.controls.profileConfig.agentKind === 'opencode') {
+    await reply(ctx, '当前上下文没有可恢复的 OpenCode session，请先在当前工作区完成一次运行。');
     return;
   }
 
@@ -688,7 +713,7 @@ function consumeResumeCandidate(
     candidate.agentId !== identity.agentId ||
     candidate.cwdRealpath !== identity.cwdRealpath ||
     candidate.policyFingerprint !== identity.policyFingerprint ||
-    (identity.agentId === 'claude' && !candidate.sessionId) ||
+    ((identity.agentId === 'claude' || identity.agentId === 'opencode') && !candidate.sessionId) ||
     (identity.agentId === 'codex' && !candidate.threadId)
   ) {
     return undefined;
@@ -802,16 +827,17 @@ async function handleStatus(_args: string, ctx: CommandContext): Promise<void> {
   const cwd = effectiveWorkspaceCwd(ctx);
   const sess = ctx.sessions.getRaw(ctx.scope);
   const isCodex = ctx.controls.profileConfig.agentKind === 'codex';
+  const isOpenCode = ctx.controls.profileConfig.agentKind === 'opencode';
   const catalogEntry =
-    isCodex && ctx.sessionCatalog && ctx.sessionCatalogIdentity
+    (isCodex || isOpenCode) && ctx.sessionCatalog && ctx.sessionCatalogIdentity
       ? ctx.sessionCatalog.activeFor(ctx.sessionCatalogIdentity)
       : undefined;
   const card = statusCard({
     profileName: ctx.controls.profile,
     cwd,
-    sessionId: isCodex ? catalogEntry?.threadId : sess?.sessionId,
-    emptySessionText: isCodex ? '(未建立)' : undefined,
-    sessionStale: !isCodex && Boolean(cwd && sess && sess.cwd !== cwd),
+    sessionId: isCodex ? catalogEntry?.threadId : isOpenCode ? catalogEntry?.sessionId : sess?.sessionId,
+    emptySessionText: isCodex || isOpenCode ? '(未建立)' : undefined,
+    sessionStale: !isCodex && !isOpenCode && Boolean(cwd && sess && sess.cwd !== cwd),
     agentName: ctx.agent.displayName,
     runtimeAccess: runtimeAccessStatus(ctx.controls.profileConfig),
     larkCliStatus: await larkCliStatus(ctx),
@@ -1119,6 +1145,8 @@ async function handleDoctor(args: string, ctx: CommandContext): Promise<void> {
   const capability =
     ctx.controls.profileConfig.agentKind === 'codex'
       ? codexCapability(ctx.controls.profileConfig)
+      : ctx.controls.profileConfig.agentKind === 'opencode'
+        ? opencodeCapability(ctx.controls.profileConfig)
       : claudeCapability(ctx.controls.profileConfig);
   const policy = evaluateRunPolicy({
     scope: {

--- a/src/config/migrate-v2.ts
+++ b/src/config/migrate-v2.ts
@@ -13,6 +13,7 @@ import {
   createDefaultProfileConfig,
   type AgentKind,
   type CodexConfig,
+  type OpenCodeConfig,
   type RootConfig,
 } from './profile-schema';
 import { markPermissionDefaultsMigration, saveRootConfig } from './profile-store';
@@ -27,6 +28,7 @@ export interface MigrateV2Options {
   workspace?: string;
   agentKind?: AgentKind;
   codex?: CodexConfig;
+  opencode?: OpenCodeConfig;
 }
 
 export interface MigrateV2Result {
@@ -129,6 +131,7 @@ export async function migrateV1ToV2(opts: MigrateV2Options = {}): Promise<Migrat
       requireMentionInGroup: legacy.preferences?.requireMentionInGroup,
     },
     ...(agentKind === 'codex' && opts.codex ? { codex: opts.codex } : {}),
+    ...(agentKind === 'opencode' && opts.opencode ? { opencode: opts.opencode } : {}),
   });
   if (legacyDefaultWorkspace) {
     profileConfig.workspaces = {
@@ -200,7 +203,9 @@ function activeProcessFromRegistryEntry(entry: RegistryEntry): ActiveBridgeMigra
   if (typeof entry.appId === 'string') active.appId = entry.appId;
   if (typeof entry.tenant === 'string') active.tenant = entry.tenant;
   if (typeof entry.profileName === 'string') active.profileName = entry.profileName;
-  if (entry.agentKind === 'claude' || entry.agentKind === 'codex') active.agentKind = entry.agentKind;
+  if (entry.agentKind === 'claude' || entry.agentKind === 'codex' || entry.agentKind === 'opencode') {
+    active.agentKind = entry.agentKind;
+  }
   if (typeof entry.configPath === 'string') active.configPath = entry.configPath;
   if (typeof entry.startedAt === 'string') active.startedAt = entry.startedAt;
   if (typeof entry.version === 'string') active.version = entry.version;

--- a/src/config/profile-schema.ts
+++ b/src/config/profile-schema.ts
@@ -13,7 +13,7 @@ import {
   type PermissionSource,
 } from './permissions';
 
-export type AgentKind = 'claude' | 'codex';
+export type AgentKind = 'claude' | 'codex' | 'opencode';
 export type SandboxMode = CodexSandboxMode;
 export type { AccessMode, PermissionConfig, PermissionSource };
 
@@ -42,6 +42,11 @@ export interface CodexConfig {
   inheritCodexHome?: boolean;
   ignoreUserConfig?: boolean;
   ignoreRules?: boolean;
+}
+
+export interface OpenCodeConfig {
+  binaryPath: string;
+  autoApprove?: boolean;
 }
 
 export interface AttachmentConfig {
@@ -90,6 +95,7 @@ export interface ProfileConfig {
   permissions: PermissionConfig;
   permissionSource?: PermissionSource;
   codex?: CodexConfig;
+  opencode?: OpenCodeConfig;
   attachments: AttachmentConfig;
   comments: CommentConfig;
   larkCli: LarkCliConfig;
@@ -116,6 +122,7 @@ export interface CreateDefaultProfileConfigInput {
   sandbox?: Partial<SandboxConfig>;
   permissions?: Partial<PermissionConfig>;
   codex?: CodexConfig;
+  opencode?: OpenCodeConfig;
   secrets?: SecretsConfig;
 }
 
@@ -150,6 +157,7 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
     sandbox?: Partial<SandboxConfig>;
     permissions?: Partial<PermissionConfig>;
     codex?: CodexConfig & { flags?: unknown };
+    opencode?: OpenCodeConfig;
     attachments?: Partial<AttachmentConfig>;
     comments?: unknown;
     larkCli?: unknown;
@@ -158,12 +166,15 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
   if (raw.schemaVersion !== 2) {
     throw new Error('profile schemaVersion must be 2');
   }
-  if (raw.agentKind !== 'claude' && raw.agentKind !== 'codex') {
-    throw new Error('agentKind must be claude or codex');
+  if (raw.agentKind !== 'claude' && raw.agentKind !== 'codex' && raw.agentKind !== 'opencode') {
+    throw new Error('agentKind must be claude, codex, or opencode');
   }
   const accounts = normalizeAccounts(raw.accounts);
   if (raw.agentKind === 'codex' && !raw.codex) {
     throw new Error('codex profile requires codex configuration');
+  }
+  if (raw.agentKind === 'opencode' && !raw.opencode) {
+    throw new Error('opencode profile requires opencode configuration');
   }
 
   const preferences = normalizePreferences(raw.preferences);
@@ -192,6 +203,7 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
     permissions,
     permissionSource,
     ...(raw.codex ? { codex: normalizeCodex(raw.codex) } : {}),
+    ...(raw.opencode ? { opencode: normalizeOpenCode(raw.opencode) } : {}),
     attachments: {
       maxCount: numberOr(raw.attachments?.maxCount, 10),
       maxBytes: numberOr(raw.attachments?.maxBytes, 100 * 1024 * 1024),
@@ -283,6 +295,13 @@ function normalizeCodex(input: CodexConfig & { flags?: unknown }): CodexConfig {
     ignoreRules: input.ignoreRules !== false,
   };
   return codex;
+}
+
+function normalizeOpenCode(input: OpenCodeConfig): OpenCodeConfig {
+  return {
+    binaryPath: input.binaryPath,
+    autoApprove: input.autoApprove === true,
+  };
 }
 
 function normalizeComments(_input: unknown): CommentConfig {

--- a/src/config/profile-store.ts
+++ b/src/config/profile-store.ts
@@ -56,6 +56,7 @@ type StoredProfileConfig = Pick<
   | 'workspaces'
   | 'permissions'
   | 'codex'
+  | 'opencode'
   | 'attachments'
   | 'comments'
   | 'larkCli'
@@ -93,6 +94,7 @@ function serializeProfileConfig(profile: ProfileConfig): StoredProfileConfig {
     workspaces: profile.workspaces,
     permissions: profile.permissions,
     ...(profile.codex ? { codex: profile.codex } : {}),
+    ...(profile.opencode ? { opencode: profile.opencode } : {}),
     attachments: profile.attachments,
     comments: {},
     larkCli: profile.larkCli,
@@ -292,7 +294,7 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 export function agentKindFromString(value: string | undefined): AgentKind | undefined {
-  if (value === 'claude' || value === 'codex') return value;
+  if (value === 'claude' || value === 'codex' || value === 'opencode') return value;
   if (value === undefined) return undefined;
   throw new Error(`unsupported agent: ${value}`);
 }

--- a/src/runtime/locks.ts
+++ b/src/runtime/locks.ts
@@ -178,7 +178,7 @@ function isRuntimeLockMeta(value: unknown): value is RuntimeLockMeta {
     (meta.kind === 'profile' || meta.kind === 'app') &&
     typeof meta.target === 'string' &&
     typeof meta.profile === 'string' &&
-    (meta.agentKind === 'claude' || meta.agentKind === 'codex') &&
+    (meta.agentKind === 'claude' || meta.agentKind === 'codex' || meta.agentKind === 'opencode') &&
     typeof meta.pid === 'number' &&
     typeof meta.startedAt === 'string' &&
     (meta.appId === undefined || typeof meta.appId === 'string')

--- a/src/runtime/profile-runtime.ts
+++ b/src/runtime/profile-runtime.ts
@@ -5,6 +5,7 @@ import { runRegistrationWizard } from '../bot/wizard';
 import { detectInstalledAgents, type DetectedAgent } from '../cli/agent-detection';
 import {
   createBootstrapCodexConfig,
+  createBootstrapOpenCodeConfig,
   createBootstrapProfileConfig,
   resolveBootstrapWorkspace,
 } from '../cli/profile-bootstrap';
@@ -90,6 +91,14 @@ export function createRuntimeProfileConfig(
     ...(input.agentKind === 'codex'
       ? { codex: input.codex ?? { binaryPath: process.env.LARK_CHANNEL_CODEX_BIN ?? 'codex' } }
       : {}),
+    ...(input.agentKind === 'opencode'
+      ? {
+          opencode: input.opencode ?? {
+            binaryPath: process.env.LARK_CHANNEL_OPENCODE_BIN ?? 'opencode',
+            autoApprove: envFlag(process.env.LARK_CHANNEL_OPENCODE_AUTO_APPROVE),
+          },
+        }
+      : {}),
   });
 }
 
@@ -137,6 +146,9 @@ export async function resolveProfileRuntime(
     ...(migrationAgent ? { agentKind: migrationAgent } : {}),
     ...(needsMigration && migrationAgent === 'codex'
       ? { codex: await createBootstrapCodexConfig(undefined) }
+      : {}),
+    ...(needsMigration && migrationAgent === 'opencode'
+      ? { opencode: await createBootstrapOpenCodeConfig(undefined) }
       : {}),
   }, opts.handleActiveBridgeMigrationConflict);
 
@@ -395,7 +407,7 @@ function resolveBootstrapAgent(
   requestedAgent: AgentKind | undefined,
   profile: string | undefined,
 ): AgentKind | undefined {
-  return requestedAgent ?? (profile === 'codex' ? 'codex' : undefined);
+  return requestedAgent ?? (profile === 'codex' || profile === 'opencode' ? profile : undefined);
 }
 
 async function hasLegacyConfig(configPath: string): Promise<boolean> {
@@ -568,7 +580,7 @@ function formatAmbiguousAgentSelectionError(
 ): string {
   const lines = detected.map((agent) => `  - ${agent.kind}: ${agent.binaryPath}`);
   return [
-    '检测到多个本地 agent，请使用 --agent <claude|codex> 指定要初始化哪一个。',
+    '检测到多个本地 agent，请使用 --agent <claude|codex|opencode> 指定要初始化哪一个。',
     '已检测到：',
     ...lines,
   ].join('\n');
@@ -613,7 +625,9 @@ class UserCancelledError extends Error {
 }
 
 function displayAgentKind(kind: AgentKind): string {
-  return kind === 'claude' ? 'Claude Code' : 'Codex CLI';
+  if (kind === 'claude') return 'Claude Code';
+  if (kind === 'codex') return 'Codex CLI';
+  return 'OpenCode';
 }
 
 async function maybeMigrateRootPlaintextSecret(
@@ -731,4 +745,8 @@ function needsProviderRewrite(cfg: AppConfig, wrapperPath: string): boolean {
   if (provider.command !== wrapperPath) return true;
   if (!Array.isArray(provider.args) || provider.args.length !== 0) return true;
   return false;
+}
+
+function envFlag(value: string | undefined): boolean {
+  return value === '1' || value?.toLowerCase() === 'true' || value?.toLowerCase() === 'yes';
 }

--- a/src/runtime/registry.ts
+++ b/src/runtime/registry.ts
@@ -64,7 +64,7 @@ function isValidEntry(e: unknown): e is ProcessEntry {
     typeof x.appId === 'string' &&
     (x.tenant === 'feishu' || x.tenant === 'lark') &&
     typeof x.profileName === 'string' &&
-    (x.agentKind === 'claude' || x.agentKind === 'codex') &&
+    (x.agentKind === 'claude' || x.agentKind === 'codex' || x.agentKind === 'opencode') &&
     typeof x.configPath === 'string' &&
     typeof x.startedAt === 'string' &&
     typeof x.version === 'string'

--- a/src/session/catalog.ts
+++ b/src/session/catalog.ts
@@ -214,7 +214,7 @@ function normalizeEntry(input: unknown): SessionCatalogEntry | undefined {
   if (
     typeof raw.key !== 'string' ||
     typeof raw.scopeId !== 'string' ||
-    (raw.agentId !== 'claude' && raw.agentId !== 'codex') ||
+    (raw.agentId !== 'claude' && raw.agentId !== 'codex' && raw.agentId !== 'opencode') ||
     typeof raw.cwdRealpath !== 'string' ||
     typeof raw.policyFingerprint !== 'string' ||
     (raw.status !== 'active' && raw.status !== 'archived') ||
@@ -247,14 +247,16 @@ function matchesIdentity(entry: SessionCatalogEntry, input: SessionCatalogIdenti
 }
 
 function isValidAgentEntry(entry: SessionCatalogEntry): boolean {
-  if (entry.agentId === 'claude') return Boolean(entry.sessionId) && !entry.threadId;
+  if (entry.agentId === 'claude' || entry.agentId === 'opencode') {
+    return Boolean(entry.sessionId) && !entry.threadId;
+  }
   return Boolean(entry.threadId) && !entry.sessionId;
 }
 
 function assertAgentIdentity(input: UpsertSessionCatalogInput): void {
-  if (input.agentId === 'claude') {
+  if (input.agentId === 'claude' || input.agentId === 'opencode') {
     if (!input.sessionId || input.threadId) {
-      throw new Error('Claude catalog entries require sessionId and must not include threadId');
+      throw new Error(`${input.agentId} catalog entries require sessionId and must not include threadId`);
     }
     return;
   }

--- a/tests/process/opencode-adapter.test.ts
+++ b/tests/process/opencode-adapter.test.ts
@@ -1,0 +1,200 @@
+import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { OpenCodeAdapter } from '../../src/agent/opencode/adapter.js';
+import { buildOpenCodeArgs } from '../../src/agent/opencode/argv.js';
+import type { AgentEvent } from '../../src/agent/types.js';
+
+interface FakeBinary {
+  path: string;
+  dir: string;
+  recordPath: string;
+}
+
+describe('OpenCodeAdapter process contract', () => {
+  const cleanup: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      cleanup.splice(0).map((dir) =>
+        rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 25 }),
+      ),
+    );
+  });
+
+  it('spawns a JSON run with prompt on stdin and bridge env injected', async () => {
+    const fake = await createFakeOpenCode({
+      lines: [
+        { type: 'step_start', sessionID: 'ses_fresh' },
+        { type: 'text', part: { text: 'hello user' } },
+        { type: 'step_finish', reason: 'stop' },
+      ],
+    });
+    cleanup.push(fake.dir);
+    const cwd = await realpath(fake.dir);
+    const rootDir = join(fake.dir, 'channel-home');
+    const larkCliConfigDir = join(rootDir, 'profiles', 'opencode', 'lark-cli');
+
+    const run = new OpenCodeAdapter({
+      binary: fake.path,
+      larkChannel: {
+        profile: 'opencode',
+        rootDir,
+        larkCliConfigDir,
+      },
+    }).run({
+      runId: 'run-fresh',
+      prompt: 'hello from lark',
+      cwd,
+    });
+
+    expect(await collect(run.events)).toEqual([
+      { type: 'system', sessionId: 'ses_fresh' },
+      { type: 'text', delta: 'hello user' },
+      { type: 'done', terminationReason: 'normal', sessionId: 'ses_fresh' },
+    ]);
+    const record = await readRecord(fake.recordPath);
+
+    expect(await realpath(record.cwd)).toBe(cwd);
+    expect(record.argv).toEqual(buildOpenCodeArgs({ cwd }));
+    expect(record.argv).not.toContain('--auto');
+    expect(record.argv).not.toContain('hello from lark');
+    expect(record.stdin).toContain('lark-channel-bridge 运行约定');
+    expect(record.stdin).toContain('__bridge_cb');
+    expect(record.stdin).toContain('hello from lark');
+    expect(record.env).toMatchObject({
+      LARK_CHANNEL: '1',
+      LARK_CHANNEL_PROFILE: 'opencode',
+      LARK_CHANNEL_HOME: rootDir,
+      LARKSUITE_CLI_CONFIG_DIR: larkCliConfigDir,
+    });
+  });
+
+  it('passes resume session and opt-in auto approval through argv', async () => {
+    const fake = await createFakeOpenCode({
+      lines: [{ type: 'step_finish', reason: 'stop' }],
+    });
+    cleanup.push(fake.dir);
+    const cwd = await realpath(fake.dir);
+
+    const run = new OpenCodeAdapter({ binary: fake.path, autoApprove: true }).run({
+      runId: 'run-resume',
+      prompt: 'continue',
+      cwd,
+      sessionId: 'ses_old',
+    });
+
+    await collect(run.events);
+    const record = await readRecord(fake.recordPath);
+    expect(record.argv).toEqual(
+      buildOpenCodeArgs({ cwd, sessionId: 'ses_old', autoApprove: true }),
+    );
+  });
+
+  it('includes stderr when the process exits non-zero before a terminal event', async () => {
+    const fake = await createFakeOpenCode({
+      lines: [{ type: 'text', part: { text: 'before failure' } }],
+      stderr: 'boom\n',
+      exitCode: 42,
+    });
+    cleanup.push(fake.dir);
+
+    const run = new OpenCodeAdapter({ binary: fake.path }).run({
+      runId: 'run-fail',
+      prompt: 'fail',
+      cwd: await realpath(fake.dir),
+    });
+
+    expect(await collect(run.events)).toEqual([
+      { type: 'text', delta: 'before failure' },
+      {
+        type: 'error',
+        message: 'opencode exited with code 42: boom',
+        terminationReason: 'failed',
+      },
+    ]);
+  });
+
+  it('requires cwd to be resolved by policy before spawning', () => {
+    expect(() =>
+      new OpenCodeAdapter({ binary: 'unused' }).run({
+        runId: 'run-no-cwd',
+        prompt: 'hi',
+      }),
+    ).toThrow(/cwd is required/);
+  });
+});
+
+async function collect(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const out: AgentEvent[] = [];
+  for await (const event of events) out.push(event);
+  return out;
+}
+
+async function createFakeOpenCode(options: {
+  lines: unknown[];
+  stderr?: string;
+  exitCode?: number;
+}): Promise<FakeBinary> {
+  const dir = await mkdtemp(join(tmpdir(), 'opencode-adapter-test-'));
+  const path = join(dir, 'fake-opencode.mjs');
+  const recordPath = join(dir, 'argv.json');
+  await writeFile(
+    path,
+    [
+      '#!/usr/bin/env node',
+      'import { writeFileSync } from "node:fs";',
+      'let stdin = "";',
+      'process.stdin.setEncoding("utf8");',
+      'process.stdin.on("data", (chunk) => { stdin += chunk; });',
+      'process.stdin.on("end", () => {',
+      `  writeFileSync(${JSON.stringify(recordPath)}, JSON.stringify({`,
+      '    argv: process.argv.slice(2),',
+      '    cwd: process.cwd(),',
+      '    stdin,',
+      '    env: {',
+      '      LARK_CHANNEL: process.env.LARK_CHANNEL,',
+      '      LARK_CHANNEL_PROFILE: process.env.LARK_CHANNEL_PROFILE,',
+      '      LARK_CHANNEL_HOME: process.env.LARK_CHANNEL_HOME,',
+      '      LARK_CHANNEL_CONFIG: process.env.LARK_CHANNEL_CONFIG,',
+      '      LARKSUITE_CLI_CONFIG_DIR: process.env.LARKSUITE_CLI_CONFIG_DIR,',
+      '    },',
+      '  }));',
+      `  const lines = ${JSON.stringify(options.lines)};`,
+      '  for (const line of lines) console.log(JSON.stringify(line));',
+      options.stderr ? `  process.stderr.write(${JSON.stringify(options.stderr)});` : '',
+      `  process.exit(${options.exitCode ?? 0});`,
+      '});',
+    ].filter(Boolean).join('\n'),
+    'utf8',
+  );
+  await chmod(path, 0o755);
+  return { path, dir, recordPath };
+}
+
+async function readRecord(path: string): Promise<{
+  argv: string[];
+  cwd: string;
+  stdin: string;
+  env: {
+    LARK_CHANNEL?: string;
+    LARK_CHANNEL_PROFILE?: string;
+    LARK_CHANNEL_HOME?: string;
+    LARK_CHANNEL_CONFIG?: string;
+    LARKSUITE_CLI_CONFIG_DIR?: string;
+  };
+}> {
+  return JSON.parse(await readFile(path, 'utf8')) as {
+    argv: string[];
+    cwd: string;
+    stdin: string;
+    env: {
+      LARK_CHANNEL?: string;
+      LARK_CHANNEL_PROFILE?: string;
+      LARK_CHANNEL_HOME?: string;
+      LARK_CHANNEL_CONFIG?: string;
+      LARKSUITE_CLI_CONFIG_DIR?: string;
+    };
+  };
+}

--- a/tests/unit/agent/capability.test.ts
+++ b/tests/unit/agent/capability.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { BRIDGE_SYSTEM_PROMPT } from '../../../src/agent/bridge-system-prompt';
-import { claudeCapability, codexCapability } from '../../../src/agent/capability';
+import {
+  claudeCapability,
+  codexCapability,
+  opencodeCapability,
+} from '../../../src/agent/capability';
 import { createDefaultProfileConfig } from '../../../src/config/profile-schema';
 
 describe('agent capability contract', () => {
@@ -71,5 +75,36 @@ describe('agent capability contract', () => {
     });
 
     expect(codexCapability(profile).permissions.maxAccess).toBe('read-only');
+  });
+
+  it('defines OpenCode capability with native session resume and stdin prompt injection', () => {
+    const profile = createDefaultProfileConfig({
+      agentKind: 'opencode',
+      accounts: {
+        app: {
+          id: 'cli_test',
+          secret: '${APP_SECRET}',
+          tenant: 'feishu',
+        },
+      },
+      opencode: {
+        binaryPath: '/usr/local/bin/opencode',
+      },
+      permissions: {
+        defaultAccess: 'workspace',
+        maxAccess: 'workspace',
+      },
+    });
+
+    expect(opencodeCapability(profile)).toMatchObject({
+      agentId: 'opencode',
+      sessionKind: 'opencode-session',
+      promptInjection: 'stdin-prefix',
+      supportsNativeHistory: true,
+      systemPrompt: BRIDGE_SYSTEM_PROMPT,
+      permissions: {
+        maxAccess: 'workspace',
+      },
+    });
   });
 });

--- a/tests/unit/agent/opencode-argv.test.ts
+++ b/tests/unit/agent/opencode-argv.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { buildOpenCodeArgs } from '../../../src/agent/opencode/argv.js';
+
+describe('OpenCode argv contract', () => {
+  it('builds a fresh JSON run without auto approval by default', () => {
+    expect(buildOpenCodeArgs({ cwd: '/repo' })).toEqual([
+      'run',
+      '--format',
+      'json',
+      '--dir',
+      '/repo',
+      '-',
+    ]);
+  });
+
+  it('passes the resume session before JSON output flags', () => {
+    expect(buildOpenCodeArgs({ cwd: '/repo', sessionId: 'ses_123' })).toEqual([
+      'run',
+      '--session',
+      'ses_123',
+      '--format',
+      'json',
+      '--dir',
+      '/repo',
+      '-',
+    ]);
+  });
+
+  it('adds --auto only when auto approval is explicitly enabled', () => {
+    expect(buildOpenCodeArgs({ cwd: '/repo', autoApprove: false })).not.toContain('--auto');
+    expect(buildOpenCodeArgs({ cwd: '/repo', autoApprove: true })).toEqual([
+      'run',
+      '--auto',
+      '--format',
+      'json',
+      '--dir',
+      '/repo',
+      '-',
+    ]);
+  });
+});

--- a/tests/unit/agent/opencode-jsonl.test.ts
+++ b/tests/unit/agent/opencode-jsonl.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { OpenCodeJsonlTranslator } from '../../../src/agent/opencode/jsonl.js';
+
+describe('OpenCode JSONL translator', () => {
+  it('captures sessionID from any OpenCode event', () => {
+    const translator = new OpenCodeJsonlTranslator();
+
+    expect(translator.translate({ type: 'step_start', sessionID: 'ses_upper' })).toEqual([
+      { type: 'system', sessionId: 'ses_upper' },
+    ]);
+  });
+
+  it('keeps tool-calls step_finish non-terminal and waits for final stop', () => {
+    const translator = new OpenCodeJsonlTranslator();
+
+    expect(
+      translator.translate({
+        type: 'step_finish',
+        sessionID: 'ses_tool',
+        reason: 'tool-calls',
+      }),
+    ).toEqual([{ type: 'system', sessionId: 'ses_tool' }]);
+    expect(translator.terminalEmitted()).toBe(false);
+    expect(translator.translate({ type: 'text', part: { text: 'after tool' } })).toEqual([
+      { type: 'text', delta: 'after tool' },
+    ]);
+    expect(translator.translate({ type: 'step_finish', reason: 'stop' })).toEqual([
+      { type: 'done', terminationReason: 'normal', sessionId: 'ses_tool' },
+    ]);
+  });
+
+  it('translates text and completed tool_use events', () => {
+    const translator = new OpenCodeJsonlTranslator();
+
+    expect(translator.translate({ type: 'text', text: 'hello' })).toEqual([
+      { type: 'text', delta: 'hello' },
+    ]);
+    expect(
+      translator.translate({
+        type: 'tool_use',
+        part: {
+          type: 'tool',
+          tool: 'bash',
+          callID: 'call_1',
+          state: {
+            status: 'completed',
+            input: { command: 'pwd' },
+            output: '/repo',
+          },
+        },
+      }),
+    ).toEqual([
+      { type: 'tool_use', id: 'call_1', name: 'bash', input: { command: 'pwd' } },
+      { type: 'tool_result', id: 'call_1', output: '/repo', isError: false },
+    ]);
+  });
+
+  it('reports early EOF before a terminal event', () => {
+    const translator = new OpenCodeJsonlTranslator();
+
+    expect(translator.finish()).toEqual([
+      {
+        type: 'error',
+        message: 'opencode stream ended before a terminal event',
+        terminationReason: 'failed',
+      },
+    ]);
+  });
+
+  it('emits interrupted done with the captured session id', () => {
+    const translator = new OpenCodeJsonlTranslator();
+    translator.translate({ type: 'session.started', session_id: 'ses_snake' });
+
+    expect(translator.finish('interrupted')).toEqual([
+      { type: 'done', terminationReason: 'interrupted', sessionId: 'ses_snake' },
+    ]);
+  });
+});

--- a/tests/unit/cli/start-agent-factory.test.ts
+++ b/tests/unit/cli/start-agent-factory.test.ts
@@ -69,6 +69,33 @@ describe('start runtime agent factory', () => {
     expect(profile.codex?.binaryPath).toBe('codex');
   });
 
+  it('creates OpenCodeAdapter from profile config without enabling auto approval by default', () => {
+    const profile = createDefaultProfileConfig({
+      agentKind: 'opencode',
+      accounts: appAccount(),
+      opencode: { binaryPath: '/usr/local/bin/opencode' },
+    });
+    const agent = createRuntimeAgent(profile, {
+      profileDir: '/tmp/lark-channel-bridge/profiles/opencode-e2e',
+    });
+
+    expect(agent.id).toBe('opencode');
+    expect(agent.displayName).toBe('OpenCode');
+    expect(profile.opencode?.autoApprove).toBe(false);
+  });
+
+  it('seeds a default OpenCode binary when bootstrapping a new OpenCode profile', () => {
+    const profile = createRuntimeProfileConfig({
+      agentKind: 'opencode',
+      accounts: appAccount(),
+    });
+
+    expect(profile.opencode).toEqual({
+      binaryPath: 'opencode',
+      autoApprove: false,
+    });
+  });
+
   it('updates the process registry before releasing the old app lock during reconnect', async () => {
     const source = await readFile(join(process.cwd(), 'src/cli/commands/start.ts'), 'utf8');
     const restartStart = source.indexOf('async restart()');

--- a/tests/unit/config/profile-schema.test.ts
+++ b/tests/unit/config/profile-schema.test.ts
@@ -60,6 +60,30 @@ describe('profile schema', () => {
     ).toThrow(/codex/i);
   });
 
+  it('normalizes OpenCode config with safe auto approval default', () => {
+    const cfg = createDefaultProfileConfig({
+      agentKind: 'opencode',
+      accounts: { app },
+      opencode: { binaryPath: '/usr/local/bin/opencode' },
+    });
+
+    expect(cfg.agentKind).toBe('opencode');
+    expect(cfg.opencode).toEqual({
+      binaryPath: '/usr/local/bin/opencode',
+      autoApprove: false,
+    });
+  });
+
+  it('requires opencode configuration when agentKind is opencode', () => {
+    expect(() =>
+      normalizeProfileConfig({
+        schemaVersion: 2,
+        agentKind: 'opencode',
+        accounts: { app },
+      }),
+    ).toThrow(/opencode/i);
+  });
+
   it('rejects sandbox defaults that exceed max capability as a permission error', () => {
     expect(() =>
       normalizeProfileConfig({

--- a/tests/unit/runtime/profile-runtime.test.ts
+++ b/tests/unit/runtime/profile-runtime.test.ts
@@ -262,7 +262,7 @@ describe('profile runtime resolver', () => {
       expect(message).toContain(claude);
       expect(message).toContain('codex');
       expect(message).toContain(codex);
-      expect(message).toContain('--agent <claude|codex>');
+      expect(message).toContain('--agent <claude|codex|opencode>');
     } finally {
       process.env.PATH = oldPath;
       if (oldClaude === undefined) {

--- a/tests/unit/session/catalog.test.ts
+++ b/tests/unit/session/catalog.test.ts
@@ -25,7 +25,7 @@ describe('agent-aware session catalog', () => {
     ).toBe('chat-1\x1fclaude\x1f/repo\x1ffp-1');
   });
 
-  it('stores Claude sessions and Codex threads in isolated active entries', async () => {
+  it('stores Claude sessions, OpenCode sessions, and Codex threads in isolated entries', async () => {
     const catalog = new SessionCatalog(await path());
 
     catalog.upsertActive({
@@ -44,6 +44,14 @@ describe('agent-aware session catalog', () => {
       threadId: 'thread-1',
       now: 2000,
     });
+    catalog.upsertActive({
+      scopeId: 'chat-1',
+      agentId: 'opencode',
+      cwdRealpath: '/repo',
+      policyFingerprint: 'fp-1',
+      sessionId: 'opencode-1',
+      now: 3000,
+    });
 
     expect(
       catalog.activeFor({
@@ -61,10 +69,18 @@ describe('agent-aware session catalog', () => {
         policyFingerprint: 'fp-1',
       }),
     ).toMatchObject({ threadId: 'thread-1', agentId: 'codex' });
+    expect(
+      catalog.activeFor({
+        scopeId: 'chat-1',
+        agentId: 'opencode',
+        cwdRealpath: '/repo',
+        policyFingerprint: 'fp-1',
+      }),
+    ).toMatchObject({ sessionId: 'opencode-1', agentId: 'opencode' });
     await catalog.flush();
   });
 
-  it('rejects mismatched Claude/Codex identity fields and does not auto-resume damaged entries', async () => {
+  it('rejects mismatched agent identity fields and does not auto-resume damaged entries', async () => {
     const catalog = new SessionCatalog(await path());
 
     expect(() =>
@@ -87,6 +103,16 @@ describe('agent-aware session catalog', () => {
         now: 1000,
       }),
     ).toThrow(/Codex.*threadId/i);
+    expect(() =>
+      catalog.upsertActive({
+        scopeId: 'chat-1',
+        agentId: 'opencode',
+        cwdRealpath: '/repo',
+        policyFingerprint: 'fp-1',
+        threadId: 'thread-wrong',
+        now: 1000,
+      }),
+    ).toThrow(/opencode.*sessionId/i);
 
     await catalog.replaceForTest([
       {


### PR DESCRIPTION
## Summary

This PR adds OpenCode as a supported local agent for `lark-channel-bridge`, rebased onto the latest `upstream/main` as a clean OpenCode-only change.

The implementation focuses on making OpenCode usable through Feishu/Lark while keeping upstream-safe defaults:

- add `opencode` as a supported `agentKind`
- add OpenCode profile bootstrap/configuration
- add an OpenCode runtime adapter using JSON output
- persist and resume OpenCode sessions through the existing session catalog
- translate OpenCode text/tool/session JSONL events into bridge agent events
- make `--auto` explicit opt-in via `opencode.autoApprove`, defaulting to `false`

## Key behavior

- Fresh run argv:
  - `opencode run --format json --dir <cwd> -`
- Resume run argv:
  - `opencode run --session <sessionId> --format json --dir <cwd> -`
- Auto approval:
  - disabled by default
  - enabled only when `opencode.autoApprove === true`
- Session handling:
  - accepts `session_id`, `sessionId`, and `sessionID`
  - records OpenCode sessions in the agent-aware session catalog
  - resumes with `--session <sessionId>` on later runs
- Stream handling:
  - `step_finish.reason === "tool-calls"` is treated as non-terminal
  - `step_finish.reason === "stop"` or legacy no-reason `step_finish` completes the run

## Out of scope

This PR intentionally does **not** include:

- Cursor support
- Codex business-logic changes
- local proxy/workstation-specific fixes
- generic Session Resume refactors
- default-on `--auto`

## Validation

Verified locally with:

- ✅ `pnpm exec vitest run tests/unit/agent/opencode-jsonl.test.ts tests/unit/agent/opencode-argv.test.ts tests/process/opencode-adapter.test.ts`
- ✅ `pnpm test` — 94 files / 560 tests passed
- ✅ `pnpm typecheck`
- ✅ `pnpm build`
- ✅ `git diff --check`

## Notes

The branch was rebuilt from latest `upstream/main` and force-pushed with a single clean commit:

- `df0a83b feat: add OpenCode agent support`

This replaces the earlier multi-commit experimental OpenCode branch with an upstream-friendly version.
