### PR TITLE
MID-15: prevent oversized Lark card replies from disappearing

### DIFF
--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -18,7 +18,7 @@ import type { AgentAdapter, AgentEvent } from '../agent/types';
 import { handleCardAction } from '../card/dispatcher';
 import { CallbackAuth } from '../card/callback-auth';
 import { CallbackNonceStore } from '../card/callback-store';
-import { renderCard } from '../card/run-renderer';
+import { getCardPayloadViolation, renderCard } from '../card/run-renderer';
 import {
   finalizeIfRunning,
   initialState,
@@ -27,7 +27,7 @@ import {
   reduce,
   type RunState,
 } from '../card/run-state';
-import { renderText } from '../card/text-renderer';
+import { renderBoundedText, renderText } from '../card/text-renderer';
 import { tryHandleCommand, type Controls } from '../commands';
 import type { AppConfig } from '../config/schema';
 import {
@@ -1026,9 +1026,53 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     if (replyMode === 'card') {
       let latestState: RunState = initialState;
       let producerStarted = false;
+      let cardUpdateFailed = false;
+      let cardUpdatesDisabled = false;
       let cardCtrl:
-        | { update(next: object | ((current: object) => object)): Promise<void> }
+        | {
+            update(next: object | ((current: object) => object)): Promise<void>;
+            readonly messageId?: string;
+          }
         | undefined;
+      const rememberCardUpdateFailure = (err: unknown, step: string): void => {
+        if (!cardUpdateFailed) {
+          log.warn('card', 'update-failed-degrading-to-markdown', {
+            scope,
+            step,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+        cardUpdateFailed = true;
+        cardUpdatesDisabled = true;
+      };
+      const updateCard = async (state: RunState): Promise<void> => {
+        if (!cardCtrl || cardUpdatesDisabled) return;
+        try {
+          const card = renderCard(filterForPrefs(state), cardRenderOptions);
+          const violation = getCardPayloadViolation(card);
+          if (violation) {
+            rememberCardUpdateFailure(new Error(violation), 'preflight');
+            return;
+          }
+          await cardCtrl.update(card);
+        } catch (err) {
+          rememberCardUpdateFailure(err, 'update');
+        }
+      };
+      let cardDegradedReplySent = false;
+      const sendCardDegradedReply = async (): Promise<void> => {
+        if (cardDegradedReplySent) return;
+        cardDegradedReplySent = true;
+        await sendStreamDegradedFinalReply({
+          channel,
+          chatId,
+          scope,
+          state: filterForPrefs(latestState),
+          sendOpts,
+          mode: 'card',
+        });
+        await markCardDeliveryDegraded(channel, cardCtrl?.messageId, scope);
+      };
       const renderDone = processAgentStream(
         handle,
         eventStream,
@@ -1037,9 +1081,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         recordSession,
         async (state) => {
           latestState = state;
-          if (cardCtrl) {
-            await cardCtrl.update(renderCard(filterForPrefs(state), cardRenderOptions));
-          }
+          await updateCard(state);
         },
       );
       const streamDone = channel.stream(
@@ -1050,30 +1092,98 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
             producer: async (ctrl) => {
               producerStarted = true;
               cardCtrl = ctrl;
-              await ctrl.update(renderCard(filterForPrefs(latestState), cardRenderOptions));
+              await updateCard(latestState);
               await renderDone;
             },
           },
         },
         sendOpts,
       );
-      await awaitRenderAwareStream({
-        mode: replyMode,
-        streamDone,
-        renderDone,
-        producerStarted: () => producerStarted,
-        fallback: async (state) => {
-          await channel.send(
-            chatId,
-            { card: renderCard(filterForPrefs(state), cardRenderOptions) },
-            sendOpts,
-          );
-        },
-      });
+      try {
+        await awaitRenderAwareStream({
+          mode: replyMode,
+          streamDone,
+          renderDone,
+          producerStarted: () => producerStarted,
+          onLateTerminal: async (result) => {
+            if (!result.ok) {
+              rememberCardUpdateFailure(result.err, 'stream-terminal-late');
+            }
+            if (cardUpdateFailed) await sendCardDegradedReply();
+          },
+          fallback: async (state) => {
+            try {
+              const card = renderCard(filterForPrefs(state), cardRenderOptions);
+              const violation = getCardPayloadViolation(card);
+              if (violation) throw new Error(violation);
+              await channel.send(
+                chatId,
+                { card },
+                sendOpts,
+              );
+            } catch (err) {
+              rememberCardUpdateFailure(err, 'fallback-card-send');
+              throw err;
+            }
+          },
+        });
+      } catch (err) {
+        rememberCardUpdateFailure(err, 'stream');
+      }
+      if (cardUpdateFailed) {
+        await sendCardDegradedReply();
+      }
     } else if (replyMode === 'markdown') {
       let latestState: RunState = initialState;
       let producerStarted = false;
-      let markdownCtrl: { setContent(markdown: string): Promise<void> } | undefined;
+      let markdownUpdateFailed = false;
+      let markdownUpdatesDisabled = false;
+      let markdownCtrl:
+        | {
+            setContent(markdown: string): Promise<void>;
+            /** @larksuite/channel 0.3.x records async patch failures here. */
+            streamingFailed?: boolean;
+          }
+        | undefined;
+      const rememberMarkdownUpdateFailure = (err: unknown, step: string): void => {
+        if (!markdownUpdateFailed) {
+          log.warn('markdown', 'update-failed-degrading-to-send', {
+            scope,
+            step,
+            err: err instanceof Error ? err.message : String(err),
+          });
+        }
+        markdownUpdateFailed = true;
+        markdownUpdatesDisabled = true;
+      };
+      const updateMarkdown = async (state: RunState): Promise<void> => {
+        if (!markdownCtrl || markdownUpdatesDisabled) return;
+        try {
+          await markdownCtrl.setContent(renderText(filterForPrefs(state)));
+        } catch (err) {
+          rememberMarkdownUpdateFailure(err, 'update');
+        }
+      };
+      const detectMarkdownSdkFailure = (): void => {
+        if (!markdownCtrl?.streamingFailed) return;
+        rememberMarkdownUpdateFailure(
+          new Error('channel SDK reported an asynchronous markdown update failure'),
+          'sdk-update',
+        );
+      };
+      let markdownDegradedReplySent = false;
+      const sendMarkdownDegradedReply = async (): Promise<void> => {
+        if (markdownDegradedReplySent) return;
+        markdownDegradedReplySent = true;
+        await sendStreamDegradedFinalReply({
+          channel,
+          chatId,
+          scope,
+          state: filterForPrefs(latestState),
+          sendOpts,
+          mode: 'markdown',
+        });
+      };
       const renderDone = processAgentStream(
         handle,
         eventStream,
@@ -1082,9 +1192,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         recordSession,
         async (state) => {
           latestState = state;
-          if (markdownCtrl) {
-            await markdownCtrl.setContent(renderText(filterForPrefs(state)));
-          }
+          await updateMarkdown(state);
         },
       );
       const streamDone = channel.stream(
@@ -1093,24 +1201,39 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
           markdown: async (ctrl) => {
             producerStarted = true;
             markdownCtrl = ctrl;
-            await ctrl.setContent(renderText(filterForPrefs(latestState)));
+            await updateMarkdown(latestState);
             await renderDone;
           },
         },
         sendOpts,
       );
-      await awaitRenderAwareStream({
-        mode: replyMode,
-        streamDone,
-        renderDone,
-        producerStarted: () => producerStarted,
-        fallback: async (state) => {
-          const body = renderText(filterForPrefs(state));
-          if (body.trim()) {
-            await channel.send(chatId, { markdown: body }, sendOpts);
-          }
-        },
-      });
+      try {
+        await awaitRenderAwareStream({
+          mode: replyMode,
+          streamDone,
+          renderDone,
+          producerStarted: () => producerStarted,
+          onLateTerminal: async (result) => {
+            if (!result.ok) {
+              rememberMarkdownUpdateFailure(result.err, 'stream-terminal-late');
+            }
+            detectMarkdownSdkFailure();
+            if (markdownUpdateFailed) await sendMarkdownDegradedReply();
+          },
+          fallback: async (state) => {
+            const body = renderText(filterForPrefs(state));
+            if (body.trim()) {
+              await channel.send(chatId, { markdown: body }, sendOpts);
+            }
+          },
+        });
+      } catch (err) {
+        rememberMarkdownUpdateFailure(err, 'stream');
+      }
+      detectMarkdownSdkFailure();
+      if (markdownUpdateFailed) {
+        await sendMarkdownDegradedReply();
+      }
     } else {
       // text mode: drain the agent stream without sending anything during
       // the run, then post the final rendered text once as a plain markdown
@@ -1141,7 +1264,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
   }
 }
 
-async function sendFinalReply(input: {
+export async function sendFinalReply(input: {
   channel: LarkChannel;
   chatId: string;
   scope: string;
@@ -1153,24 +1276,46 @@ async function sendFinalReply(input: {
   const body = renderText(input.state);
 
   if (input.replyMode === 'card') {
-    const result = await input.channel.send(
-      input.chatId,
-      { card: renderCard(input.state, input.cardRenderOptions) },
-      input.sendOpts,
-    );
-    log.info('outbound', 'sent', outboundLogFields(input, 'card', body, result));
+    const card = renderCard(input.state, input.cardRenderOptions);
+    const violation = getCardPayloadViolation(card);
+    if (violation) {
+      log.warn('card', 'final-preflight-failed', { scope: input.scope, err: violation });
+      await sendStreamDegradedFinalReply({ ...input, mode: 'card' });
+      return;
+    }
+    try {
+      const result = await input.channel.send(
+        input.chatId,
+        { card },
+        input.sendOpts,
+      );
+      log.info('outbound', 'sent', outboundLogFields(input, 'card', body, result));
+    } catch (err) {
+      log.warn('card', 'final-send-failed', {
+        scope: input.scope,
+        err: err instanceof Error ? err.message : String(err),
+      });
+      await sendStreamDegradedFinalReply({ ...input, mode: 'card' });
+    }
   } else if (input.replyMode === 'markdown') {
     if (body.trim()) {
+      let markdownCtrl:
+        | { setContent(markdown: string): Promise<void>; streamingFailed?: boolean }
+        | undefined;
       try {
         await input.channel.stream(
           input.chatId,
           {
             markdown: async (ctrl) => {
+              markdownCtrl = ctrl;
               await ctrl.setContent(body);
             },
           },
           input.sendOpts,
         );
+        if (markdownCtrl?.streamingFailed) {
+          throw new Error('channel SDK reported an asynchronous markdown update failure');
+        }
         log.info('outbound', 'sent', outboundLogFields(input, 'markdown-stream', body));
       } catch (err) {
         log.warn('outbound', 'markdown-stream-fallback', {
@@ -1191,6 +1336,58 @@ async function sendFinalReply(input: {
       input.sendOpts,
     );
     log.info('outbound', 'sent', outboundLogFields(input, 'text', body, result));
+  }
+}
+
+async function sendStreamDegradedFinalReply(input: {
+  channel: LarkChannel;
+  chatId: string;
+  scope: string;
+  state: RunState;
+  sendOpts: { replyTo: string; replyInThread?: boolean };
+  mode: 'card' | 'markdown';
+}): Promise<void> {
+  const body = renderBoundedText(input.state).trim() || '_（未返回内容）_';
+  const reason =
+    input.mode === 'card' ? '飞书卡片更新失败' : '飞书流式消息更新失败';
+  const markdown = `⚠️ ${reason}，已改发截断版最终回复。\n\n${body}`;
+  try {
+    const result = await input.channel.send(input.chatId, { markdown }, input.sendOpts);
+    log.info(
+      'outbound',
+      'sent',
+      outboundLogFields(
+        { scope: input.scope, replyMode: input.mode, sendOpts: input.sendOpts },
+        'markdown-degraded',
+        markdown,
+        result,
+      ),
+    );
+  } catch (err) {
+    log.fail('stream', err, { mode: input.mode, step: 'degraded-final-fallback' });
+  }
+}
+
+async function markCardDeliveryDegraded(
+  channel: LarkChannel,
+  messageId: string | undefined,
+  scope: string,
+): Promise<void> {
+  if (!messageId) return;
+  const card = renderCard({
+    ...initialState,
+    terminal: 'error',
+    footer: null,
+    errorMsg: '飞书卡片更新失败，最终回复已改发为普通消息。',
+  });
+  try {
+    await channel.updateCard(messageId, card);
+    log.info('card', 'marked-degraded', { scope, messageId });
+  } catch (err) {
+    log.warn('card', 'mark-degraded-failed', {
+      scope,
+      err: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 
@@ -1366,12 +1563,17 @@ async function processAgentStream(
   return state;
 }
 
+type StreamTerminalResult =
+  | { ok: true }
+  | { ok: false; err: unknown };
+
 async function awaitRenderAwareStream(input: {
   mode: 'card' | 'markdown';
   streamDone: Promise<unknown>;
   renderDone: Promise<RunState>;
   producerStarted: () => boolean;
   fallback: (state: RunState) => Promise<void>;
+  onLateTerminal?: (result: StreamTerminalResult) => Promise<void>;
 }): Promise<void> {
   const streamResult = input.streamDone.then(
     () => ({ kind: 'stream' as const, ok: true as const }),
@@ -1414,9 +1616,14 @@ async function awaitRenderAwareStream(input: {
       mode: input.mode,
       graceMs: STREAM_TERMINAL_GRACE_MS,
     });
-    void streamResult.then((result) => {
+    void streamResult.then(async (result) => {
       if (!result.ok) {
         log.fail('stream', result.err, { mode: input.mode, step: 'stream-terminal-late' });
+      }
+      try {
+        await input.onLateTerminal?.(result);
+      } catch (err) {
+        log.fail('stream', err, { mode: input.mode, step: 'late-terminal-handler' });
       }
     });
     return;

--- a/src/card/run-renderer.ts
+++ b/src/card/run-renderer.ts
@@ -3,6 +3,14 @@ import { toolBodyMd, toolHeaderText } from './tool-render';
 
 const REASONING_MAX = 1500;
 const COLLAPSE_TOOL_THRESHOLD = 3;
+const CARD_BODY_ELEMENT_MAX = 10;
+const CARD_TOTAL_ELEMENT_MAX = 45;
+const CARD_SERIALIZED_MAX_BYTES = 24_000;
+const CARD_MARKDOWN_TABLE_MAX = 3;
+const TEXT_BLOCK_MAX = 6000;
+const TOOL_SUMMARY_MAX = 6000;
+const TEXT_TRUNCATED_NOTICE =
+  '\n\n_（回复过长，中间内容已截断以避免飞书卡片发送失败。）_\n\n';
 
 interface ToolGroup {
   kind: 'tools';
@@ -18,38 +26,65 @@ export interface RunCardRenderOptions {
   signCallback?: (action: string) => string;
 }
 
+export function getCardPayloadViolation(card: object): string | undefined {
+  const serialized = JSON.stringify(card);
+  const bytes = Buffer.byteLength(serialized, 'utf8');
+  if (bytes > CARD_SERIALIZED_MAX_BYTES) {
+    return `serialized card is ${bytes} bytes (limit ${CARD_SERIALIZED_MAX_BYTES})`;
+  }
+
+  const stats = inspectCardPayload(card);
+  if (stats.elements > CARD_TOTAL_ELEMENT_MAX) {
+    return `card has ${stats.elements} elements (limit ${CARD_TOTAL_ELEMENT_MAX})`;
+  }
+  if (stats.tables > CARD_MARKDOWN_TABLE_MAX) {
+    return `card has ${stats.tables} markdown tables (limit ${CARD_MARKDOWN_TABLE_MAX})`;
+  }
+  return undefined;
+}
+
 export function renderCard(state: RunState, options: RunCardRenderOptions = {}): object {
-  const elements: object[] = [];
+  const contentElements: object[] = [];
+  const trailingElements: object[] = [];
 
   if (state.reasoning.content) {
-    elements.push(reasoningPanel(state.reasoning.content, state.reasoning.active));
+    contentElements.push(reasoningPanel(state.reasoning.content, state.reasoning.active));
   }
 
   for (const group of groupBlocks(state.blocks)) {
     if (group.kind === 'text') {
       if (group.content.trim()) {
-        elements.push(markdown(group.content));
+        contentElements.push(markdown(group.content));
       }
     } else {
-      elements.push(...renderToolGroup(group.tools, state.terminal !== 'running'));
+      contentElements.push(...renderToolGroup(group.tools, state.terminal !== 'running'));
     }
   }
 
   if (state.terminal === 'interrupted') {
-    elements.push(noteMd('_⏹ 已被中断_'));
+    trailingElements.push(noteMd('_⏹ 已被中断_'));
   } else if (state.terminal === 'idle_timeout') {
     const mins = state.idleTimeoutMinutes ?? 0;
-    elements.push(noteMd(`_⏱ ${mins} 分钟无响应,已自动终止_`));
+    trailingElements.push(noteMd(`_⏱ ${mins} 分钟无响应,已自动终止_`));
   } else if (state.terminal === 'error' && state.errorMsg) {
-    elements.push(noteMd(`⚠️ agent 失败：${state.errorMsg}`));
-  } else if (state.terminal === 'done' && elements.length === 0) {
-    elements.push(noteMd('_（未返回内容）_'));
+    trailingElements.push(noteMd(`⚠️ agent 失败：${truncate(state.errorMsg, 2000)}`));
+  } else if (state.terminal === 'done' && contentElements.length === 0) {
+    contentElements.push(noteMd('_（未返回内容）_'));
   }
 
   if (state.terminal === 'running') {
-    if (state.footer) elements.push(footerStatus(state.footer));
-    elements.push(stopButton(options));
+    if (state.footer) trailingElements.push(footerStatus(state.footer));
+    trailingElements.push(stopButton(options));
   }
+
+  // Feishu counts nested card nodes toward its element limit. Keeping the
+  // top-level body conservative leaves room for each collapsible panel's
+  // child markdown element while preserving terminal controls and notices.
+  const contentLimit = Math.max(0, CARD_BODY_ELEMENT_MAX - trailingElements.length);
+  const elements = [
+    ...limitBodyElements(contentElements, contentLimit),
+    ...trailingElements,
+  ];
 
   return {
     schema: '2.0',
@@ -128,7 +163,10 @@ function toolPanel(tool: ToolEntry, expanded: boolean): object {
 function collapsedToolSummary(tools: ToolEntry[], finalized: boolean): object {
   const suffix = finalized ? '（已结束）' : '';
   const title = `☕ **${tools.length} 个工具调用${suffix}**`;
-  const headerList = tools.map((t) => `- ${toolHeaderText(t)}`).join('\n');
+  const headerList = limitToolSummary(
+    tools.map((t) => `- ${toolHeaderText(t)}`),
+    TOOL_SUMMARY_MAX,
+  );
   return {
     tag: 'collapsible_panel',
     expanded: false,
@@ -170,7 +208,7 @@ function panelHeader(titleMd: string): object {
 }
 
 function markdown(content: string): object {
-  return { tag: 'markdown', content };
+  return { tag: 'markdown', content: truncateWithNotice(content, TEXT_BLOCK_MAX) };
 }
 
 function noteMd(content: string): object {
@@ -212,5 +250,112 @@ function summaryText(state: RunState): string {
 }
 
 function truncate(s: string, max: number): string {
-  return s.length > max ? `${s.slice(0, max)}…` : s;
+  return s.length > max ? `${safeHead(s, max)}…` : s;
+}
+
+function truncateWithNotice(content: string, max: number): string {
+  if (content.length <= max) return content;
+  const keep = Math.max(0, max - TEXT_TRUNCATED_NOTICE.length);
+  const head = Math.floor(keep / 3);
+  const tail = keep - head;
+  return `${safeHead(content, head)}${TEXT_TRUNCATED_NOTICE}${safeTail(content, tail)}`;
+}
+
+function limitBodyElements(elements: object[], max: number): object[] {
+  if (elements.length <= max) return elements;
+  if (max <= 0) return [];
+
+  const keep = Math.max(0, max - 1);
+  const omitted = elements.length - keep;
+  return [
+    noteMd(`_（较早的 ${omitted} 个过程块已折叠，以避免飞书卡片元素超限。）_`),
+    ...elements.slice(-keep),
+  ];
+}
+
+function limitToolSummary(lines: string[], max: number): string {
+  const full = lines.join('\n');
+  if (full.length <= max) return full;
+
+  const kept: string[] = [];
+  let used = 0;
+  // Reserve enough room for the omission notice, including a large count.
+  const budget = Math.max(0, max - 80);
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i];
+    if (!line) continue;
+    const nextSize = line.length + (kept.length > 0 ? 1 : 0);
+    if (used + nextSize > budget) break;
+    kept.push(line);
+    used += nextSize;
+  }
+  kept.reverse();
+  const omitted = lines.length - kept.length;
+  const notice = `_（较早的 ${omitted} 个工具调用已省略。）_`;
+  return safeHead(`${notice}\n${kept.join('\n')}`, max);
+}
+
+function inspectCardPayload(value: unknown): { elements: number; tables: number } {
+  if (Array.isArray(value)) {
+    return value.reduce(
+      (total, item) => {
+        const next = inspectCardPayload(item);
+        return {
+          elements: total.elements + next.elements,
+          tables: total.tables + next.tables,
+        };
+      },
+      { elements: 0, tables: 0 },
+    );
+  }
+  if (!value || typeof value !== 'object') {
+    return { elements: 0, tables: 0 };
+  }
+
+  const record = value as Record<string, unknown>;
+  let elements = typeof record.tag === 'string' ? 1 : 0;
+  let tables = typeof record.content === 'string' ? countMarkdownTables(record.content) : 0;
+  for (const [key, child] of Object.entries(record)) {
+    if (key === 'content' || key === 'tag') continue;
+    const next = inspectCardPayload(child);
+    elements += next.elements;
+    tables += next.tables;
+  }
+  return { elements, tables };
+}
+
+function countMarkdownTables(content: string): number {
+  let tables = 0;
+  let fence: '```' | '~~~' | undefined;
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
+      const marker = trimmed.startsWith('```') ? '```' : '~~~';
+      if (!fence) fence = marker;
+      else if (fence === marker) fence = undefined;
+      continue;
+    }
+    if (fence) continue;
+
+    const row = trimmed.replace(/^\|/, '').replace(/\|$/, '');
+    const cells = row.split('|').map((cell) => cell.trim());
+    if (cells.length >= 2 && cells.every((cell) => /^:?-{3,}:?$/.test(cell))) {
+      tables += 1;
+    }
+  }
+  return tables;
+}
+
+function safeHead(content: string, length: number): string {
+  let end = Math.min(length, content.length);
+  const last = content.charCodeAt(end - 1);
+  if (last >= 0xd800 && last <= 0xdbff) end -= 1;
+  return content.slice(0, end);
+}
+
+function safeTail(content: string, length: number): string {
+  let start = Math.max(0, content.length - length);
+  const first = content.charCodeAt(start);
+  if (first >= 0xdc00 && first <= 0xdfff) start += 1;
+  return content.slice(start);
 }

--- a/src/card/text-renderer.ts
+++ b/src/card/text-renderer.ts
@@ -1,6 +1,10 @@
 import type { Block, RunState, ToolEntry } from './run-state';
 import { toolHeaderText } from './tool-render';
 
+const BOUNDED_REPLY_MAX = 12000;
+const TEXT_TRUNCATED_NOTICE =
+  '\n\n_（回复过长，中间内容已截断；请继续追问以获取完整内容。）_\n\n';
+
 /**
  * Render `RunState` as plain markdown text — used in `messageReply: 'text'`
  * mode where we stream a markdown message instead of a card.
@@ -33,6 +37,14 @@ export function renderText(state: RunState): string {
   return parts.join('\n\n');
 }
 
+/**
+ * Bound only degraded fallback replies. Normal markdown/text delivery is left
+ * intact because the channel SDK already rolls over or chunks long content.
+ */
+export function renderBoundedText(state: RunState, max = BOUNDED_REPLY_MAX): string {
+  return truncateReply(renderText(state), max);
+}
+
 function renderBlock(block: Block): string {
   if (block.kind === 'text') {
     return block.content.trim();
@@ -54,4 +66,26 @@ function footerLine(status: 'thinking' | 'tool_running' | 'streaming'): string {
   if (status === 'thinking') return '_🧠 正在思考…_';
   if (status === 'tool_running') return '_🧰 正在调用工具…_';
   return '_✍️ 正在输出…_';
+}
+
+function truncateReply(content: string, max: number): string {
+  if (content.length <= max) return content;
+  const keep = Math.max(0, max - TEXT_TRUNCATED_NOTICE.length);
+  const head = Math.floor(keep / 3);
+  const tail = keep - head;
+  return `${safeHead(content, head)}${TEXT_TRUNCATED_NOTICE}${safeTail(content, tail)}`;
+}
+
+function safeHead(content: string, length: number): string {
+  let end = Math.min(length, content.length);
+  const last = content.charCodeAt(end - 1);
+  if (last >= 0xd800 && last <= 0xdbff) end -= 1;
+  return content.slice(0, end);
+}
+
+function safeTail(content: string, length: number): string {
+  let start = Math.max(0, content.length - length);
+  const first = content.charCodeAt(start);
+  if (first >= 0xdc00 && first <= 0xdfff) start += 1;
+  return content.slice(start);
 }

--- a/tests/integration/bot/markdown-stream-startup-failure.test.ts
+++ b/tests/integration/bot/markdown-stream-startup-failure.test.ts
@@ -1,12 +1,14 @@
-import type { NormalizedMessage } from '@larksuite/channel';
+import type { LarkChannel, NormalizedMessage } from '@larksuite/channel';
 import { realpath } from 'node:fs/promises';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AgentEvent } from '../../../src/agent/types.js';
 import { createDefaultProfileConfig } from '../../../src/config/profile-schema.js';
+import { initialState, reduce, type RunState } from '../../../src/card/run-state.js';
 import { log } from '../../../src/core/logger.js';
 import { SessionStore } from '../../../src/session/store.js';
 import { WorkspaceStore } from '../../../src/workspace/store.js';
-import { FakeAgentAdapter } from '../../helpers/fake-agent.js';
+import { FakeAgentAdapter, type FakeAgentEvents } from '../../helpers/fake-agent.js';
 import { createTmpProfile, type TmpProfile } from '../../helpers/tmp-profile.js';
 
 const sdkMock = vi.hoisted(() => ({
@@ -25,7 +27,7 @@ vi.mock('@larksuite/channel', async (importOriginal) => {
   };
 });
 
-import { startChannel } from '../../../src/bot/channel.js';
+import { sendFinalReply, startChannel } from '../../../src/bot/channel.js';
 
 interface MessageHandlerMap {
   message?: (msg: NormalizedMessage) => Promise<void> | void;
@@ -35,6 +37,7 @@ interface FakeLarkChannel {
   botIdentity: { openId: string; name: string };
   handlers: MessageHandlerMap;
   sent: Array<{ chatId: string; content: unknown; options?: unknown }>;
+  cardUpdates: Array<{ messageId: string; card: object }>;
   rawClient: {
     request: ReturnType<typeof vi.fn>;
     application: {
@@ -63,6 +66,7 @@ interface FakeLarkChannel {
   getConnectionStatus(): { state: 'connected'; reconnectAttempts: number };
   send(chatId: string, content: unknown, options?: unknown): Promise<void>;
   stream(chatId: string, input: unknown, options?: unknown): Promise<void>;
+  updateCard(messageId: string, card: object): Promise<void>;
   addReaction(messageId: string, emojiType: string): Promise<string>;
   removeReaction(messageId: string, reactionId: string): Promise<void>;
 }
@@ -117,7 +121,7 @@ describe('markdown stream startup failures', () => {
     await waitFor(() => h.channel.rawClient.im.v1.messageReaction.delete.mock.calls.length > 0);
   });
 
-  it('logs stream failures that arrive after terminal grace expires', async () => {
+  it('delivers a fallback when stream failure arrives after terminal grace expires', async () => {
     const streamFailure = deferred<void>();
     let streamProducerStarted = false;
     const h = await createHarness({
@@ -155,12 +159,215 @@ describe('markdown stream startup failures', () => {
         (call[2] as { step?: string } | undefined)?.step === 'stream-terminal-late',
       ),
     );
+    await waitFor(
+      () => markdownForReply(h.channel, 'om_first')?.includes('流式消息更新失败') === true,
+    );
   }, 10_000);
+
+  it('falls back to a visible markdown reply when card updates fail', async () => {
+    let streamCalls = 0;
+    const h = await createHarness({
+      messageReply: 'card',
+      events: [
+        [
+          { type: 'text', delta: `start ${'x'.repeat(20_000)} end-marker` },
+          { type: 'done', terminationReason: 'normal' },
+        ],
+        [{ type: 'done', terminationReason: 'normal' }],
+      ],
+      stream: async (_chatId, input) => {
+        streamCalls += 1;
+        const producer = (input as {
+          card?: {
+            producer?: (ctrl: {
+              update(next: object | ((current: object) => object)): Promise<void>;
+              readonly messageId?: string;
+            }) => Promise<void>;
+          };
+        }).card?.producer;
+        if (producer) {
+          await producer({
+            // The real SDK resolves update() after scheduling a patch. The
+            // asynchronous patch failure is surfaced by the stream terminal.
+            update: vi.fn(async () => {}),
+            messageId: 'om_stream_card',
+          });
+        }
+        if (streamCalls > 1) return;
+        await new Promise((resolve) => setTimeout(resolve, 3200));
+        throw new Error('230099 / 11310: element exceeds the limit');
+      },
+    });
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(message('om_first', 'first'));
+    await waitFor(
+      () => latestMarkdownContent(h.channel)?.includes('飞书卡片更新失败') === true,
+      6000,
+    );
+
+    const fallback = lastMarkdown(h.channel);
+    expect(fallback).toContain('start ');
+    expect(fallback).toContain('回复过长');
+    expect(fallback).toContain('end-marker');
+    expect(h.channel.cardUpdates.at(-1)?.messageId).toBe('om_stream_card');
+    expect(JSON.stringify(h.channel.cardUpdates.at(-1)?.card)).toContain('最终回复已改发');
+
+    await h.channel.handlers.message?.(message('om_second', 'second'));
+    await waitFor(() => h.agent.runOptions.length === 2);
+  }, 10_000);
+
+  it('preflights over-budget cards and sends markdown without an invalid update', async () => {
+    const update = vi.fn(async (_next: object | ((current: object) => object)) => {});
+    const tables = Array.from(
+      { length: 4 },
+      (_, i) => `table ${i}\n\n| key | value |\n| --- | --- |\n| a | b |`,
+    ).join('\n\n');
+    const h = await createHarness({
+      messageReply: 'card',
+      events: [
+        [
+          { type: 'text', delta: tables },
+          { type: 'done', terminationReason: 'normal' },
+        ],
+        [{ type: 'done', terminationReason: 'normal' }],
+      ],
+      stream: async (_chatId, input) => {
+        const producer = (input as {
+          card?: {
+            producer?: (ctrl: {
+              update(next: object | ((current: object) => object)): Promise<void>;
+              readonly messageId?: string;
+            }) => Promise<void>;
+          };
+        }).card?.producer;
+        if (producer) await producer({ update, messageId: 'om_preflight_card' });
+      },
+    });
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(message('om_first', 'first'));
+    await waitFor(
+      () => latestMarkdownContent(h.channel)?.includes('飞书卡片更新失败') === true,
+    );
+
+    expect(
+      update.mock.calls.some((call) => JSON.stringify(call[0]).includes('| --- |')),
+    ).toBe(false);
+    expect(lastMarkdown(h.channel)).toContain('table 0');
+    expect(JSON.stringify(h.channel.cardUpdates.at(-1)?.card)).toContain('最终回复已改发');
+
+    await h.channel.handlers.message?.(message('om_second', 'second'));
+    await waitFor(() => h.agent.runOptions.length === 2);
+  });
+
+  it('falls back to a visible markdown reply when markdown stream updates fail', async () => {
+    let streamCalls = 0;
+    const h = await createHarness({
+      messageReply: 'markdown',
+      events: [
+        [
+          { type: 'text', delta: `start ${'x'.repeat(20_000)} end-marker` },
+          { type: 'done', terminationReason: 'normal' },
+        ],
+        [{ type: 'done', terminationReason: 'normal' }],
+      ],
+      stream: async (_chatId, input) => {
+        streamCalls += 1;
+        const producer = (input as {
+          markdown?: (ctrl: { setContent(markdown: string): Promise<void> }) => Promise<void>;
+        }).markdown;
+        if (producer) {
+          // @larksuite/channel 0.3.x swallows asynchronous markdown patch
+          // errors and records them on the controller instead of rejecting.
+          const ctrl = {
+            streamingFailed: false,
+            setContent: vi.fn(async () => {}),
+          };
+          await producer(ctrl);
+          if (streamCalls > 1) return;
+          await new Promise((resolve) => setTimeout(resolve, 3200));
+          ctrl.streamingFailed = true;
+        }
+      },
+    });
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(message('om_first', 'first'));
+    await waitFor(
+      () => latestMarkdownContent(h.channel)?.includes('飞书流式消息更新失败') === true,
+      6000,
+    );
+
+    const fallback = lastMarkdown(h.channel);
+    expect(fallback).toContain('start ');
+    expect(fallback).toContain('回复过长');
+    expect(fallback).toContain('end-marker');
+
+    await h.channel.handlers.message?.(message('om_second', 'second'));
+    await waitFor(() => h.agent.runOptions.length === 2);
+  }, 10_000);
+
+  it('applies card preflight and fallback to non-stream final replies', async () => {
+    const tables = Array.from(
+      { length: 4 },
+      (_, i) => `table ${i}\n\n| key | value |\n| --- | --- |\n| a | b |`,
+    ).join('\n\n');
+    const h = await createHarness();
+
+    await sendFinalReply({
+      channel: h.channel as unknown as LarkChannel,
+      chatId: 'oc_dm',
+      scope: 'oc_dm',
+      state: stateFrom([
+        { type: 'text', delta: tables },
+        { type: 'done', terminationReason: 'normal' },
+      ]),
+      replyMode: 'card',
+      sendOpts: { replyTo: 'om_final' },
+      cardRenderOptions: {},
+    });
+
+    expect(lastMarkdown(h.channel)).toContain('飞书卡片更新失败');
+    expect(lastMarkdown(h.channel)).toContain('table 0');
+    expect(h.channel.sent.some((entry) => 'card' in (entry.content as object))).toBe(false);
+  });
+
+  it('detects swallowed SDK failures in non-stream markdown final replies', async () => {
+    const h = await createHarness({
+      stream: async (_chatId, input) => {
+        const producer = (input as {
+          markdown?: (ctrl: { setContent(markdown: string): Promise<void> }) => Promise<void>;
+        }).markdown;
+        if (!producer) return;
+        const ctrl = { streamingFailed: false, setContent: vi.fn(async () => {}) };
+        await producer(ctrl);
+        ctrl.streamingFailed = true;
+      },
+    });
+
+    await sendFinalReply({
+      channel: h.channel as unknown as LarkChannel,
+      chatId: 'oc_dm',
+      scope: 'oc_dm',
+      state: stateFrom([
+        { type: 'text', delta: 'final answer' },
+        { type: 'done', terminationReason: 'normal' },
+      ]),
+      replyMode: 'markdown',
+      sendOpts: { replyTo: 'om_final' },
+      cardRenderOptions: {},
+    });
+
+    expect(lastMarkdown(h.channel)).toBe('final answer');
+  });
 });
 
 async function createHarness(options: {
   reactionCreate?: () => Promise<{ data: { reaction_id: string } }>;
   stream?: StreamFn;
+  messageReply?: 'card' | 'markdown' | 'text';
+  events?: FakeAgentEvents;
 } = {}): Promise<{
   tmp: TmpProfile;
   channel: FakeLarkChannel;
@@ -190,6 +397,12 @@ async function createHarness(options: {
   });
   const profileConfig = {
     ...baseProfileConfig,
+    preferences: {
+      ...baseProfileConfig.preferences,
+      ...(options.messageReply
+        ? { messageReply: options.messageReply, messageReplyMigrated: true }
+        : {}),
+    },
     workspaces: {
       ...baseProfileConfig.workspaces,
       default: workspace,
@@ -200,7 +413,7 @@ async function createHarness(options: {
   const agent = new FakeAgentAdapter({
     id: 'codex',
     displayName: 'Codex',
-    events: [
+    events: options.events ?? [
       [
         {
           type: 'error',
@@ -252,9 +465,11 @@ function createFakeLarkChannel(options: {
 } = {}): FakeLarkChannel {
   const handlers: MessageHandlerMap = {};
   const sent: FakeLarkChannel['sent'] = [];
+  const cardUpdates: FakeLarkChannel['cardUpdates'] = [];
   const channel: FakeLarkChannel = {
     handlers,
     sent,
+    cardUpdates,
     botIdentity: { openId: 'ou_bot', name: 'Bridge' },
     rawClient: {
       request: vi.fn(async () => ({ data: { items: [] } })),
@@ -296,6 +511,9 @@ function createFakeLarkChannel(options: {
     stream: options.stream ?? (async () => {
       await new Promise<void>(() => {});
     }),
+    async updateCard(messageId, card) {
+      cardUpdates.push({ messageId, card });
+    },
     async addReaction(messageId, emojiType) {
       const r = await channel.rawClient.im.v1.messageReaction.create({
         path: { message_id: messageId },
@@ -356,9 +574,25 @@ function message(messageId: string, content: string): NormalizedMessage {
 }
 
 function lastMarkdown(channel: FakeLarkChannel): string {
+  const content = latestMarkdownContent(channel);
+  expect(content).toBeTypeOf('string');
+  return content ?? '';
+}
+
+function latestMarkdownContent(channel: FakeLarkChannel): string | undefined {
   const content = channel.sent.at(-1)?.content as { markdown?: string } | undefined;
-  expect(content?.markdown).toBeTypeOf('string');
-  return content?.markdown ?? '';
+  return content?.markdown;
+}
+
+function markdownForReply(channel: FakeLarkChannel, replyTo: string): string | undefined {
+  const entry = channel.sent.find((item) =>
+    (item.options as { replyTo?: string } | undefined)?.replyTo === replyTo,
+  );
+  return (entry?.content as { markdown?: string } | undefined)?.markdown;
+}
+
+function stateFrom(events: readonly AgentEvent[]): RunState {
+  return events.reduce((state, event) => reduce(state, event), initialState);
 }
 
 async function waitFor(predicate: () => boolean, timeoutMs = 3000): Promise<void> {

--- a/tests/unit/card/run-renderer.snapshot.test.ts
+++ b/tests/unit/card/run-renderer.snapshot.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { renderCard } from '../../../src/card/run-renderer.js';
+import {
+  getCardPayloadViolation,
+  renderCard,
+} from '../../../src/card/run-renderer.js';
 import {
   initialState,
   markIdleTimeout,
@@ -7,7 +10,7 @@ import {
   reduce,
   type RunState,
 } from '../../../src/card/run-state.js';
-import { renderText } from '../../../src/card/text-renderer.js';
+import { renderBoundedText, renderText } from '../../../src/card/text-renderer.js';
 import type { AgentEvent } from '../../../src/agent/types.js';
 import { normalizeCard } from '../../helpers/card-normalize.js';
 
@@ -114,6 +117,134 @@ describe('run card renderer snapshots', () => {
     expect(card).toContain(sensitivePath);
     expect(text).toContain(sensitivePath);
   });
+
+  it('truncates oversized card and markdown text payloads', () => {
+    const state = stateFrom([
+      { type: 'text', delta: `start ${'x'.repeat(20_000)} end-marker` },
+      { type: 'done', terminationReason: 'normal' },
+    ]);
+
+    const card = JSON.stringify(renderCard(state));
+    const text = renderText(state);
+    const boundedText = renderBoundedText(state);
+
+    expect(card).toContain('回复过长');
+    expect(card).toContain('end-marker');
+    expect(text).not.toContain('回复过长');
+    expect(text).toContain('end-marker');
+    expect(text.length).toBeGreaterThan(12_000);
+    expect(boundedText).toContain('回复过长');
+    expect(boundedText).toContain('start ');
+    expect(boundedText).toContain('end-marker');
+    expect(boundedText.length).toBeLessThanOrEqual(12_000);
+  });
+
+  it('preserves the final answer when bounding long tool history', () => {
+    const events: AgentEvent[] = [];
+    for (let i = 0; i < 200; i += 1) {
+      events.push({
+        type: 'tool_use',
+        id: `tool-${i}`,
+        name: 'Bash',
+        input: { command: `echo ${i} ${'x'.repeat(80)}` },
+      });
+      events.push({ type: 'tool_result', id: `tool-${i}`, output: 'ok', isError: false });
+    }
+    events.push({ type: 'text', delta: 'the actual final answer' });
+    events.push({ type: 'done', terminationReason: 'normal' });
+
+    const bounded = renderBoundedText(stateFrom(events));
+
+    expect(bounded).toContain('回复过长');
+    expect(bounded).toContain('the actual final answer');
+    expect(bounded.length).toBeLessThanOrEqual(12_000);
+  });
+
+  it('does not split surrogate pairs at truncation boundaries', () => {
+    const state = stateFrom([
+      { type: 'text', delta: `${'a'.repeat(3991)}😀${'b'.repeat(20_000)}😀tail` },
+      { type: 'done', terminationReason: 'normal' },
+    ]);
+    const bounded = renderBoundedText(state);
+    const card = renderCard(state) as {
+      body?: { elements?: Array<{ content?: string }> };
+    };
+    const cardContent = card.body?.elements?.map((element) => element.content ?? '').join('') ?? '';
+
+    expect(hasUnpairedSurrogate(bounded)).toBe(false);
+    expect(hasUnpairedSurrogate(cardContent)).toBe(false);
+    expect(bounded).toContain('😀tail');
+  });
+
+  it('does not split surrogate pairs in truncated terminal errors', () => {
+    const card = renderCard({
+      ...initialState,
+      terminal: 'error',
+      errorMsg: `${'a'.repeat(1999)}😀tail`,
+    }) as { body?: { elements?: Array<{ content?: string }> } };
+    const errorContent = card.body?.elements?.at(-1)?.content ?? '';
+
+    expect(errorContent).toContain('agent 失败');
+    expect(hasUnpairedSurrogate(errorContent)).toBe(false);
+  });
+
+  it('keeps cards within a conservative element budget', () => {
+    const events: AgentEvent[] = [];
+    for (let i = 0; i < 80; i += 1) {
+      events.push({ type: 'text', delta: `phase-${i}` });
+      events.push({
+        type: 'tool_use',
+        id: `tool-${i}`,
+        name: 'Read',
+        input: { file_path: `/tmp/${i}` },
+      });
+      events.push({ type: 'tool_result', id: `tool-${i}`, output: 'ok', isError: false });
+    }
+    events.push({ type: 'text', delta: 'final-answer' });
+    events.push({ type: 'done', terminationReason: 'normal' });
+
+    const card = renderCard(stateFrom(events)) as { body?: { elements?: object[] } };
+    const serialized = JSON.stringify(card);
+
+    expect(card.body?.elements?.length).toBeLessThanOrEqual(10);
+    expect(serialized).toContain('过程块已折叠');
+    expect(serialized).toContain('final-answer');
+    expect(getCardPayloadViolation(card)).toBeUndefined();
+  });
+
+  it('bounds collapsed tool summaries while preserving recent tools', () => {
+    const events: AgentEvent[] = [];
+    for (let i = 0; i < 150; i += 1) {
+      events.push({
+        type: 'tool_use',
+        id: `tool-${i}`,
+        name: 'Bash',
+        input: { command: `echo ${i} ${'x'.repeat(80)}` },
+      });
+      events.push({ type: 'tool_result', id: `tool-${i}`, output: 'ok', isError: false });
+    }
+    events.push({ type: 'done', terminationReason: 'normal' });
+
+    const serialized = JSON.stringify(renderCard(stateFrom(events)));
+
+    expect(serialized).toContain('工具调用已省略');
+    expect(serialized).toContain('echo 149');
+    expect(serialized.length).toBeLessThan(10_000);
+    expect(getCardPayloadViolation(renderCard(stateFrom(events)))).toBeUndefined();
+  });
+
+  it('rejects cards with too many markdown tables before sending', () => {
+    const tables = Array.from(
+      { length: 4 },
+      (_, i) => `table ${i}\n\n| key | value |\n| --- | --- |\n| a | b |`,
+    ).join('\n\n');
+    const card = renderCard(stateFrom([
+      { type: 'text', delta: tables },
+      { type: 'done', terminationReason: 'normal' },
+    ]));
+
+    expect(getCardPayloadViolation(card)).toContain('markdown tables');
+  });
 });
 
 function stateFrom(events: AgentEvent[]): RunState {
@@ -122,4 +253,18 @@ function stateFrom(events: AgentEvent[]): RunState {
 
 function expectCard(state: RunState) {
   return expect(normalizeCard(renderCard(state)));
+}
+
+function hasUnpairedSurrogate(value: string): boolean {
+  for (let i = 0; i < value.length; i += 1) {
+    const code = value.charCodeAt(i);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(i + 1);
+      if (next < 0xdc00 || next > 0xdfff) return true;
+      i += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true;
+    }
+  }
+  return false;
 }


### PR DESCRIPTION
## Summary

- keep streamed cards under conservative body, recursive element, serialized-byte, and Markdown-table budgets
- preserve the beginning and final answer when card content or tool summaries must be bounded
- detect delayed card terminal failures and the SDK's asynchronous Markdown failure state, then send one bounded plain-message fallback
- apply the same preflight/fallback behavior to CoT final replies and replace failed running cards with a small terminal status card when possible

## Motivation

Long tool-heavy runs can exceed Feishu's card element limits. The agent run still completes, but the final card update fails with `230099 / 11310: element exceeds the limit`, leaving users with a running card and no visible final answer. This is the same failure class discussed in #152.

## Verification

- `pnpm test` (`91` files, `556` tests)
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

The added integration coverage verifies queue continuation, delayed terminal failures beyond the existing grace period, card and Markdown degradation, non-stream/CoT final delivery, and a second message after each failed run. Unit coverage includes card budgets, final-answer preservation, and Unicode-safe truncation.

## Follow-up risks

- Markdown failure detection currently observes `streamingFailed`, which exists in `@larksuite/channel@0.3.0` but is not part of its public controller type. A public SDK failure signal would remove that dependency.
- The pre-existing producer-startup race can still create a second stream if the SDK starts its producer only after the bridge already sent the startup fallback; this change does not widen or resolve that race.
