### PR TITLE
fix: auto-allow the group created by /new chat

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -354,6 +354,32 @@ async function handleNewChat(rawName: string, ctx: CommandContext): Promise<void
     ctx.workspaces.setCwd(created.chatId, sourceCwd);
   }
 
+  // Auto-allow the freshly created group. The v2 access policy is
+  // fail-closed: a chat_id absent from `allowedChats` is denied with reason
+  // `denied-chat` (logged as `skip-not-allowed-user`), so a group the bot
+  // itself just spun up would be silently ignored — the bot builds a room it
+  // then refuses to talk in.
+  // Persist the new chat_id into the allowlist (idempotent) so messages in
+  // the new group are accepted immediately, without the user having to run
+  // `/invite group` from inside it. Best-effort: the group already exists, so
+  // a persistence failure must not fail the command — just log and continue
+  // (the user can still `/invite group` manually).
+  try {
+    await saveAccessConfig(ctx, (current) => {
+      const list = new Set(current.allowedChats);
+      if (list.has(created.chatId)) return current;
+      list.add(created.chatId);
+      return { ...current, allowedChats: [...list] };
+    });
+    log.info('command', 'new-chat-auto-allowed', {
+      chatId: `…${created.chatId.slice(-6)}`,
+    });
+  } catch (err) {
+    log.warn('command', 'new-chat-auto-allow-failed', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+  }
+
   // Welcome the user inside the new group with a hint about how to start.
   const welcome = sourceCwd
     ? `🎉 群已建好，cwd 继承自原群：\`${sourceCwd}\`\n\n@我 + 任意消息开始对话。`

--- a/tests/integration/commands/new-chat-auto-allow.test.ts
+++ b/tests/integration/commands/new-chat-auto-allow.test.ts
@@ -1,0 +1,141 @@
+import { mkdir, realpath, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { NormalizedMessage } from '@larksuite/channel';
+import { ActiveRuns } from '../../../src/bot/active-runs.js';
+import type { CommandContext, Controls } from '../../../src/commands/index.js';
+import { createDefaultProfileConfig, type ProfileConfig } from '../../../src/config/profile-schema.js';
+import { SessionStore } from '../../../src/session/store.js';
+import { WorkspaceStore } from '../../../src/workspace/store.js';
+import { createFakeAgent } from '../../helpers/fake-agent.js';
+import { createFakeChannel } from '../../helpers/fake-channel.js';
+import { createTmpProfile } from '../../helpers/tmp-profile.js';
+
+const NEW_CHAT_ID = 'oc-new-group-xyz';
+
+const cleanups: Array<() => Promise<void>> = [];
+
+describe('/new chat auto-allow', () => {
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+  });
+
+  it('persists the freshly created group chat_id into allowedChats', async () => {
+    const h = await createHarness();
+
+    // The v2 access policy is fail-closed, so the new group starts out unable
+    // to reach the bot until it's whitelisted.
+    const { loadRootConfig } = await import('../../../src/config/profile-store.js');
+    const before = await loadRootConfig(h.configPath);
+    expect(before?.profiles.claude?.access.allowedChats ?? []).not.toContain(NEW_CHAT_ID);
+
+    const handled = await h.run('/new chat Demo');
+    expect(handled).toBe(true);
+    expect(h.createdChatNames).toContain('Demo');
+
+    const after = await loadRootConfig(h.configPath);
+    expect(after?.profiles.claude?.access.allowedChats).toContain(NEW_CHAT_ID);
+  });
+
+  it('is idempotent when the chat_id is already allowed', async () => {
+    const h = await createHarness({ preAllow: [NEW_CHAT_ID] });
+
+    const handled = await h.run('/new chat Again');
+    expect(handled).toBe(true);
+
+    const { loadRootConfig } = await import('../../../src/config/profile-store.js');
+    const after = await loadRootConfig(h.configPath);
+    const list = after?.profiles.claude?.access.allowedChats ?? [];
+    expect(list.filter((id) => id === NEW_CHAT_ID)).toHaveLength(1);
+  });
+});
+
+async function createHarness(opts: { preAllow?: string[] } = {}): Promise<{
+  configPath: string;
+  createdChatNames: string[];
+  run(content: string): Promise<boolean>;
+}> {
+  const tmp = await createTmpProfile('new-chat-auto-allow-');
+  const configPath = join(tmp.root, 'config.json');
+  const profileConfig = appConfig(await realpath(tmp.workspace), opts.preAllow ?? []);
+  const { createRootConfig } = await import('../../../src/config/profile-store.js');
+  await mkdir(tmp.root, { recursive: true });
+  await writeFile(
+    configPath,
+    `${JSON.stringify(createRootConfig('claude', profileConfig), null, 2)}\n`,
+  );
+
+  const base = createFakeChannel();
+  const createdChatNames: string[] = [];
+  const channel = {
+    ...base,
+    async createChat(params: { name?: string }): Promise<{ chatId: string }> {
+      createdChatNames.push(params.name ?? '');
+      return { chatId: NEW_CHAT_ID };
+    },
+  };
+
+  const sessions = new SessionStore(join(tmp.profile, 'sessions.json'));
+  const workspaces = new WorkspaceStore(join(tmp.profile, 'workspaces.json'));
+  const activeRuns = new ActiveRuns();
+  const agent = createFakeAgent();
+  const { tryHandleCommand } = await import('../../../src/commands/index.js');
+  const controls = {
+    profile: 'claude',
+    profileConfig,
+    botOwnerId: 'ou-owner',
+    ownerRefreshState: 'ok',
+    async refreshOwner() {},
+    restart: vi.fn(async () => {}),
+    exit: vi.fn(async () => {}),
+    configPath,
+    cfg: profileConfig,
+    processId: 'proc-1',
+  } satisfies Controls;
+
+  cleanups.push(async () => {
+    await Promise.all([sessions.flush(), workspaces.flush()]);
+    await tmp.cleanup();
+  });
+
+  return {
+    configPath,
+    createdChatNames,
+    run: (content) =>
+      tryHandleCommand({
+        channel: channel as unknown as CommandContext['channel'],
+        msg: message(content),
+        scope: 'chat-1',
+        chatMode: 'p2p',
+        sessions,
+        workspaces,
+        agent,
+        activeRuns,
+        controls,
+      }),
+  };
+}
+
+function appConfig(defaultWorkspace: string, allowedChats: string[]): ProfileConfig {
+  const config = createDefaultProfileConfig({
+    agentKind: 'claude',
+    accounts: { app: { id: 'app-id', secret: 'secret', tenant: 'feishu' } },
+    access: { admins: ['ou-owner'], allowedChats },
+  });
+  config.workspaces.default = defaultWorkspace;
+  return config;
+}
+
+function message(content: string): NormalizedMessage {
+  return {
+    messageId: `om-${content.replace(/\W+/g, '-').slice(0, 20)}`,
+    chatId: 'chat-1',
+    chatType: 'p2p',
+    senderId: 'ou-owner',
+    senderName: 'Owner',
+    content,
+    resources: [],
+    mentions: [],
+    mentionedBot: false,
+  } as unknown as NormalizedMessage;
+}


### PR DESCRIPTION
## Motivation

`/new chat` spins up a fresh Feishu/Lark group, invites the requester, inherits
the cwd, and posts a welcome message — but the new `chat_id` is never added to
`preferences.access.allowedChats`.

The v2 access policy is **fail-closed**: `canUseGroup` only lets a group
through when the sender is the owner/an admin, or the `chat_id` is in
`allowedChats`. So for anyone who isn't the owner/admin, the bot won't engage
in the very group it just created (`skip-not-allowed-user`, reason
`denied-chat`) — at best it replies with a "group not allowed" hint telling
you to run `/invite group`, at worst (non-mention messages) it just drops
them. Either way, it builds a room it then refuses to actually use. The only
recovery today is to run `/invite group` from inside the new group.

### Repro

1. Ensure the requesting user is a non-owner allowed user (`allowedUsers`, not
   `admins`).
2. Send `/new chat demo`.
3. The bot creates the group and posts the welcome message.
4. Send any message in the new group.
5. The bot won't actually chat there — log event: `skip-not-allowed-user`
   (reason `denied-chat`) — because the new `chat_id` was never whitelisted.

## Change

After the group is created (and the cwd inherited), persist the new `chat_id`
into `allowedChats`, reusing the existing `saveAccessConfig` path so the write
goes through the same config-file lock and in-memory refresh as `/invite`. The
add is idempotent (set-based) and **best-effort**: the group already exists, so
a persistence failure only logs a warning and leaves `/invite group` as the
manual fallback rather than failing the command. The log line records only the
last 6 chars of the `chat_id`.

## Compatibility

No behavior change to any existing flow. This only writes a `chat_id` the bot
just created into the allowlist — exactly what the user would otherwise have to
do by hand with `/invite group`. Existing groups and access lists are
untouched.

## Testing

- `pnpm typecheck` — clean.
- `pnpm test` — full suite green (adds 2 tests).
- New `tests/integration/commands/new-chat-auto-allow.test.ts`:
  - `/new chat` persists the created `chat_id` into `allowedChats`.
  - Idempotent when the `chat_id` is already allowed (no duplicate entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
