### PR TITLE
fix(runtime): validate only the requested runtime profile

### DIFF
--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -9,7 +9,7 @@ import {
   type ProfileConfig,
 } from '../config/profile-schema';
 import {
-  loadRootConfig,
+  loadRootConfigForProfile,
   saveRootConfig,
   withConfigFileLock,
 } from '../config/profile-store';
@@ -522,7 +522,7 @@ async function persistLarkCliConfig(
   let saveSucceeded = false;
   try {
     await withConfigFileLock(appPaths.configFile, async () => {
-      const root = await loadRootConfig(appPaths.configFile);
+      const root = await loadRootConfigForProfile(appPaths.configFile, appPaths.profile);
       if (!root) return;
       const profile = root.profiles[appPaths.profile];
       if (!profile) return;

--- a/src/config/profile-store.ts
+++ b/src/config/profile-store.ts
@@ -37,6 +37,40 @@ function normalizeRootConfig(root: RootConfig): RootConfig {
   };
 }
 
+export async function loadRootConfigForProfile(
+  path: string,
+  activeProfile: string,
+): Promise<RootConfig | undefined> {
+  try {
+    const raw = JSON.parse(await readFile(path, 'utf8')) as unknown;
+    if (!isRootConfig(raw)) return undefined;
+    return normalizeRootConfigForProfile(raw, activeProfile);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw err;
+  }
+}
+
+function normalizeRootConfigForProfile(root: RootConfig, activeProfile: string): RootConfig {
+  const profiles: RootConfig['profiles'] = {};
+  for (const [name, profile] of Object.entries(root.profiles)) {
+    if (name === activeProfile) {
+      profiles[name] = normalizeProfileConfig(profile);
+    } else {
+      profiles[name] = profile;
+    }
+  }
+  const migrations = normalizeRootMigrations(root.migrations);
+  return {
+    schemaVersion: 2,
+    activeProfile: root.activeProfile,
+    preferences: {},
+    ...(root.secrets ? { secrets: root.secrets } : {}),
+    ...(migrations ? { migrations } : {}),
+    profiles,
+  };
+}
+
 export async function saveRootConfig(root: RootConfig, path: string): Promise<void> {
   await writeFileAtomic(path, formatRootConfig(root), { mode: 0o600 });
 }

--- a/src/runtime/profile-runtime.ts
+++ b/src/runtime/profile-runtime.ts
@@ -22,6 +22,7 @@ import {
   createRootConfig,
   hasPermissionDefaultsMigration,
   loadRootConfig,
+  loadRootConfigForProfile,
   markPermissionDefaultsMigration,
   readActiveProfile,
   runtimeProfileConfig,
@@ -140,7 +141,7 @@ export async function resolveProfileRuntime(
       : {}),
   }, opts.handleActiveBridgeMigrationConflict);
 
-  let rootConfig = await loadRootConfig(configPath);
+  let rootConfig = await loadRootConfigForProfile(configPath, profile);
   if (rootConfig) {
     if (!explicitProfile && !activeProfile) {
       profile = rootConfig.activeProfile;

--- a/tests/unit/cli/preflight.test.ts
+++ b/tests/unit/cli/preflight.test.ts
@@ -10,7 +10,7 @@ import {
   createDefaultProfileConfig,
   type RootConfig,
 } from '../../../src/config/profile-schema';
-import { loadRootConfig, saveRootConfig } from '../../../src/config/profile-store';
+import { loadRootConfig, loadRootConfigForProfile, saveRootConfig } from '../../../src/config/profile-store';
 
 const mocks = vi.hoisted(() => ({
   spawnProcess: vi.fn(),
@@ -1214,6 +1214,57 @@ describe('lark-cli preflight', () => {
       'profile-config-persist-failed',
       expect.objectContaining({ profile: 'codex' }),
     );
+  });
+
+  it('loadRootConfigForProfile loads the active profile when an inactive profile has an unknown agentKind', async () => {
+    const rootDir = await tempRoot();
+    const appPaths = resolveAppPaths({ rootDir, profile: 'codex' });
+    const codexConfig = createDefaultProfileConfig({
+      agentKind: 'codex',
+      accounts: bridgeConfig.accounts,
+      codex: { binaryPath: 'codex' },
+    });
+    const rootConfig: RootConfig = {
+      schemaVersion: 2,
+      activeProfile: 'codex',
+      preferences: {} as Record<string, never>,
+      profiles: {
+        codex: codexConfig,
+        cursor: {
+          schemaVersion: 2,
+          agentKind: 'cursor',
+          accounts: bridgeConfig.accounts,
+        },
+      } as unknown as RootConfig['profiles'],
+    };
+    await saveRootConfig(rootConfig, appPaths.configFile);
+
+    const loaded = await loadRootConfigForProfile(appPaths.configFile, 'codex');
+    expect(loaded).toBeDefined();
+    expect(loaded?.profiles.codex).toBeDefined();
+    expect(loaded?.profiles.cursor).toBeDefined();
+  });
+
+  it('loadRootConfigForProfile rejects the active profile when it has an unknown agentKind', async () => {
+    const rootDir = await tempRoot();
+    const appPaths = resolveAppPaths({ rootDir, profile: 'cursor' });
+    const rootConfig: RootConfig = {
+      schemaVersion: 2,
+      activeProfile: 'cursor',
+      preferences: {} as Record<string, never>,
+      profiles: {
+        cursor: {
+          schemaVersion: 2,
+          agentKind: 'cursor',
+          accounts: bridgeConfig.accounts,
+        },
+      } as unknown as RootConfig['profiles'],
+    };
+    await saveRootConfig(rootConfig, appPaths.configFile);
+
+    await expect(
+      loadRootConfigForProfile(appPaths.configFile, 'cursor'),
+    ).rejects.toThrow(/agentKind must be claude/);
   });
 });
 

--- a/tests/unit/runtime/profile-runtime.test.ts
+++ b/tests/unit/runtime/profile-runtime.test.ts
@@ -8,6 +8,7 @@ import {
   resolveProfileRuntime,
 } from '../../../src/runtime/profile-runtime';
 import { createDefaultProfileConfig } from '../../../src/config/profile-schema';
+import { loadRootConfig } from '../../../src/config/profile-store';
 import { resolveAppPaths } from '../../../src/config/app-paths';
 import { getSecret } from '../../../src/config/keystore';
 import { secretKeyForApp } from '../../../src/config/schema';
@@ -1148,6 +1149,71 @@ describe('profile runtime resolver', () => {
       LARK_CHANNEL_HOME: root,
       LARK_CHANNEL_PROFILE: 'codex-dev',
     });
+  });
+
+  it('resolves the requested codex profile when an inactive profile has an unknown agentKind', async () => {
+    const root = await tmpRoot();
+    await writeProfileRoot(root, 'codex', {
+      codex: createDefaultProfileConfig({
+        agentKind: 'codex',
+        accounts: { app },
+        codex: { binaryPath: 'codex' },
+      }),
+      // inactive cursor profile with agentKind not in the known set
+      cursor: {
+        schemaVersion: 2,
+        agentKind: 'cursor',
+        accounts: { app },
+      },
+    });
+
+    const runtime = await resolveProfileRuntime({
+      config: join(root, 'config.json'),
+      profile: 'codex',
+      allowBootstrap: false,
+    });
+
+    expect(runtime.profile).toBe('codex');
+    expect(runtime.profileConfig.agentKind).toBe('codex');
+  });
+
+  it('rejects the requested profile when it has an unknown agentKind', async () => {
+    const root = await tmpRoot();
+    await writeProfileRoot(root, 'cursor', {
+      cursor: {
+        schemaVersion: 2,
+        agentKind: 'cursor',
+        accounts: { app },
+      },
+    });
+
+    await expect(
+      resolveProfileRuntime({
+        config: join(root, 'config.json'),
+        profile: 'cursor',
+        allowBootstrap: false,
+      }),
+    ).rejects.toThrow(/agentKind must be claude/);
+  });
+
+  it('loadRootConfig rejects unknown agentKind on any profile', async () => {
+    const root = await tmpRoot();
+    await writeProfileRoot(root, 'opencode', {
+      codex: createDefaultProfileConfig({
+        agentKind: 'codex',
+        accounts: { app },
+        codex: { binaryPath: 'codex' },
+      }),
+      cursor: {
+        schemaVersion: 2,
+        agentKind: 'cursor',
+        accounts: { app },
+      },
+    });
+
+    await expect(
+      loadRootConfig(join(root, 'config.json')),
+    ).rejects.toThrow(/agentKind must be claude/);
   });
 });
 


### PR DESCRIPTION
## Problem

Runtime startup could fail because an unrelated inactive profile contained an unsupported `agentKind`.

For example:

- requested profile: `codex`
- inactive profile: `cursor`

The runtime failed before selecting the requested profile.

## Root cause

`loadRootConfig()` normalized every profile during config loading.

As a result, an unsupported inactive profile could prevent an otherwise valid runtime profile from starting.

## Solution

- add a runtime-specific root config loader
- normalize only the requested runtime profile
- keep `loadRootConfig()` strict for configuration and management paths
- update runtime profile resolution and runtime profile persistence to use the runtime loader

## Validation

- `pnpm typecheck`
- `pnpm test`
- `pnpm build`

## Backward compatibility

`loadRootConfig()` remains unchanged and continues to validate the entire configuration.

Only runtime operations targeting a single profile are isolated from unrelated inactive profiles.