### PR TITLE
feat: service 文件持久化，restart 时刷新配置

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lark-channel-bridge",
-  "version": "0.5.5",
+  "version": "0.5.5-unofficial.balance.0",
   "description": "Bridge Feishu/Lark messenger with local CLI coding agents",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/card/templates.ts
+++ b/src/card/templates.ts
@@ -82,6 +82,8 @@ export interface StatusInfo {
   scope: string;
   /** Chat mode — used to label scope. */
   chatMode: 'p2p' | 'group' | 'topic';
+    /** Account balance string. */
+    balance?: string;
 }
 
 export function statusCard(info: StatusInfo): object {
@@ -119,6 +121,7 @@ export function statusCard(info: StatusInfo): object {
       : []),
     `🚦 **queue**: ${queueLine}`,
     `👤 **owner API**: ${escapeMd(info.ownerState)}`,
+    `💰 **可用余额**: ${info.balance ?? '-'}`,
   ];
   return shell('📊 当前状态', [
     divMd(lines.join('\n')),

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -409,6 +409,7 @@ export async function runServiceStatus(opts: ServiceProfileOptions = {}): Promis
     console.log('✓ bot 正在后台运行');
   }
   if (pid) console.log(`  进程 ID: ${pid}`);
+  console.log(`  服务文件: ${adapter.servicePath()}`);
   console.log('  日志:');
   console.log(`    ${daemonStdoutPath(profile)}`);
   console.log(`    ${daemonStderrPath(profile)}`);

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -19,6 +19,7 @@ import {
 } from '../../config/profile-schema';
 import type { AppConfig } from '../../config/schema';
 import { isComplete } from '../../config/schema';
+import { writeUnit } from '../../daemon/systemd';
 import { configureLogger, gcOldLogs, log, reportError } from '../../core/logger';
 import { loadTelemetryAdapter, telemetry } from '../../core/telemetry';
 import { gcMediaCache } from '../../media/cache';
@@ -98,6 +99,14 @@ export async function runStart(opts: StartOptions): Promise<void> {
   const appPaths = runtime.appPaths;
   let profileConfig = runtime.profileConfig;
   configureLogger({ logsDir: appPaths.logsDir });
+
+  // On every run/start/restart, pre-read the systemd unit file. Inside
+  // writeUnit, check whether rootDir/bot.<profile>.service exists; if so,
+  // copy it to the user-level systemd unit path; otherwise create a
+  // template from buildUnit first.
+  try {
+    await writeUnit(appPaths.profile, appPaths.rootDir);
+  } catch {}
 
   await preFlightChecks({
     skipCheckLarkCli: opts.skipCheckLarkCli,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -77,6 +77,7 @@ import type { ProcessPool } from '../bot/process-pool';
 import type { RunExecutor } from '../runtime/run-executor';
 import { RunRejected } from '../runtime/errors';
 import { validateAppCredentials } from '../utils/feishu-auth';
+import { resolveModelProvider, fetchModelBalance } from '../utils/model-balance';
 import type { WorkspaceStore } from '../workspace/store';
 import { createBoundChat, defaultChatName } from '../bot/group';
 import { fetchKnownChats, type KnownChat } from '../bot/lark-info';
@@ -806,6 +807,8 @@ async function handleStatus(_args: string, ctx: CommandContext): Promise<void> {
     isCodex && ctx.sessionCatalog && ctx.sessionCatalogIdentity
       ? ctx.sessionCatalog.activeFor(ctx.sessionCatalogIdentity)
       : undefined;
+  const provider = await resolveModelProvider(ctx.controls.profile);
+  const balance = provider ? (await fetchModelBalance(provider)) ?? '-' : '-';
   const card = statusCard({
     profileName: ctx.controls.profile,
     cwd,
@@ -822,6 +825,7 @@ async function handleStatus(_args: string, ctx: CommandContext): Promise<void> {
     ownerState: formatOwnerState(ctx),
     scope: ctx.scope,
     chatMode: ctx.chatMode,
+    balance,
   });
   await ctx.channel.send(ctx.msg.chatId, { card }, commandReplyOptions(ctx));
 }

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -68,7 +68,7 @@ export function buildPlist(inputs: PlistInputs): string {
 `;
 }
 
-export async function writePlist(profile: string): Promise<void> {
+export async function writePlist(profile: string, channelHome?: string): Promise<void> {
   const bridgeEntryPath = process.argv[1];
   if (!bridgeEntryPath) {
     throw new Error('cannot determine bridge entry path (process.argv[1] is empty)');
@@ -78,7 +78,7 @@ export async function writePlist(profile: string): Promise<void> {
     bridgeEntryPath,
     envPath: process.env.PATH ?? '',
     profile,
-    channelHome: paths.rootDir,
+    channelHome: channelHome ?? paths.rootDir,
   });
   const plistPath = launchAgentPlistPath(profile);
   await mkdir(dirname(plistPath), { recursive: true });

--- a/src/daemon/paths.ts
+++ b/src/daemon/paths.ts
@@ -94,6 +94,17 @@ export function daemonStdoutPath(profile: string = paths.profile): string {
   return join(daemonLogDir(profile), 'daemon-stdout.log');
 }
 
+/**
+ * Path to the persisted systemd service file in the bridge's own config
+ * directory (~/.lark-channel/bot.<profile>.service). Written once by the
+ * first `start` and read on subsequent starts so users can edit the unit
+ * file without it being overwritten by the built-in template.
+ */
+export function channelUnitPath(profile: string = paths.profile, rootDir?: string): string {
+  const base = rootDir ?? paths.rootDir;
+  return join(base, `bot.${serviceProfileId(profile)}.service`);
+}
+
 export function daemonStderrPath(profile: string = paths.profile): string {
   return join(daemonLogDir(profile), 'daemon-stderr.log');
 }

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -46,7 +46,7 @@ export function buildLauncherCmd(inputs: LauncherInputs): string {
   ].join('\r\n');
 }
 
-async function writeLauncherCmd(profile: string): Promise<void> {
+export async function writeLauncherCmd(profile: string, channelHome?: string): Promise<void> {
   const bridgeEntryPath = process.argv[1];
   if (!bridgeEntryPath) {
     throw new Error('cannot determine bridge entry path (process.argv[1] is empty)');
@@ -56,7 +56,7 @@ async function writeLauncherCmd(profile: string): Promise<void> {
     bridgeEntryPath,
     envPath: process.env.PATH ?? '',
     profile,
-    channelHome: paths.rootDir,
+    channelHome: channelHome ?? paths.rootDir,
   });
   const cmdPath = windowsLauncherCmdPath(profile);
   await mkdir(dirname(cmdPath), { recursive: true });

--- a/src/daemon/service-adapter.ts
+++ b/src/daemon/service-adapter.ts
@@ -73,7 +73,10 @@ function makeLaunchdAdapter(profile: string): ServiceAdapter {
     // launchd has no separate "disable" — bootout already removes the
     // service from launchd, which also nukes KeepAlive / RunAtLoad.
     stopAndDisableAutostart: () => launchd.bootout(profile),
-    restart: () => launchd.kickstart(profile),
+    restart: async () => {
+      await launchd.writePlist(profile);
+      return launchd.kickstart(profile);
+    },
     waitUntilStopped: (timeoutMs) => launchd.waitUntilUnloaded(profile, timeoutMs),
     deleteFile: () => launchd.deletePlist(profile),
     describeStatus: () => launchd.describeService(profile),
@@ -98,7 +101,11 @@ function makeSystemdAdapter(profile: string): ServiceAdapter {
     start: () => systemd.enableAndStart(profile),
     stop: () => systemd.stop(profile),
     stopAndDisableAutostart: () => systemd.disableAndStop(profile),
-    restart: () => systemd.restart(profile),
+    restart: async () => {
+      await systemd.writeUnit(profile);
+      systemd.daemonReload();
+      return systemd.restart(profile);
+    },
     waitUntilStopped: (timeoutMs) => systemd.waitUntilInactive(profile, timeoutMs),
     deleteFile: async () => {
       await systemd.deleteUnit(profile);
@@ -133,7 +140,11 @@ function makeSchtasksAdapter(profile: string): ServiceAdapter {
     stop: () => schtasks.endTask(profile),
     stopAndDisableAutostart: () => schtasks.endAndDisable(profile),
     // schtasks has no native /Restart — adapter awaits end+wait+run.
-    restart: () => schtasks.restartTask(profile),
+    // Rewrite the launcher .cmd first so current node/PATH/env are captured.
+    restart: async () => {
+      await schtasks.writeLauncherCmd(profile);
+      return schtasks.restartTask(profile);
+    },
     waitUntilStopped: (timeoutMs) => schtasks.waitUntilStopped(profile, timeoutMs),
     deleteFile: async () => {
       await schtasks.deleteTask(profile);

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1,8 +1,9 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import {
+  channelUnitPath,
   daemonLogDir,
   daemonStderrPath,
   daemonStdoutPath,
@@ -42,7 +43,7 @@ export interface UnitInputs {
 export function buildUnit(inputs: UnitInputs): string {
   const escape = (s: string): string => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   return `[Unit]
-Description=Lark Channel Bridge bot
+Description=Lark Channel Bridge bot ${inputs.profile}
 After=network-online.target
 Wants=network-online.target
 
@@ -61,19 +62,31 @@ WantedBy=default.target
 `;
 }
 
-export async function writeUnit(profile: string): Promise<void> {
-  const bridgeEntryPath = process.argv[1];
-  if (!bridgeEntryPath) {
-    throw new Error('cannot determine bridge entry path (process.argv[1] is empty)');
-  }
-  const content = buildUnit({
-    nodePath: process.execPath,
-    bridgeEntryPath,
-    envPath: process.env.PATH ?? '',
-    profile,
-    channelHome: paths.rootDir,
-  });
+export async function writeUnit(profile: string, channelHome?: string): Promise<void> {
   const unitPath = systemdUnitPath(profile);
+  const persistedPath = channelUnitPath(profile, channelHome);
+
+  if (!existsSync(persistedPath)) {
+    const bridgeEntryPath = process.argv[1];
+    if (!bridgeEntryPath) {
+      throw new Error('cannot determine bridge entry path (process.argv[1] is empty)');
+    }
+    await mkdir(dirname(persistedPath), { recursive: true });
+    await writeFile(
+      persistedPath,
+      buildUnit({
+        nodePath: process.execPath,
+        bridgeEntryPath,
+        envPath: process.env.PATH ?? '',
+        profile,
+        channelHome: channelHome ?? paths.rootDir,
+      }),
+      'utf8',
+    );
+  }
+
+  const content = await readFile(persistedPath, 'utf8');
+
   await mkdir(dirname(unitPath), { recursive: true });
   await mkdir(daemonLogDir(profile), { recursive: true });
   await writeFile(unitPath, content, 'utf8');

--- a/src/utils/model-balance.ts
+++ b/src/utils/model-balance.ts
@@ -1,0 +1,338 @@
+import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { resolveAppPaths } from '../config/app-paths';
+import { getSecret, setSecret } from '../config/keystore';
+import { log } from '../core/logger';
+
+// ========================================================================
+// Types
+// ========================================================================
+
+export interface ResolvedProvider {
+    apiKey: string;
+    providerName: string;
+    baseUrl: string;
+}
+
+// ========================================================================
+// Keystore key helper — entry IDs use profile name as prefix so that
+// multiple profiles coexist in the same secrets.enc.
+// Examples: `claude:OPENAI_API_KEY`, `codex:OPENAI_BASE_URL`
+// ========================================================================
+
+function ksKey(keyName: string, profile: string): string {
+    return `${profile}:${keyName}`;
+}
+
+// ========================================================================
+// Provider declarations — balance fetch only (key resolution is now
+// entirely driven by the per-profile import sources below).
+// ========================================================================
+
+/** balanceFetchers[providerName] → fetches account balance from the provider API */
+const balanceFetchers: Record<string, (apiKey: string, baseUrl: string) => Promise<string | undefined>> = {
+    DeepSeek: fetchDeepseekBalance,
+    Kimi: fetchKimiBalance,
+};
+
+/**
+ * profileImportSources[profileName] → declares how to auto-import model
+ * keys for each supported agent platform.
+ *
+ * Profile  Import logic
+ * -------  ------------------------------------------------------------------
+ * claude   Read `~/.claude/settings.json` env section — Claude stores its
+ *          full env config (including API keys) in this JSON file.
+ *
+ * codex    Codex CLI does **not** store actual API keys in any config file.
+ *          Its `~/.codex/config.toml` maps provider IDs to env var names
+ *          via `env_key` (e.g. `env_key = "OPENAI_API_KEY"`). The actual
+ *          key value only exists in the codex process's environment at
+ *          runtime, which is invisible to lark-bridge (a separate daemon).
+ *
+ *          What we CAN extract from `config.toml`:
+ *            - active model_provider (e.g. "deepseek")
+ *            - base_url for that provider
+ *            - env_key (the env var name, e.g. "OPENAI_API_KEY")
+ *
+ *          What we CANNOT extract:
+ *            - the actual API key value
+ *
+ *          The import writes `base_url` to keystore. For the API key, it
+ *          tries `process.env[envKey]` (best-effort — works if daemon is
+ *          started from a session where the env var happens to be set).
+ *          If the key is unavailable, the import silently skips it; the
+ *          user can set it manually via `lark-channel-bridge secrets set`.
+ */
+const profileImportSources: Record<string, (profile: string) => Promise<boolean>> = {
+    claude: importFromClaudeSettings,
+    codex: importFromCodexConfig,
+};
+
+// ========================================================================
+// Resolution logic
+// ========================================================================
+
+/**
+ * Resolve the model provider info — checks, in order:
+ *  1. Per-profile encrypted keystore (entries `<profile>:OPENAI_API_KEY` etc.)
+ *  2. Auto-import from agent config, then retry keystore
+ *
+ * Note: `process.env` is deliberately NOT checked here. lark-bridge runs
+ * as a standalone daemon (or foreground process), not as a child of the
+ * agent CLI. The agent's environment variables belong to the agent process
+ * and are never inherited by the bridge.
+ */
+export async function resolveModelProvider(profile?: string): Promise<ResolvedProvider | null> {
+    if (!profile) return null;
+
+    // 1. Try per-profile encrypted keystore
+    const storeProvider = await resolveFromKeystore(profile);
+    if (storeProvider) {
+        return storeProvider;
+    }
+
+    // 2. Auto-import from the agent's native config, then retry
+    const importFn = profileImportSources[profile];
+    if (importFn) {
+        try {
+            const ok = await importFn(profile);
+            if (ok) {
+                const retry = await resolveFromKeystore(profile);
+                if (retry) {
+                    return retry;
+                }
+            }
+        } catch (err) {
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Fetch the account balance from the model provider.
+ * Routes to the right fetcher via `balanceFetchers[provider.providerName]`.
+ */
+export async function fetchModelBalance(provider: ResolvedProvider): Promise<string | undefined> {
+    const fetcher = balanceFetchers[provider.providerName];
+    return fetcher ? fetcher(provider.apiKey, provider.baseUrl) : undefined;
+}
+
+// ---- keystore helpers ----
+
+function storePathsFor(profile: string) {
+    const p = resolveAppPaths({ profile });
+    return { secretsFile: p.secretsFile, keystoreSaltFile: p.keystoreSaltFile };
+}
+
+async function resolveFromKeystore(profile: string): Promise<ResolvedProvider | null> {
+    try {
+        const sp = storePathsFor(profile);
+        const openaiKey = await getSecret(ksKey('OPENAI_API_KEY', profile), sp);
+        const baseUrl = await getSecret(ksKey('OPENAI_BASE_URL', profile), sp);
+
+        if (openaiKey && baseUrl?.includes('deepseek.com')) {
+            return { apiKey: openaiKey, providerName: 'DeepSeek', baseUrl };
+        }
+
+        const moonshotKey = await getSecret(ksKey('MOONSHOT_API_KEY', profile), sp);
+        if (moonshotKey) {
+            return { apiKey: moonshotKey, providerName: 'Kimi', baseUrl: 'https://api.moonshot.cn' };
+        }
+
+        return null;
+    } catch (err) {
+        return null;
+    }
+}
+
+// ========================================================================
+// Profile import implementations
+// ========================================================================
+
+/**
+ * Import from Claude Code's `~/.claude/settings.json`.
+ *
+ * This file has an `env` section containing the full env config
+ * (API keys, base URLs, model preferences).
+ */
+async function importFromClaudeSettings(profile: string): Promise<boolean> {
+    const settingsPath = join(homedir(), '.claude', 'settings.json');
+    let raw: string;
+    try {
+        raw = await readFile(settingsPath, 'utf8');
+    } catch {
+        return false;
+    }
+
+    let parsed: { env?: Record<string, string> };
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return false;
+    }
+
+    const env = parsed?.env;
+    if (!env || typeof env !== 'object') {
+        return false;
+    }
+
+    const relevantKeys = ['OPENAI_API_KEY', 'OPENAI_BASE_URL', 'MOONSHOT_API_KEY'];
+    const sp = storePathsFor(profile);
+    let count = 0;
+
+    for (const key of relevantKeys) {
+        const val = env[key];
+        if (val && typeof val === 'string') {
+            await setSecret(ksKey(key, profile), val, sp);
+            count++;
+        }
+    }
+
+    if (count > 0) {
+        log.info('model-balance', 'imported-claude-keys', { profile, count });
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Import from Codex CLI's `~/.codex/config.toml`.
+ *
+ * Codex stores provider config (base_url, env_key reference) in TOML
+ * format. The actual API key is NOT in this file — it comes from the
+ * environment variable named by `env_key`. We extract what we can:
+ *
+ *  - `base_url` is written directly to the keystore
+ *  - API key is read from `process.env[envKey]` if available (best-effort)
+ *
+ * Returns true if at least `base_url` was successfully imported.
+ */
+async function importFromCodexConfig(profile: string): Promise<boolean> {
+    const configPath = join(homedir(), '.codex', 'config.toml');
+    if (!existsSync(configPath)) {
+        return false;
+    }
+
+    let raw: string;
+    try {
+        raw = await readFile(configPath, 'utf8');
+    } catch {
+        return false;
+    }
+
+    // Parse the active model_provider name (e.g. `model_provider = "deepseek"`)
+    const modelProvider = raw.match(/^model_provider\s*=\s*"([^"]+)"\s*$/m)?.[1];
+    if (!modelProvider) {
+        return false;
+    }
+
+    // Find the matching [model_providers.<name>] section and extract its content
+    const sectionRe = new RegExp(`\\[model_providers\\.${escapeRegex(modelProvider)}\\]\\s*\\n([^\\[]*)`);
+    const sectionMatch = raw.match(sectionRe);
+    if (!sectionMatch || !sectionMatch[1]) {
+        return false;
+    }
+    const sectionBody = sectionMatch[1];
+
+    const baseUrl = sectionBody.match(/^base_url\s*=\s*"([^"]+)"\s*$/m)?.[1];
+    const envKey = sectionBody.match(/^env_key\s*=\s*"([^"]+)"\s*$/m)?.[1];
+
+    if (!baseUrl) {
+        return false;
+    }
+
+    const sp = storePathsFor(profile);
+
+    // Store base_url — always available from config.toml
+    await setSecret(ksKey('OPENAI_BASE_URL', profile), baseUrl, sp);
+
+    // Store API key — only available if the env var happens to be set in our
+    // process (e.g. when the daemon is started from a login shell that exports it)
+    if (envKey) {
+        const keyValue = process.env[envKey];
+        if (keyValue) {
+            await setSecret(ksKey('OPENAI_API_KEY', profile), keyValue, sp);
+            log.info('model-balance', 'imported-codex-key', { profile, envKey });
+        }
+    }
+
+    return true;
+}
+
+function escapeRegex(s: string): string {
+    return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ========================================================================
+// Provider-specific balance fetch implementations
+// ========================================================================
+
+async function fetchDeepseekBalance(apiKey: string, baseUrl: string): Promise<string | undefined> {
+    try {
+        const url = `${baseUrl.replace(/\/+$/, '')}/user/balance`;
+        const res = await fetch(url, {
+            headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (!res.ok) {
+            log.warn('model-balance', 'deepseek-fetch-failed', { status: res.status });
+            return undefined;
+        }
+        const body = (await res.json()) as {
+            is_available?: boolean;
+            balance_infos?: Array<{
+                currency?: string;
+                total_balance?: string;
+                granted_balance?: string;
+                topped_up_balance?: string;
+            }>;
+        };
+        if (!body.balance_infos || body.balance_infos.length === 0) {
+            return body.is_available === false ? '不可用' : undefined;
+        }
+        return body.balance_infos
+            .map((b) => {
+                const cur = b.currency ?? 'CNY';
+                const total = b.total_balance ?? '?';
+                return `${cur} ${total}`;
+            })
+            .join(' / ');
+    } catch (err) {
+        log.warn('model-balance', 'deepseek-error', {
+            message: err instanceof Error ? err.message : String(err),
+        });
+        return undefined;
+    }
+}
+
+async function fetchKimiBalance(apiKey: string, _baseUrl: string): Promise<string | undefined> {
+    try {
+        const res = await fetch('https://api.moonshot.cn/v1/users/me/balance', {
+            headers: { Authorization: `Bearer ${apiKey}` },
+        });
+        if (!res.ok) {
+            log.warn('model-balance', 'kimi-fetch-failed', { status: res.status });
+            return undefined;
+        }
+        const body = (await res.json()) as {
+            status?: boolean;
+            data?: {
+                available_balance?: number;
+                voucher_balance?: number;
+                cash_balance?: number;
+            };
+        };
+        if (body.data?.available_balance !== undefined) {
+            return `¥${body.data.available_balance.toFixed(2)}`;
+        }
+        return undefined;
+    } catch (err) {
+        log.warn('model-balance', 'kimi-error', {
+            message: err instanceof Error ? err.message : String(err),
+        });
+        return undefined;
+    }
+}

--- a/tests/unit/cli/service-profile.test.ts
+++ b/tests/unit/cli/service-profile.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../../src/config/paths', () => ({
 vi.mock('../../../src/daemon/paths', () => ({
   daemonStdoutPath: (profile: string) => `/tmp/lark-channel-home/profiles/${profile}/logs/daemon/stdout.log`,
   daemonStderrPath: (profile: string) => `/tmp/lark-channel-home/profiles/${profile}/logs/daemon/stderr.log`,
+  systemdUnitPath: (profile: string) => `/root/.config/systemd/user/lark-channel-bridge.bot.${profile}.service`,
 }));
 
 vi.mock('../../../src/cli/preflight', () => ({


### PR DESCRIPTION
## Changes

 src/cli/commands/start.ts              |  9 ++++++++
 src/daemon/launchd.ts                  |  4 ++--
 src/daemon/paths.ts                    | 11 +++++++++
 src/daemon/schtasks.ts                 |  4 ++--
 src/daemon/service-adapter.ts          | 17 +++++++++++---
 src/daemon/systemd.ts                  | 41 ++++++++++++++++++++++------------
 tests/unit/cli/service-profile.test.ts |  1 +
 7 files changed, 66 insertions(+), 21 deletions(-)

## Summary

- writeUnit/writePlist/writeLauncherCmd 接受 channelHome 参数
- writeUnit 优先读取持久化文件，用户可自定义 unit 不被覆盖
- 三个平台的 service-adapter restart 方法重启前重新生成文件