### PR TITLE
feat(linux): systemd unit 文件持久化

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lark-channel-bridge",
-  "version": "0.5.6",
+  "version": "0.5.6-unofficial.persist.0",
   "description": "Bridge Feishu/Lark messenger with local CLI coding agents",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -409,6 +409,7 @@ export async function runServiceStatus(opts: ServiceProfileOptions = {}): Promis
     console.log('✓ bot 正在后台运行');
   }
   if (pid) console.log(`  进程 ID: ${pid}`);
+  console.log(`  服务文件: ${adapter.servicePath()}`);
   console.log('  日志:');
   console.log(`    ${daemonStdoutPath(profile)}`);
   console.log(`    ${daemonStderrPath(profile)}`);

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -19,6 +19,7 @@ import {
 } from '../../config/profile-schema';
 import type { AppConfig } from '../../config/schema';
 import { isComplete } from '../../config/schema';
+import { daemonReload, writeUnit } from '../../daemon/systemd';
 import { configureLogger, gcOldLogs, log, reportError } from '../../core/logger';
 import { loadTelemetryAdapter, telemetry } from '../../core/telemetry';
 import { gcMediaCache } from '../../media/cache';
@@ -98,6 +99,16 @@ export async function runStart(opts: StartOptions): Promise<void> {
   const appPaths = runtime.appPaths;
   let profileConfig = runtime.profileConfig;
   configureLogger({ logsDir: appPaths.logsDir });
+
+  // Sync the persisted unit file (written by `start`/`restart` adapter phase) to
+  // the user-level systemd unit path, then reload so systemd picks it up.
+  // Both `start`/`restart` service commands ultimately execute `bridge run`,
+  // so the sync lives here — in the `run` phase — rather than duplicating it
+  // in the adapter.
+  try {
+    await writeUnit(appPaths.profile, appPaths.rootDir);
+    daemonReload();
+  } catch {}
 
   await preFlightChecks({
     skipCheckLarkCli: opts.skipCheckLarkCli,

--- a/src/daemon/paths.ts
+++ b/src/daemon/paths.ts
@@ -94,6 +94,17 @@ export function daemonStdoutPath(profile: string = paths.profile): string {
   return join(daemonLogDir(profile), 'daemon-stdout.log');
 }
 
+/**
+ * Path to the persisted systemd service file in the bridge's own config
+ * directory (~/.lark-channel/bot.<profile>.service). Written once by the
+ * first `start` and read on subsequent starts so users can edit the unit
+ * file without it being overwritten by the built-in template.
+ */
+export function channelUnitPath(profile: string = paths.profile, rootDir?: string): string {
+  const base = rootDir ?? paths.rootDir;
+  return join(base, `bot.${serviceProfileId(profile)}.service`);
+}
+
 export function daemonStderrPath(profile: string = paths.profile): string {
   return join(daemonLogDir(profile), 'daemon-stderr.log');
 }

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1,8 +1,9 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdir, rm, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import {
+  channelUnitPath,
   daemonLogDir,
   daemonStderrPath,
   daemonStdoutPath,
@@ -42,7 +43,7 @@ export interface UnitInputs {
 export function buildUnit(inputs: UnitInputs): string {
   const escape = (s: string): string => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
   return `[Unit]
-Description=Lark Channel Bridge bot
+Description=Lark Channel Bridge bot ${inputs.profile}
 After=network-online.target
 Wants=network-online.target
 
@@ -61,19 +62,31 @@ WantedBy=default.target
 `;
 }
 
-export async function writeUnit(profile: string): Promise<void> {
-  const bridgeEntryPath = process.argv[1];
-  if (!bridgeEntryPath) {
-    throw new Error('cannot determine bridge entry path (process.argv[1] is empty)');
-  }
-  const content = buildUnit({
-    nodePath: process.execPath,
-    bridgeEntryPath,
-    envPath: process.env.PATH ?? '',
-    profile,
-    channelHome: paths.rootDir,
-  });
+export async function writeUnit(profile: string, channelHome?: string): Promise<void> {
   const unitPath = systemdUnitPath(profile);
+  const persistedPath = channelUnitPath(profile, channelHome);
+
+  if (!existsSync(persistedPath)) {
+    const bridgeEntryPath = process.argv[1];
+    if (!bridgeEntryPath) {
+      throw new Error('cannot determine bridge entry path (process.argv[1] is empty)');
+    }
+    await mkdir(dirname(persistedPath), { recursive: true });
+    await writeFile(
+      persistedPath,
+      buildUnit({
+        nodePath: process.execPath,
+        bridgeEntryPath,
+        envPath: process.env.PATH ?? '',
+        profile,
+        channelHome: channelHome ?? paths.rootDir,
+      }),
+      'utf8',
+    );
+  }
+
+  const content = await readFile(persistedPath, 'utf8');
+
   await mkdir(dirname(unitPath), { recursive: true });
   await mkdir(daemonLogDir(profile), { recursive: true });
   await writeFile(unitPath, content, 'utf8');

--- a/tests/unit/cli/service-profile.test.ts
+++ b/tests/unit/cli/service-profile.test.ts
@@ -52,6 +52,7 @@ vi.mock('../../../src/config/paths', () => ({
 vi.mock('../../../src/daemon/paths', () => ({
   daemonStdoutPath: (profile: string) => `/tmp/lark-channel-home/profiles/${profile}/logs/daemon/stdout.log`,
   daemonStderrPath: (profile: string) => `/tmp/lark-channel-home/profiles/${profile}/logs/daemon/stderr.log`,
+  systemdUnitPath: (profile: string) => `/root/.config/systemd/user/lark-channel-bridge.bot.${profile}.service`,
 }));
 
 vi.mock('../../../src/cli/preflight', () => ({


### PR DESCRIPTION
## 概述

Linux 平台下，systemd user service 的单元文件由 bridge 内置模板动态生成（`buildUnit()`），
用户无法自定义 unit 配置（如新增环境变量、调整 RestartSec 等参数）。
本修改引入持久化机制，将 unit 文件存入 bridge 配置目录（`~/.lark-channel/`），
用户可直接编辑持久化文件实现自定义配置，且不会被内置模板覆盖。

## systemd unit 文件持久化

### 持久化文件路径

新增 `channelUnitPath()` 返回 `~/.lark-channel/bot.<profile>.service`。
该文件由首次 `run` / `start` 自动创建，后续运行直接读取。

### 读取策略（src/daemon/systemd.ts）

`writeUnit()` 的执行逻辑改为：

1. 检查持久化文件 `~/.lark-channel/bot.<profile>.service` 是否存在
2. **存在** → 直接读取其内容作为 unit 配置（用户可自由编辑该文件）
3. **不存在** → 调用 `buildUnit()` 生成模板并写入持久化路径

### 同步到 systemd（src/cli/commands/start.ts）

在 `runStart()` 阶段（`start`/`restart` 的 ExecStart 均指向 `run`）调用 `writeUnit()`，
将持久化文件内容同步到用户级 systemd unit 路径 `~/.config/systemd/user/`。

## 其他平台说明

-   **macOS (launchd)** — `launchctl bootstrap` 直接读取 plist 文件，无缓存机制，无需持久化
-   **Windows (schtasks)** — 任务存储在 Task Scheduler 数据库中，无文件缓存问题

## 修改的文件

1. **`src/daemon/paths.ts`** — 新增 `channelUnitPath()` 函数
2. **`src/daemon/systemd.ts`** — `writeUnit()` 增加持久化文件读取逻辑
3. **`src/cli/commands/start.ts`** — `runStart()` 调用 `writeUnit()` 同步配置