### PR TITLE
feat: route reply-quotes of past answers back to their source session

### DIFF
--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -52,6 +52,7 @@ import { createOwnerRefreshController } from '../policy/owner';
 import { RunExecutor } from '../runtime/run-executor';
 import type { SessionCatalog } from '../session/catalog';
 import type { SessionStore } from '../session/store';
+import type { MessageRouteStore } from '../session/message-routes';
 import type { WorkspaceStore } from '../workspace/store';
 import { ActiveRuns, type RunHandle } from './active-runs';
 import { ChatModeCache, type ChatMode } from './chat-mode-cache';
@@ -177,6 +178,11 @@ export interface StartChannelDeps {
   workspaces: WorkspaceStore;
   controls: Controls;
   appPaths?: Pick<AppPaths, 'secretsFile' | 'keystoreSaltFile' | 'mediaDir'>;
+  /** Optional reply-quote → source-session routing ledger. When present, the
+   * bridge records each outbound reply's message_id and routes inbound
+   * reply-quotes of those messages back to their originating scope. Omitting
+   * it disables the feature (no behavior change). */
+  messageRoutes?: MessageRouteStore;
 }
 
 export async function startChannel(deps: StartChannelDeps): Promise<BridgeChannel> {
@@ -315,6 +321,7 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
           callbackAuth,
           activePolicyFingerprints,
           lastRunModelByScope,
+          messageRoutes: deps.messageRoutes,
           scope,
           mode,
         });
@@ -699,6 +706,7 @@ interface RunBatchDeps {
   callbackAuth?: CallbackAuth;
   activePolicyFingerprints: Map<string, string>;
   lastRunModelByScope: Map<string, string>;
+  messageRoutes?: MessageRouteStore;
   scope: string;
   mode: ChatMode;
 }
@@ -717,9 +725,12 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     callbackAuth,
     activePolicyFingerprints,
     lastRunModelByScope,
-    scope,
+    messageRoutes,
     mode,
   } = deps;
+  // `scope` is `let` (not destructured) because reply-quote routing may
+  // override it below to the source session's scope.
+  let scope = deps.scope;
   if (batch.length === 0) return;
   const firstMsg = batch[0];
   const lastMsg = batch[batch.length - 1];
@@ -767,6 +778,37 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         type: q.rawContentType,
         contentChars: q.content.length,
       });
+    }
+  }
+
+  // Reply-quote session routing. If any quoted message is one the bridge
+  // previously sent (recorded in the message-route ledger), route this run
+  // back to that message's originating scope instead of the current chat's
+  // scope. Because cwd + session resume are derived from the scope downstream,
+  // overriding the scope reconnects the run to the source conversation. This
+  // is what lets a user pull a past answer's session into any chat by quoting
+  // it. Entirely best-effort and gated on a ledger hit — a miss, a disabled
+  // ledger, or any error leaves `scope` untouched, so non-quote messages and
+  // quotes of non-bridge messages behave exactly as before.
+  if (messageRoutes && quoteTargets.length > 0) {
+    for (const targetId of quoteTargets) {
+      try {
+        const route = await messageRoutes.lookup(targetId);
+        if (route && route.scope !== scope) {
+          log.info('quote-route', 'inbound-routed', {
+            quotedMessageId: targetId,
+            fromScope: scope,
+            toScope: route.scope,
+          });
+          scope = route.scope;
+          break;
+        }
+      } catch (err) {
+        log.warn('quote-route', 'lookup-failed', {
+          quotedMessageId: targetId,
+          err: err instanceof Error ? err.message : String(err),
+        });
+      }
     }
   }
 
@@ -939,6 +981,23 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     log.info('flush', 'idle-watchdog', { idleTimeoutMs });
   }
 
+  // Register this run's final reply in the message-route ledger so a later
+  // reply-quote of it routes back to this (possibly already-overridden) scope
+  // and its session. Best-effort: `record` never throws, and the whole thing
+  // is a no-op when the ledger is disabled or no message_id came back (e.g. a
+  // stream that produced no message). Uses the session id/cwd this run just
+  // recorded so external tools reading the ledger can target the session.
+  const registerReplyRoute = async (messageId: string | undefined): Promise<void> => {
+    if (!messageRoutes || !messageId) return;
+    const entry = sessions.getRaw(scope);
+    await messageRoutes.record(messageId, {
+      scope,
+      ts: Date.now(),
+      ...(entry?.sessionId ? { sessionId: entry.sessionId } : {}),
+      cwd: entry?.cwd ?? cwd,
+    });
+  };
+
   const replyMode = getMessageReplyMode(controls.cfg);
   log.info('flush', 'reply-mode', { mode: replyMode });
   const cotMessages = getCotMessages(controls.cfg);
@@ -1009,7 +1068,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
             reason: cotPublisher.degradedReason,
           });
         }
-        await sendFinalReply({
+        const cotReplyId = await sendFinalReply({
           channel,
           chatId,
           scope,
@@ -1018,6 +1077,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
           sendOpts,
           cardRenderOptions,
         });
+        await registerReplyRoute(cotReplyId);
         return;
       }
       log.warn('cot', 'fallback-existing-reply', { reason: 'create-disabled' });
@@ -1057,19 +1117,19 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         },
         sendOpts,
       );
-      await awaitRenderAwareStream({
+      const cardReplyId = await awaitRenderAwareStream({
         mode: replyMode,
         streamDone,
         renderDone,
         producerStarted: () => producerStarted,
-        fallback: async (state) => {
-          await channel.send(
+        fallback: async (state) =>
+          channel.send(
             chatId,
             { card: renderCard(filterForPrefs(state), cardRenderOptions) },
             sendOpts,
-          );
-        },
+          ),
       });
+      await registerReplyRoute(cardReplyId);
     } else if (replyMode === 'markdown') {
       let latestState: RunState = initialState;
       let producerStarted = false;
@@ -1099,7 +1159,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         },
         sendOpts,
       );
-      await awaitRenderAwareStream({
+      const markdownReplyId = await awaitRenderAwareStream({
         mode: replyMode,
         streamDone,
         renderDone,
@@ -1107,10 +1167,12 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         fallback: async (state) => {
           const body = renderText(filterForPrefs(state));
           if (body.trim()) {
-            await channel.send(chatId, { markdown: body }, sendOpts);
+            return channel.send(chatId, { markdown: body }, sendOpts);
           }
+          return undefined;
         },
       });
+      await registerReplyRoute(markdownReplyId);
     } else {
       // text mode: drain the agent stream without sending anything during
       // the run, then post the final rendered text once as a plain markdown
@@ -1123,7 +1185,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         recordSession,
         async () => {},
       );
-      await sendFinalReply({
+      const textReplyId = await sendFinalReply({
         channel,
         chatId,
         scope,
@@ -1132,6 +1194,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         sendOpts,
         cardRenderOptions,
       });
+      await registerReplyRoute(textReplyId);
     }
   } catch (err) {
     log.fail('stream', err);
@@ -1149,7 +1212,7 @@ async function sendFinalReply(input: {
   replyMode: ReturnType<typeof getMessageReplyMode>;
   sendOpts: { replyTo: string; replyInThread?: boolean };
   cardRenderOptions: { signCallback?: (action: string) => string };
-}): Promise<void> {
+}): Promise<string | undefined> {
   const body = renderText(input.state);
 
   if (input.replyMode === 'card') {
@@ -1159,10 +1222,11 @@ async function sendFinalReply(input: {
       input.sendOpts,
     );
     log.info('outbound', 'sent', outboundLogFields(input, 'card', body, result));
+    return result.messageId;
   } else if (input.replyMode === 'markdown') {
     if (body.trim()) {
       try {
-        await input.channel.stream(
+        const result = await input.channel.stream(
           input.chatId,
           {
             markdown: async (ctrl) => {
@@ -1171,7 +1235,8 @@ async function sendFinalReply(input: {
           },
           input.sendOpts,
         );
-        log.info('outbound', 'sent', outboundLogFields(input, 'markdown-stream', body));
+        log.info('outbound', 'sent', outboundLogFields(input, 'markdown-stream', body, result));
+        return result.messageId;
       } catch (err) {
         log.warn('outbound', 'markdown-stream-fallback', {
           err: err instanceof Error ? err.message : String(err),
@@ -1182,8 +1247,10 @@ async function sendFinalReply(input: {
           input.sendOpts,
         );
         log.info('outbound', 'sent', outboundLogFields(input, 'markdown', body, result));
+        return result.messageId;
       }
     }
+    return undefined;
   } else if (body.trim()) {
     const result = await input.channel.send(
       input.chatId,
@@ -1191,7 +1258,9 @@ async function sendFinalReply(input: {
       input.sendOpts,
     );
     log.info('outbound', 'sent', outboundLogFields(input, 'text', body, result));
+    return result.messageId;
   }
+  return undefined;
 }
 
 async function sendCotDegradedNotice(input: {
@@ -1368,13 +1437,13 @@ async function processAgentStream(
 
 async function awaitRenderAwareStream(input: {
   mode: 'card' | 'markdown';
-  streamDone: Promise<unknown>;
+  streamDone: Promise<{ messageId?: string }>;
   renderDone: Promise<RunState>;
   producerStarted: () => boolean;
-  fallback: (state: RunState) => Promise<void>;
-}): Promise<void> {
+  fallback: (state: RunState) => Promise<{ messageId?: string } | void>;
+}): Promise<string | undefined> {
   const streamResult = input.streamDone.then(
-    () => ({ kind: 'stream' as const, ok: true as const }),
+    (res) => ({ kind: 'stream' as const, ok: true as const, messageId: res?.messageId }),
     (err) => ({ kind: 'stream' as const, ok: false as const, err }),
   );
   const renderResult = input.renderDone.then(
@@ -1387,8 +1456,7 @@ async function awaitRenderAwareStream(input: {
       log.fail('stream', first.err, { mode: input.mode, step: 'stream' });
       const rendered = await renderResult;
       if (!rendered.ok) throw rendered.err;
-      await runFallbackReply(input.mode, rendered.state, input.fallback);
-      return;
+      return runFallbackReply(input.mode, rendered.state, input.fallback);
     }
     throw first.err;
   }
@@ -1396,13 +1464,12 @@ async function awaitRenderAwareStream(input: {
   if (first.kind === 'stream') {
     const rendered = await renderResult;
     if (!rendered.ok) throw rendered.err;
-    return;
+    return first.messageId;
   }
 
   if (!input.producerStarted()) {
     log.warn('stream', 'producer-not-started-before-agent-terminal', { mode: input.mode });
-    await runFallbackReply(input.mode, first.state, input.fallback);
-    return;
+    return runFallbackReply(input.mode, first.state, input.fallback);
   }
 
   const terminal = await Promise.race([
@@ -1419,20 +1486,23 @@ async function awaitRenderAwareStream(input: {
         log.fail('stream', result.err, { mode: input.mode, step: 'stream-terminal-late' });
       }
     });
-    return;
+    return undefined;
   }
   if (!terminal.ok) throw terminal.err;
+  return terminal.messageId;
 }
 
 async function runFallbackReply(
   mode: 'card' | 'markdown',
   state: RunState,
-  fallback: (state: RunState) => Promise<void>,
-): Promise<void> {
+  fallback: (state: RunState) => Promise<{ messageId?: string } | void>,
+): Promise<string | undefined> {
   try {
-    await fallback(state);
+    const result = await fallback(state);
+    return result?.messageId;
   } catch (err) {
     log.fail('stream', err, { mode, step: 'fallback' });
+    return undefined;
   }
 }
 

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -44,6 +44,7 @@ import { resolveProfileRuntime } from '../../runtime/profile-runtime';
 import { refreshOwnerControls } from '../../policy/owner';
 import { SessionStore } from '../../session/store';
 import { SessionCatalog } from '../../session/catalog';
+import { MessageRouteStore } from '../../session/message-routes';
 import { WorkspaceStore } from '../../workspace/store';
 
 // Prefer IPv4 — Node 20+ defaults to "verbatim" which respects whatever
@@ -143,6 +144,9 @@ export async function runStart(opts: StartOptions): Promise<void> {
           await sessionCatalog.load();
           const workspaces = new WorkspaceStore(appPaths.workspacesFile);
           await workspaces.load();
+          // Reply-quote → source-session routing ledger. Disk-backed and
+          // best-effort; no load() needed (the file is read fresh per op).
+          const messageRoutes = new MessageRouteStore(`${appPaths.sessionsFile}.routes.json`);
 
         await gcMediaCache(MEDIA_GC_MAX_AGE_MS, appPaths.mediaDir);
         await gcOldLogs();
@@ -272,6 +276,7 @@ export async function runStart(opts: StartOptions): Promise<void> {
                   sessions,
                   sessionCatalog,
                   workspaces,
+                  messageRoutes,
                   controls: nextControls,
                   appPaths: nextRuntime.appPaths,
                 });
@@ -328,6 +333,7 @@ export async function runStart(opts: StartOptions): Promise<void> {
           sessions,
           sessionCatalog,
           workspaces,
+          messageRoutes,
           controls,
           appPaths,
         });

--- a/src/session/message-routes.ts
+++ b/src/session/message-routes.ts
@@ -1,0 +1,136 @@
+import { readFile } from 'node:fs/promises';
+import { paths } from '../config/paths';
+import { log } from '../core/logger';
+import { writeFileAtomic } from '../platform/atomic-write';
+
+/**
+ * A single outbound-message → source-session mapping.
+ *
+ * The bridge records one of these every time it sends a reply, keyed by the
+ * reply's `message_id`. When a later inbound message reply-quotes that
+ * `message_id`, the bridge routes the new run back to `scope` (and, through
+ * the scope, the same session + cwd) instead of the quoting chat's own scope.
+ * This lets a user pull a past answer's conversation into any chat by quoting
+ * it.
+ *
+ * `sessionId` / `cwd` are informational: the bridge routes by `scope` (session
+ * and cwd follow the scope's current state), but they're persisted so external
+ * tools can target a session directly — see {@link MessageRouteStore}.
+ */
+export interface MessageRoute {
+  scope: string;
+  sessionId?: string;
+  cwd?: string;
+  /** Epoch ms the entry was recorded; used for LRU-style pruning. */
+  ts: number;
+}
+
+type RouteMap = Record<string, MessageRoute>;
+
+/**
+ * Keep the ledger bounded — a busy bot would otherwise grow it without limit.
+ * Oldest entries (by `ts`) are evicted first. 1000 recent outbound messages is
+ * far more reply-quote reach-back than anyone uses in practice.
+ */
+const DEFAULT_MAX_ENTRIES = 1000;
+
+/**
+ * On-disk ledger mapping an outbound `message_id` to the session scope it was
+ * produced by. Lives next to `sessions.json` (default
+ * `<sessionsFile>.routes.json`, mirroring the `.catalog.json` convention).
+ *
+ * Disk is the source of truth: every {@link lookup} and {@link record} reads
+ * the current file, so the bridge is **not** the only permitted writer.
+ * External notification tools (anything that sends messages "as" this bot via
+ * its own path) can append their own `message_id → {scope, sessionId, cwd, ts}`
+ * entries to the same JSON object to make those messages reply-quote-routable
+ * too. This is the intended, documented extension point.
+ *
+ * All operations are best-effort: a missing or corrupt file resolves to "no
+ * route" rather than throwing, so a broken ledger degrades to the normal
+ * per-chat routing instead of breaking message handling.
+ */
+export class MessageRouteStore {
+  private readonly path: string;
+  private readonly maxEntries: number;
+  /** Serializes this process's own writes so concurrent records don't lose
+   * each other's entries. Cross-process writers race last-writer-wins, which
+   * is acceptable for a best-effort routing hint. */
+  private writes: Promise<void> = Promise.resolve();
+
+  constructor(path: string = `${paths.sessionsFile}.routes.json`, maxEntries = DEFAULT_MAX_ENTRIES) {
+    this.path = path;
+    this.maxEntries = maxEntries;
+  }
+
+  /**
+   * Return the route recorded for `messageId`, or `undefined` when there is
+   * none / the ledger can't be read. Never throws.
+   */
+  async lookup(messageId: string): Promise<MessageRoute | undefined> {
+    const map = await this.read();
+    const entry = map[messageId];
+    if (!entry || typeof entry.scope !== 'string' || entry.scope.length === 0) return undefined;
+    return entry;
+  }
+
+  /**
+   * Upsert `messageId → route` and persist. Serialized against this process's
+   * other records and performed as a read-modify-write so entries added by
+   * external writers between reads are preserved. Never throws — logs and
+   * moves on, since a failed routing hint must not fail message sending.
+   */
+  async record(messageId: string, route: MessageRoute): Promise<void> {
+    this.writes = this.writes
+      .then(async () => {
+        const map = await this.read();
+        map[messageId] = route;
+        this.prune(map);
+        await writeFileAtomic(this.path, `${JSON.stringify(map, null, 2)}\n`, { mode: 0o600 });
+      })
+      .catch((err: unknown) => {
+        log.warn('quote-route', 'record-failed', {
+          err: err instanceof Error ? err.message : String(err),
+        });
+      });
+    return this.writes;
+  }
+
+  /** Wait for pending writes to settle (tests / shutdown). */
+  async flush(): Promise<void> {
+    await this.writes;
+  }
+
+  private async read(): Promise<RouteMap> {
+    try {
+      const text = await readFile(this.path, 'utf8');
+      const raw = JSON.parse(text) as Record<string, Partial<MessageRoute>>;
+      const out: RouteMap = {};
+      for (const [id, entry] of Object.entries(raw)) {
+        if (!entry || typeof entry.scope !== 'string' || typeof entry.ts !== 'number') continue;
+        out[id] = {
+          scope: entry.scope,
+          ts: entry.ts,
+          ...(typeof entry.sessionId === 'string' ? { sessionId: entry.sessionId } : {}),
+          ...(typeof entry.cwd === 'string' ? { cwd: entry.cwd } : {}),
+        };
+      }
+      return out;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return {};
+      log.warn('quote-route', 'read-failed', {
+        err: err instanceof Error ? err.message : String(err),
+      });
+      return {};
+    }
+  }
+
+  private prune(map: RouteMap): void {
+    const ids = Object.keys(map);
+    if (ids.length <= this.maxEntries) return;
+    ids
+      .sort((a, b) => (map[a]?.ts ?? 0) - (map[b]?.ts ?? 0))
+      .slice(0, ids.length - this.maxEntries)
+      .forEach((id) => delete map[id]);
+  }
+}

--- a/tests/integration/bot/quote-route.test.ts
+++ b/tests/integration/bot/quote-route.test.ts
@@ -1,0 +1,284 @@
+import type { NormalizedMessage } from '@larksuite/channel';
+import { realpath } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createDefaultProfileConfig } from '../../../src/config/profile-schema.js';
+import { MessageRouteStore } from '../../../src/session/message-routes.js';
+import { SessionStore } from '../../../src/session/store.js';
+import { WorkspaceStore } from '../../../src/workspace/store.js';
+import { FakeAgentAdapter } from '../../helpers/fake-agent.js';
+import { createTmpProfile, type TmpProfile } from '../../helpers/tmp-profile.js';
+
+const sdkMock = vi.hoisted(() => ({
+  channel: undefined as FakeChannel | undefined,
+  createLarkChannel: vi.fn(() => {
+    if (!sdkMock.channel) throw new Error('fake channel not configured');
+    return sdkMock.channel;
+  }),
+}));
+
+vi.mock('@larksuite/channel', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@larksuite/channel')>();
+  return { ...actual, createLarkChannel: sdkMock.createLarkChannel };
+});
+
+import { startChannel } from '../../../src/bot/channel.js';
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  sdkMock.channel = undefined;
+  sdkMock.createLarkChannel.mockClear();
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+describe('reply-quote session routing', () => {
+  it('routes a reply-quote of a past answer back to its source session', async () => {
+    const h = await createHarness();
+    await startTestBridge(h);
+
+    // Run 1 in chat A — a fresh conversation that records session `sess-a`.
+    await h.channel.handlers.message?.(
+      inbound({ messageId: 'om_a_1', chatId: 'oc_a', content: '@Bridge hello from A' }),
+    );
+    await waitFor(() => h.agent.runOptions.length === 1);
+    await waitFor(() => h.channel.replies.length === 1);
+    const replyId = h.channel.replies[0]!.messageId;
+    // The bridge registered its reply → source scope in the ledger.
+    await waitFor(async () => Boolean(await h.routes.lookup(replyId)), 1500);
+    expect(await h.routes.lookup(replyId)).toMatchObject({
+      scope: 'oc_a',
+      sessionId: 'sess-a',
+    });
+
+    // Run 2 in chat B — a *different* chat — that reply-quotes A's answer.
+    await h.channel.handlers.message?.(
+      inbound({
+        messageId: 'om_b_1',
+        chatId: 'oc_b',
+        content: '@Bridge follow up',
+        replyTo: replyId,
+      }),
+    );
+    await waitFor(() => h.agent.runOptions.length === 2);
+
+    // The second run resumed chat A's session (sess-a) even though it arrived
+    // in chat B — the quote routed it back to the source conversation.
+    expect(h.agent.runOptions[1]?.sessionId).toBe('sess-a');
+    expect(h.agent.runOptions[1]?.cwd).toBe(h.workspace);
+  });
+
+  it('leaves an un-quoted message on its own chat scope (no routing)', async () => {
+    const h = await createHarness();
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(
+      inbound({ messageId: 'om_a_1', chatId: 'oc_a', content: '@Bridge hello from A' }),
+    );
+    await waitFor(() => h.agent.runOptions.length === 1);
+    await waitFor(() => h.channel.replies.length === 1);
+
+    // A plain (non-reply) message in chat B must start its own session, not
+    // resume chat A's — proving the routing is gated strictly on a quote hit.
+    await h.channel.handlers.message?.(
+      inbound({ messageId: 'om_b_1', chatId: 'oc_b', content: '@Bridge unrelated' }),
+    );
+    await waitFor(() => h.agent.runOptions.length === 2);
+
+    expect(h.agent.runOptions[1]?.sessionId).toBeUndefined();
+  });
+});
+
+interface FakeChannel {
+  handlers: { message?: (msg: NormalizedMessage) => Promise<void> | void };
+  replies: Array<{ messageId: string; chatId: string }>;
+  botIdentity: { openId: string; name: string };
+  rawClient: unknown;
+  getAppInfo: ReturnType<typeof vi.fn>;
+  listChats: ReturnType<typeof vi.fn>;
+  fetchRawMessage: ReturnType<typeof vi.fn>;
+  on(handlers: { message?: (msg: NormalizedMessage) => Promise<void> | void }): void;
+  connect(): Promise<void>;
+  disconnect(): Promise<void>;
+  getChatMode(): Promise<'group' | 'topic'>;
+  getConnectionStatus(): { state: 'connected'; reconnectAttempts: number };
+  send(chatId: string, content: unknown, options?: unknown): Promise<{ messageId: string }>;
+  stream(chatId: string, input: unknown, options?: unknown): Promise<{ messageId: string }>;
+}
+
+async function createHarness(): Promise<{
+  tmp: TmpProfile;
+  workspace: string;
+  channel: FakeChannel;
+  agent: FakeAgentAdapter;
+  sessions: SessionStore;
+  workspaces: WorkspaceStore;
+  routes: MessageRouteStore;
+  profileConfig: ReturnType<typeof createDefaultProfileConfig>;
+  controls: ReturnType<typeof createControls>;
+}> {
+  const tmp = await createTmpProfile('quote-route-');
+  const workspace = await realpath(tmp.workspace);
+  const base = createDefaultProfileConfig({
+    agentKind: 'claude',
+    accounts: { app: { id: 'cli_test', secret: 'secret', tenant: 'feishu' } },
+    access: { allowedChats: ['oc_a', 'oc_b'], allowedUsers: ['ou_user'] },
+  });
+  const profileConfig = {
+    ...base,
+    workspaces: { ...base.workspaces, default: workspace },
+  };
+  const sessions = new SessionStore(join(tmp.profile, 'sessions.json'));
+  const workspaces = new WorkspaceStore(join(tmp.profile, 'workspaces.json'));
+  const routes = new MessageRouteStore(join(tmp.profile, 'sessions.json.routes.json'));
+  const agent = new FakeAgentAdapter({
+    events: [
+      [{ type: 'system', sessionId: 'sess-a' }, { type: 'done', terminationReason: 'normal' }],
+      [{ type: 'done', terminationReason: 'normal' }],
+    ],
+  });
+  const channel = createFakeChannel();
+  sdkMock.channel = channel;
+  const controls = createControls(profileConfig);
+  cleanups.push(async () => {
+    await Promise.all([sessions.flush(), workspaces.flush(), routes.flush()]);
+    await tmp.cleanup();
+  });
+  return { tmp, workspace, channel, agent, sessions, workspaces, routes, profileConfig, controls };
+}
+
+async function startTestBridge(h: {
+  profileConfig: ReturnType<typeof createDefaultProfileConfig>;
+  agent: FakeAgentAdapter;
+  sessions: SessionStore;
+  workspaces: WorkspaceStore;
+  routes: MessageRouteStore;
+  controls: ReturnType<typeof createControls>;
+}): Promise<void> {
+  const bridge = await startChannel({
+    cfg: h.profileConfig,
+    agent: h.agent,
+    sessions: h.sessions,
+    workspaces: h.workspaces,
+    messageRoutes: h.routes,
+    controls: h.controls,
+  });
+  cleanups.push(() => bridge.disconnect());
+}
+
+function createFakeChannel(): FakeChannel {
+  const handlers: FakeChannel['handlers'] = {};
+  const replies: Array<{ messageId: string; chatId: string }> = [];
+  let nextId = 0;
+  return {
+    handlers,
+    replies,
+    botIdentity: { openId: 'ou_bot', name: 'Bridge' },
+    rawClient: {
+      request: vi.fn(async () => ({ data: { items: [] } })),
+      im: {
+        v1: {
+          message: { list: vi.fn(async () => ({ data: { items: [], has_more: false } })) },
+          messageReaction: {
+            create: vi.fn(async () => ({ data: { reaction_id: 'r1' } })),
+            delete: vi.fn(async () => ({})),
+          },
+        },
+      },
+    },
+    getAppInfo: vi.fn(async () => ({ ownerId: 'ou_owner' })),
+    listChats: vi.fn(async () => []),
+    fetchRawMessage: vi.fn(async (messageId: string) => [
+      {
+        message_id: messageId,
+        msg_type: 'text',
+        body: { content: JSON.stringify({ text: 'prior answer' }) },
+        create_time: '1760000000000',
+        sender: { id: 'ou_bot', sender_type: 'app' },
+      },
+    ]),
+    on(next) {
+      Object.assign(handlers, next);
+    },
+    async connect() {},
+    async disconnect() {},
+    async getChatMode() {
+      return 'group';
+    },
+    getConnectionStatus() {
+      return { state: 'connected', reconnectAttempts: 0 };
+    },
+    async send(chatId) {
+      const messageId = `om_reply_${++nextId}`;
+      replies.push({ messageId, chatId });
+      return { messageId };
+    },
+    async stream(chatId, input) {
+      const messageId = `om_reply_${++nextId}`;
+      replies.push({ messageId, chatId });
+      if (isMarkdownStreamInput(input)) {
+        await input.markdown({ setContent: async () => {} });
+      }
+      return { messageId };
+    },
+  };
+}
+
+function createControls(profileConfig: ReturnType<typeof createDefaultProfileConfig>) {
+  return {
+    profile: 'test',
+    profileConfig,
+    ownerRefreshState: 'unknown' as const,
+    async refreshOwner() {},
+    async restart() {},
+    async exit() {},
+    configPath: '/tmp/config.json',
+    cfg: profileConfig,
+    processId: 'proc_test',
+  };
+}
+
+function inbound(input: {
+  messageId: string;
+  chatId: string;
+  content: string;
+  replyTo?: string;
+}): NormalizedMessage {
+  return {
+    messageId: input.messageId,
+    chatId: input.chatId,
+    chatType: 'group',
+    senderId: 'ou_user',
+    senderName: 'User',
+    content: input.content,
+    rawContentType: 'text',
+    resources: [],
+    mentions: [{ key: '@_user_1', openId: 'ou_bot', name: 'Bridge', isBot: true }],
+    mentionAll: false,
+    mentionedBot: true,
+    createTime: 1760000001000,
+    ...(input.replyTo
+      ? { replyToMessageId: input.replyTo, rootId: input.replyTo, parentId: input.replyTo }
+      : {}),
+  } as unknown as NormalizedMessage;
+}
+
+interface MarkdownStreamInput {
+  markdown(ctrl: { setContent(markdown: string): Promise<void> }): Promise<void> | void;
+}
+
+function isMarkdownStreamInput(input: unknown): input is MarkdownStreamInput {
+  return Boolean(input && typeof input === 'object' && 'markdown' in input);
+}
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 1500,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  throw new Error('timed out waiting for async work');
+}

--- a/tests/unit/session/message-routes.test.ts
+++ b/tests/unit/session/message-routes.test.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { MessageRouteStore } from '../../../src/session/message-routes.js';
+
+const cleanups: Array<() => Promise<void>> = [];
+
+describe('message route ledger', () => {
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+  });
+
+  it('records and looks up an outbound message → source scope mapping', async () => {
+    const { store } = await makeStore();
+    await store.record('om-1', { scope: 'chat-a', sessionId: 'sess-1', cwd: '/repo', ts: 1 });
+
+    const route = await store.lookup('om-1');
+    expect(route).toEqual({ scope: 'chat-a', sessionId: 'sess-1', cwd: '/repo', ts: 1 });
+    expect(await store.lookup('om-missing')).toBeUndefined();
+  });
+
+  it('reads disk fresh so external writers can register their own entries', async () => {
+    const { store, path } = await makeStore();
+    await store.record('om-bridge', { scope: 'chat-a', ts: 1 });
+
+    // Simulate an external notification tool appending to the same file.
+    const disk = JSON.parse(await readFile(path, 'utf8')) as Record<string, unknown>;
+    disk['om-external'] = { scope: 'chat-b', sessionId: 'sess-b', cwd: '/other', ts: 2 };
+    await writeFile(path, `${JSON.stringify(disk, null, 2)}\n`);
+
+    // The bridge sees the external entry (disk is the source of truth)...
+    expect(await store.lookup('om-external')).toMatchObject({ scope: 'chat-b' });
+    // ...and a subsequent bridge record does not clobber it.
+    await store.record('om-bridge-2', { scope: 'chat-a', ts: 3 });
+    expect(await store.lookup('om-external')).toMatchObject({ scope: 'chat-b' });
+    expect(await store.lookup('om-bridge')).toMatchObject({ scope: 'chat-a' });
+  });
+
+  it('evicts the oldest entries once the cap is exceeded', async () => {
+    const { store } = await makeStore(2);
+    await store.record('old', { scope: 's', ts: 1 });
+    await store.record('mid', { scope: 's', ts: 2 });
+    await store.record('new', { scope: 's', ts: 3 });
+
+    expect(await store.lookup('old')).toBeUndefined();
+    expect(await store.lookup('mid')).toMatchObject({ scope: 's' });
+    expect(await store.lookup('new')).toMatchObject({ scope: 's' });
+  });
+
+  it('degrades to "no route" on a corrupt or missing ledger', async () => {
+    const { store, path } = await makeStore();
+    expect(await store.lookup('anything')).toBeUndefined();
+
+    await writeFile(path, 'not json{');
+    expect(await store.lookup('anything')).toBeUndefined();
+
+    // A malformed entry (missing scope/ts) is ignored, not returned.
+    await writeFile(path, JSON.stringify({ 'om-x': { cwd: '/repo' } }));
+    expect(await store.lookup('om-x')).toBeUndefined();
+  });
+});
+
+async function makeStore(
+  maxEntries?: number,
+): Promise<{ store: MessageRouteStore; path: string }> {
+  const dir = await mkdtemp(join(tmpdir(), 'message-routes-'));
+  const path = join(dir, 'sessions.json.routes.json');
+  cleanups.push(() => rm(dir, { recursive: true, force: true }));
+  return { store: new MessageRouteStore(path, maxEntries), path };
+}


### PR DESCRIPTION
## Motivation

A run's session is scoped to its chat (`scope = chatId`, or `chatId:threadId`
for topics). That means a conversation lives and dies in the chat it started
in: there's no way to pick a past answer back up from somewhere else. A common
want is "reply-quote something the bot told me earlier — even in another chat —
and keep talking to *that* conversation."

This PR adds an opt-in mechanism for exactly that: quote one of the bot's
earlier replies and the new run resumes the session that produced it.

## Change

- **New `MessageRouteStore`** (`src/session/message-routes.ts`) — a small
  disk-backed ledger stored next to `sessions.json` (default
  `<sessionsFile>.routes.json`, mirroring the existing `.catalog.json`
  convention). It maps an outbound `message_id` → `{ scope, sessionId, cwd, ts }`.
  Disk is the source of truth (each op reads the file fresh), so the bridge is
  **not** the only permitted writer: external notification tools that send
  messages "as" the bot through their own path can append their own entries to
  the same JSON object to make those messages reply-quote-routable too. This is
  a documented extension point (see the class doc-comment). Entries are bounded
  (LRU by `ts`, default 1000).

- **Outbound registration** — when a run sends its final reply, the bridge
  records that reply's `message_id` against the run's (possibly already-routed)
  scope, together with the session id / cwd the run used.

- **Inbound routing** — on intake, if a message reply-quotes a `message_id`
  that's in the ledger, the run's scope is overridden to the recorded scope.
  Because cwd resolution and session resume are both derived from the scope
  downstream, overriding the scope reconnects the run to the source
  conversation — the reply still lands in the chat the user wrote in, but the
  agent continues the quoted session.

### Use case

1. Ask the bot something in chat A; it answers.
2. Later, in chat B (or a DM), reply-quote that answer and ask a follow-up.
3. The follow-up resumes chat A's session (same session id + cwd) instead of
   starting a blank one in chat B.

## Compatibility

Fully backward compatible and opt-in:

- The feature is gated on `startChannel({ messageRoutes })`. Omit the store and
  nothing changes.
- Routing only ever fires on a **ledger hit for a quoted message**. Messages
  with no reply-quote, and quotes of messages that aren't in the ledger, take
  the exact same path as before — the non-quote path is untouched.
- The whole thing is best-effort: `record` never throws, `lookup` returns
  "no route" on a missing/corrupt ledger, and any error falls back to the
  normal per-chat scope. A broken ledger degrades to today's behavior, it can't
  break message handling.

## Testing

- `pnpm typecheck` — clean.
- `pnpm test` — full suite green (adds 6 tests).
- `tests/unit/session/message-routes.test.ts` — record/lookup, external-writer
  entries surviving a subsequent bridge write, LRU eviction, and graceful
  degradation on a corrupt/missing/malformed ledger.
- `tests/integration/bot/quote-route.test.ts` — drives the real `startChannel`
  pipeline across two chats: a reply-quote of chat A's answer sent in chat B
  resumes chat A's session (`sessionId` + `cwd`), while a plain (non-quote)
  message in chat B starts its own session (no routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
