### PR TITLE
支持单个群组配置免@回复

### DIFF
--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -66,6 +66,7 @@ import { lookupMessageThreadId } from './thread-id';
 import { addWorkingReaction, removeReaction } from './reaction';
 import { fetchKnownChats } from './lark-info';
 import type { AppPaths } from '../config/app-paths';
+import type { ProfileConfig } from '../config/profile-schema';
 import {
   consumeCotEvents,
   CotClient,
@@ -93,6 +94,17 @@ const SUPPRESSED_API_ERROR_CODES = new Set([
   1069307, // drive.fileComment.get "not exist" — fall back to .list
   1069302, // drive.fileCommentReply.create — whole-doc comments don't accept replies; fall back to fileComment.create
 ]);
+
+export function shouldRequireMentionForGroupMessage(
+  cfg: AppConfig,
+  profileConfig: Pick<ProfileConfig, 'access'>,
+  chatId: string,
+): boolean {
+  return (
+    getRequireMentionInGroup(cfg) &&
+    !profileConfig.access.autoReplyChats.includes(chatId)
+  );
+}
 
 const SUPPRESSED_ENDPOINT_API_ERRORS = [
   {
@@ -646,7 +658,7 @@ async function intakeMessage(deps: IntakeDeps): Promise<void> {
   // event reaching here is either targeted or undirected chatter.
   if (
     msg.chatType !== 'p2p' &&
-    getRequireMentionInGroup(controls.cfg) &&
+    shouldRequireMentionForGroupMessage(controls.cfg, controls.profileConfig, msg.chatId) &&
     !msg.mentionedBot
   ) {
     log.info('intake', 'skip-no-mention', { scope, chatType: msg.chatType });

--- a/src/card/config-card.ts
+++ b/src/card/config-card.ts
@@ -15,6 +15,7 @@ export interface ConfigFormOpts {
   /** 0 means "disabled". */
   runIdleTimeoutMinutes: number;
   requireMentionInGroup: boolean;
+  currentChatRequireMentionInGroup?: boolean;
   larkCliIdentity: LarkCliIdentityPreset;
   allowedUsers: string[];
   allowedChats: string[];
@@ -210,9 +211,9 @@ export function configFormCard(opts: ConfigFormOpts): object {
             {
               tag: 'markdown',
               content:
-                '\n**群里需要 @ bot**\n' +
+                '\n**所有群需要 @ bot**\n' +
                 '_是(默认):群和话题群里,不 @ bot 的消息不会触发回复,bot 不接群里聊天_\n' +
-                '_否:任何消息都会发给 agent(0.1.21 及更早版本的行为)_\n' +
+                '_否:所有群里任何消息都会发给 agent(0.1.21 及更早版本的行为)_\n' +
                 '_私聊永远不需要 @;`@全员` 永远不响应_',
             },
             {
@@ -224,6 +225,26 @@ export function configFormCard(opts: ConfigFormOpts): object {
                 { text: { tag: 'plain_text', content: '否' }, value: 'no' },
               ],
             },
+            ...(opts.currentChatRequireMentionInGroup === undefined
+              ? []
+              : [
+                  {
+                    tag: 'markdown',
+                    content:
+                      '\n**本群单独设置需要 @ bot**\n' +
+                      '_是(默认):本群沿用“所有群需要 @ bot”的默认安静策略_\n' +
+                      '_否:仅本群不 @ bot 也回复,其他群不受影响_',
+                  },
+                  {
+                    tag: 'select_static',
+                    name: 'current_chat_require_mention',
+                    initial_option: opts.currentChatRequireMentionInGroup ? 'yes' : 'no',
+                    options: [
+                      { text: { tag: 'plain_text', content: '是(默认)' }, value: 'yes' },
+                      { text: { tag: 'plain_text', content: '否' }, value: 'no' },
+                    ],
+                  },
+                ]),
             {
               tag: 'markdown',
               content:
@@ -307,7 +328,10 @@ export function configSavedCard(opts: ConfigFormOpts): object {
             `**COT 过程消息**:\`${cotLabel}\`\n` +
             `**并发上限**:\`${opts.maxConcurrentRuns}\`\n` +
             `**run 探活**:\`${opts.runIdleTimeoutMinutes > 0 ? `${opts.runIdleTimeoutMinutes} 分钟` : '关闭'}\`\n` +
-            `**群里需要 @ bot**:\`${opts.requireMentionInGroup ? '是' : '否'}\`\n\n` +
+            `**所有群需要 @ bot**:\`${opts.requireMentionInGroup ? '是' : '否'}\`\n` +
+            (opts.currentChatRequireMentionInGroup === undefined
+              ? '\n'
+              : `**本群单独设置需要 @ bot**:\`${opts.currentChatRequireMentionInGroup ? '是' : '否'}\`\n\n`) +
             `**lark-cli 身份策略**:\`${opts.larkCliIdentity === 'user-default' ? '允许用户身份' : '只允许应用身份'}\`\n\n` +
             '🔒 **访问控制**\n' +
             `**允许私聊的用户**:${summarize(opts.allowedUsers)}\n` +

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1802,6 +1802,8 @@ async function showConfigForm(ctx: CommandContext): Promise<void> {
 
   const ms = getRunIdleTimeoutMs(ctx.controls.cfg);
   const access = ctx.controls.profileConfig.access;
+  const currentChatRequireMentionInGroup =
+    ctx.chatMode === 'p2p' ? undefined : !access.autoReplyChats.includes(ctx.msg.chatId);
   const card = configFormCard({
     agentKind: ctx.controls.profileConfig.agentKind,
     model: normalizeModelSelection(
@@ -1814,6 +1816,7 @@ async function showConfigForm(ctx: CommandContext): Promise<void> {
     maxConcurrentRuns: getMaxConcurrentRuns(ctx.controls.cfg),
     runIdleTimeoutMinutes: ms ? Math.round(ms / 60_000) : 0,
     requireMentionInGroup: getRequireMentionInGroup(ctx.controls.cfg),
+    currentChatRequireMentionInGroup,
     larkCliIdentity: ctx.controls.profileConfig.larkCli.identityPreset,
     allowedUsers: access.allowedUsers,
     allowedChats: access.allowedChats,
@@ -1911,6 +1914,15 @@ async function submitConfig(ctx: CommandContext): Promise<void> {
   if (rawRequireMention === 'yes') requireMentionInGroup = true;
   else if (rawRequireMention === 'no') requireMentionInGroup = false;
   else requireMentionInGroup = getRequireMentionInGroup(ctx.controls.cfg);
+  const rawCurrentChatRequireMention = String(fv.current_chat_require_mention ?? '').trim();
+  const currentChatRequireMentionInGroup =
+    ctx.chatMode === 'p2p'
+      ? undefined
+      : rawCurrentChatRequireMention === 'yes'
+        ? true
+        : rawCurrentChatRequireMention === 'no'
+          ? false
+          : !ctx.controls.profileConfig.access.autoReplyChats.includes(ctx.msg.chatId);
   const rawLarkCliIdentity = String(fv.lark_cli_identity ?? '').trim();
   const larkCliIdentity =
     rawLarkCliIdentity === 'user-default' || rawLarkCliIdentity === 'bot-only'
@@ -1920,7 +1932,6 @@ async function submitConfig(ctx: CommandContext): Promise<void> {
   const larkCliIdentityChanged = larkCliIdentity !== previousLarkCliIdentity;
 
   const formMsgId = ctx.msg.messageId;
-  const access = ctx.controls.profileConfig.access;
 
   // Detach: same reason as account submit — Lark's client locks the form
   // while the cardAction handler is running. Wait out FORM_SETTLE_MS *after*
@@ -1963,6 +1974,17 @@ async function submitConfig(ctx: CommandContext): Promise<void> {
         failureStep = 'config.save';
       }
       await savePreferencesConfig(ctx, nextPreferences, requireMentionInGroup, larkCliIdentity);
+      if (currentChatRequireMentionInGroup !== undefined) {
+        await saveAccessConfig(ctx, (current) => {
+          const list = new Set(current.autoReplyChats);
+          if (currentChatRequireMentionInGroup) list.delete(ctx.msg.chatId);
+          else list.add(ctx.msg.chatId);
+          return {
+            ...current,
+            autoReplyChats: [...list],
+          };
+        });
+      }
     } catch (err) {
       let rollbackFailed = false;
       if (larkCliIdentityChanged) {
@@ -1993,11 +2015,14 @@ async function submitConfig(ctx: CommandContext): Promise<void> {
       maxConcurrentRuns,
       runIdleTimeoutMinutes,
       requireMentionInGroup,
+      currentChatRequireMentionInGroup,
       larkCliIdentity,
-      allowedUsersCount: access.allowedUsers.length,
-      allowedChatsCount: access.allowedChats.length,
-      adminsCount: access.admins.length,
+      allowedUsersCount: ctx.controls.profileConfig.access.allowedUsers.length,
+      allowedChatsCount: ctx.controls.profileConfig.access.allowedChats.length,
+      adminsCount: ctx.controls.profileConfig.access.admins.length,
+      autoReplyChatsCount: ctx.controls.profileConfig.access.autoReplyChats.length,
     });
+    const savedAccess = ctx.controls.profileConfig.access;
     await waitForSettle();
     await showResultCardInPlace(
       ctx,
@@ -2011,10 +2036,11 @@ async function submitConfig(ctx: CommandContext): Promise<void> {
         maxConcurrentRuns,
         runIdleTimeoutMinutes,
         requireMentionInGroup,
+        currentChatRequireMentionInGroup,
         larkCliIdentity,
-        allowedUsers: access.allowedUsers,
-        allowedChats: access.allowedChats,
-        admins: access.admins,
+        allowedUsers: savedAccess.allowedUsers,
+        allowedChats: savedAccess.allowedChats,
+        admins: savedAccess.admins,
         knownChats: ctx.controls.knownChats ?? [],
       }),
     );
@@ -2022,7 +2048,7 @@ async function submitConfig(ctx: CommandContext): Promise<void> {
     // "群里不需要 @ bot" only works if the app can actually receive non-@
     // group messages (`im:message.group_msg`). When the user opts in, verify
     // the scope and, if missing, push a one-click re-authorization link.
-    if (!requireMentionInGroup) {
+    if (!requireMentionInGroup || currentChatRequireMentionInGroup === false) {
       await promptGroupMsgScopeIfMissing(ctx);
     }
   })();

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1535,6 +1535,7 @@ async function handleInvite(args: string, ctx: CommandContext): Promise<void> {
         '• `/invite user @某人` — 加入允许私聊\n' +
         '• `/invite admin @某人` — 加入管理员\n' +
         '• `/invite group` — 把当前群加入响应群名单\n' +
+        '• `/invite auto group` — 当前群无需 @ bot 也回复\n' +
         '• `/invite all group` — 把 bot 所在的所有群一键加入',
     );
     return;
@@ -1546,6 +1547,25 @@ async function handleInvite(args: string, ctx: CommandContext): Promise<void> {
       return;
     }
     const chatId = ctx.msg.chatId;
+    if (tokens.includes('auto')) {
+      let already = false;
+      await saveAccessConfig(ctx, (current) => {
+        const list = new Set(current.autoReplyChats);
+        already = list.has(chatId);
+        if (!already) list.add(chatId);
+        return {
+          ...current,
+          autoReplyChats: [...list],
+        };
+      });
+      if (already) {
+        await reply(ctx, '✅ 当前群已开启免 @ 回复，无需重复添加。');
+        return;
+      }
+      await reply(ctx, `✅ 当前群（\`${chatId}\`）已开启免 @ 回复。其他群仍照常需要 @ bot。`);
+      await promptGroupMsgScopeIfMissing(ctx);
+      return;
+    }
     let already = false;
     await saveAccessConfig(ctx, (current) => {
       const list = new Set(current.allowedChats);
@@ -1613,7 +1633,8 @@ async function handleRemove(args: string, ctx: CommandContext): Promise<void> {
       '用法：\n' +
         '• `/remove user @某人` — 移出用户白名单\n' +
         '• `/remove admin @某人` — 移出管理员\n' +
-        '• `/remove group` — 把当前群移出响应群名单',
+        '• `/remove group` — 把当前群移出响应群名单\n' +
+        '• `/remove auto group` — 关闭当前群免 @ 回复',
     );
     return;
   }
@@ -1624,6 +1645,24 @@ async function handleRemove(args: string, ctx: CommandContext): Promise<void> {
       return;
     }
     const chatId = ctx.msg.chatId;
+    if (tokens.includes('auto')) {
+      let missing = false;
+      await saveAccessConfig(ctx, (current) => {
+        const list = new Set(current.autoReplyChats);
+        missing = !list.has(chatId);
+        list.delete(chatId);
+        return {
+          ...current,
+          autoReplyChats: [...list],
+        };
+      });
+      if (missing) {
+        await reply(ctx, '✅ 当前群本来就没有开启免 @ 回复，无需移除。');
+        return;
+      }
+      await reply(ctx, '✅ 已关闭当前群免 @ 回复；之后这个群照常需要 @ bot。');
+      return;
+    }
     let missing = false;
     await saveAccessConfig(ctx, (current) => {
       const list = new Set(current.allowedChats);
@@ -1703,6 +1742,7 @@ async function saveAccessConfig(
             allowedUsers: access.allowedUsers,
             allowedChats: access.allowedChats,
             admins: access.admins,
+            autoReplyChats: access.autoReplyChats,
           },
           requireMentionInGroup: access.requireMentionInGroup,
         };
@@ -1724,6 +1764,7 @@ async function saveAccessConfig(
         allowedUsers: access.allowedUsers.length,
         allowedChats: access.allowedChats.length,
         admins: access.admins.length,
+        autoReplyChats: access.autoReplyChats.length,
       });
       return access;
     });

--- a/src/config/profile-schema.ts
+++ b/src/config/profile-schema.ts
@@ -22,6 +22,7 @@ export interface ProfileAccess {
   allowedChats: string[];
   admins: string[];
   requireMentionInGroup: boolean;
+  autoReplyChats: string[];
 }
 
 export interface SandboxConfig {
@@ -254,6 +255,7 @@ function normalizeAccess(
     allowedChats: stringArray(access?.allowedChats),
     admins: stringArray(access?.admins),
     requireMentionInGroup: access?.requireMentionInGroup ?? legacyRequireMentionInGroup ?? true,
+    autoReplyChats: stringArray(access?.autoReplyChats),
   };
 }
 

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -84,6 +84,8 @@ export interface AppAccess {
    * (/account, /config, /exit, /reconnect, /doctor, /cd, /ws, /doc,
    * /invite, /remove). */
   admins?: string[];
+  /** chat_id list for groups where non-@ messages also reach the agent. */
+  autoReplyChats?: string[];
 }
 
 export interface AppPreferences {

--- a/src/policy/fingerprint.ts
+++ b/src/policy/fingerprint.ts
@@ -47,6 +47,7 @@ export function policyFingerprint(input: FingerprintInputV2): string {
 export function accessPolicyDigest(access: ProfileConfig['access']): string {
   return digestCanonical({
     admins: [...access.admins].sort(),
+    autoReplyChats: [...access.autoReplyChats].sort(),
     allowedChats: [...access.allowedChats].sort(),
     allowedUsers: [...access.allowedUsers].sort(),
     requireMentionInGroup: access.requireMentionInGroup,

--- a/tests/integration/commands/commands-v1.test.ts
+++ b/tests/integration/commands/commands-v1.test.ts
@@ -261,9 +261,12 @@ describe('Bridge command contracts', () => {
   it('does not expose access allowlists through the Lark /config form', async () => {
     const h = await createHarness();
 
-    await expect(h.run('/config')).resolves.toBe(true);
+    await expect(h.run('/config', { chatMode: 'group' })).resolves.toBe(true);
 
     const configCard = JSON.stringify(lastContent(h.channel));
+    expect(configCard).toContain('所有群需要 @ bot');
+    expect(configCard).toContain('本群单独设置需要 @ bot');
+    expect(configCard).toContain('current_chat_require_mention');
     expect(configCard).not.toContain('allowed_users');
     expect(configCard).not.toContain('allowed_chats');
     expect(configCard).not.toContain('admins');

--- a/tests/integration/commands/commands-v1.test.ts
+++ b/tests/integration/commands/commands-v1.test.ts
@@ -285,18 +285,34 @@ describe('Bridge command contracts', () => {
         chatMode: 'group',
       }),
     ).resolves.toBe(true);
+    await expect(
+      h.run('/invite auto group', {
+        chatId: 'oc-solo-agent',
+        scope: 'oc-solo-agent',
+        chatMode: 'group',
+      }),
+    ).resolves.toBe(true);
 
     let root = await loadRootConfig(h.controls.configPath);
     expect(root?.profiles.claude?.access.allowedUsers).toContain('ou-alice');
     expect(root?.profiles.claude?.access.admins).toEqual(['ou-admin', 'ou-bob']);
     expect(root?.profiles.claude?.access.allowedChats).toContain('oc-group-1');
+    expect(root?.profiles.claude?.access.autoReplyChats).toContain('oc-solo-agent');
     expect(root?.profiles.claude?.preferences).not.toHaveProperty('access');
 
     await expect(
       h.run('/remove user @Alice', { mentions: [mention('ou-alice', 'Alice')] }),
     ).resolves.toBe(true);
+    await expect(
+      h.run('/remove auto group', {
+        chatId: 'oc-solo-agent',
+        scope: 'oc-solo-agent',
+        chatMode: 'group',
+      }),
+    ).resolves.toBe(true);
     root = await loadRootConfig(h.controls.configPath);
     expect(root?.profiles.claude?.access.allowedUsers).not.toContain('ou-alice');
+    expect(root?.profiles.claude?.access.autoReplyChats).not.toContain('oc-solo-agent');
   });
 
   it('adds every known bot group through /invite all group', async () => {

--- a/tests/integration/commands/profile-config-command.test.ts
+++ b/tests/integration/commands/profile-config-command.test.ts
@@ -90,6 +90,40 @@ describe('profile-aware account and config commands', () => {
     expect((root as unknown as { accounts?: unknown }).accounts).toBeUndefined();
   });
 
+  it('saves the current group mention override from /config submit', async () => {
+    vi.useFakeTimers();
+    const h = await createHarness();
+
+    await h.command('/config submit', {
+      require_mention_in_group: 'yes',
+      current_chat_require_mention: 'no',
+    }, {
+      chatMode: 'group',
+      chatId: 'oc-solo-agent',
+      scope: 'oc-solo-agent',
+    });
+
+    let root = await waitForRoot(h.rootDir, (candidate) =>
+      candidate.profiles.claude?.access.autoReplyChats.includes('oc-solo-agent') === true,
+    );
+    expect(root.profiles.claude?.access.requireMentionInGroup).toBe(true);
+    expect(root.profiles.claude?.access.autoReplyChats).toContain('oc-solo-agent');
+
+    await h.command('/config submit', {
+      require_mention_in_group: 'yes',
+      current_chat_require_mention: 'yes',
+    }, {
+      chatMode: 'group',
+      chatId: 'oc-solo-agent',
+      scope: 'oc-solo-agent',
+    });
+
+    root = await waitForRoot(h.rootDir, (candidate) =>
+      candidate.profiles.claude?.access.autoReplyChats.includes('oc-solo-agent') === false,
+    );
+    expect(root.profiles.claude?.access.autoReplyChats).not.toContain('oc-solo-agent');
+  });
+
   it('persists the picked model and clears it when "default" is chosen', async () => {
     vi.useFakeTimers();
     const h = await createHarness();
@@ -247,7 +281,15 @@ async function createHarness(options: {
 } = {}): Promise<{
   rootDir: string;
   channel: ReturnType<typeof createFakeChannel>;
-  command(content: string, formValue?: Record<string, unknown>): Promise<boolean>;
+  command(
+    content: string,
+    formValue?: Record<string, unknown>,
+    overrides?: {
+      chatMode?: 'p2p' | 'group' | 'topic';
+      chatId?: string;
+      scope?: string;
+    },
+  ): Promise<boolean>;
 }> {
   const rootDir = await mkdtemp(join(tmpdir(), 'bridge-profile-config-command-'));
   roots.push(rootDir);
@@ -275,20 +317,25 @@ async function createHarness(options: {
   return {
     rootDir,
     channel,
-    command: (content: string, formValue?: Record<string, unknown>) =>
-      tryHandleCommand({
-        channel: channel as unknown as CommandContext['channel'],
-        msg: message(content),
-        scope: 'chat-1',
-        chatMode: 'p2p',
-        sessions,
-        workspaces,
-        agent: new FakeAgentAdapter(),
-        activeRuns: new ActiveRuns(),
-        controls,
-        formValue,
-        fromCardAction: true,
-      }),
+    command: (content: string, formValue?: Record<string, unknown>, overrides = {}) => {
+      const chatId = overrides.chatId ?? 'chat-1';
+      return tryHandleCommand({
+          channel: channel as unknown as CommandContext['channel'],
+          msg: message(content, {
+            chatId,
+            chatType: overrides.chatMode ?? 'p2p',
+          }),
+          scope: overrides.scope ?? chatId,
+          chatMode: overrides.chatMode ?? 'p2p',
+          sessions,
+          workspaces,
+          agent: new FakeAgentAdapter(),
+          activeRuns: new ActiveRuns(),
+          controls,
+          formValue,
+          fromCardAction: true,
+        });
+    },
   };
 }
 
@@ -369,11 +416,14 @@ async function writeJson(path: string, value: unknown): Promise<void> {
   await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
 }
 
-function message(content: string): NormalizedMessage {
+function message(
+  content: string,
+  opts: { chatId?: string; chatType?: 'p2p' | 'group' | 'topic' } = {},
+): NormalizedMessage {
   return {
     messageId: `om-${content.replace(/\W+/g, '-').slice(0, 20)}`,
-    chatId: 'chat-1',
-    chatType: 'p2p',
+    chatId: opts.chatId ?? 'chat-1',
+    chatType: opts.chatType ?? 'p2p',
     senderId: 'ou-admin',
     senderName: 'Admin',
     content,

--- a/tests/integration/config/profile-migration.test.ts
+++ b/tests/integration/config/profile-migration.test.ts
@@ -87,6 +87,7 @@ describe('profile v2 migration', () => {
       allowedChats: ['oc_allowed'],
       admins: ['ou_admin'],
       requireMentionInGroup: false,
+      autoReplyChats: [],
     });
     expect(next.profiles.claude?.preferences).toEqual({ messageReply: 'card' });
     expect(next.profiles.claude?.workspaces).toEqual({});

--- a/tests/unit/bot/channel-logger.test.ts
+++ b/tests/unit/bot/channel-logger.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import * as channelModule from '../../../src/bot/channel.js';
+import { createDefaultProfileConfig } from '../../../src/config/profile-schema.js';
 
 describe('Lark SDK logger noise filtering', () => {
   it('suppresses optional wiki-node permission failures that fall back to the original file token', () => {
@@ -57,6 +58,31 @@ describe('Lark SDK logger noise filtering', () => {
           },
         },
       ]),
+    ).toBe(false);
+  });
+});
+
+describe('group mention policy', () => {
+  it('keeps regular groups mention-only while allowing configured auto-reply chats', () => {
+    const profile = createDefaultProfileConfig({
+      agentKind: 'claude',
+      accounts: {
+        app: {
+          id: 'cli_test',
+          secret: '${APP_SECRET}',
+          tenant: 'feishu',
+        },
+      },
+      access: {
+        autoReplyChats: ['oc-solo-agent'],
+      },
+    });
+
+    expect(
+      channelModule.shouldRequireMentionForGroupMessage(profile, profile, 'oc-large-group'),
+    ).toBe(true);
+    expect(
+      channelModule.shouldRequireMentionForGroupMessage(profile, profile, 'oc-solo-agent'),
     ).toBe(false);
   });
 });

--- a/tests/unit/config/profile-schema.test.ts
+++ b/tests/unit/config/profile-schema.test.ts
@@ -96,6 +96,7 @@ describe('profile schema', () => {
       allowedChats: [],
       admins: [],
       requireMentionInGroup: true,
+      autoReplyChats: [],
     });
   });
 

--- a/tests/unit/runtime/profile-runtime.test.ts
+++ b/tests/unit/runtime/profile-runtime.test.ts
@@ -414,6 +414,7 @@ describe('profile runtime resolver', () => {
       allowedChats: ['oc_allowed'],
       admins: ['ou_admin'],
       requireMentionInGroup: false,
+      autoReplyChats: [],
     });
     expect(runtime.profileConfig.preferences).toMatchObject({
       messageReply: 'card',
@@ -430,6 +431,7 @@ describe('profile runtime resolver', () => {
       allowedChats: ['oc_allowed'],
       admins: ['ou_admin'],
       requireMentionInGroup: false,
+      autoReplyChats: [],
     });
     expect(saved.profiles.claude?.preferences).toMatchObject({
       messageReply: 'card',


### PR DESCRIPTION
现有功能开启群免@，会把所有群都改成免@，但有些场景下是只需要部分群免@，而默认还是保持群里@才回复。
因此新增加“本群单独设置需要 @ bot” 选项

<img width="475" height="276" alt="PixPin_2026-07-07_11-54-59" src="https://github.com/user-attachments/assets/33b60ba7-64be-4fa9-808f-233da995392e" />
