### PR TITLE
Codex/add macos floating status ball

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 dist/
 coverage/
 .corepack/
+.build/
 *.log
 *.tsbuildinfo
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,31 @@ Platform mapping:
 
 Daemon logs are under `~/.lark-channel/profiles/<profile>/logs/daemon/`.
 
+### macOS floating status ball
+
+On macOS, the bridge starts a small desktop status ball by default. It stays on top, can be dragged, saves its position, and expands on hover to show every visible profile. Multiple profiles share one ball; its color/state follows the highest-priority profile state.
+
+Disable it for one run with:
+
+```bash
+lark-channel-bridge run --no-floating-ball
+lark-channel-bridge start --no-floating-ball
+```
+
+Or disable it persistently in a profile config:
+
+```json
+{
+  "desktop": {
+    "floatingBall": {
+      "enabled": false
+    }
+  }
+}
+```
+
+The status snapshot is local-only and limited to profile name, bot display name, agent, status, counts, update time, short app-id suffix, and low-sensitive error kind. It does not write prompts, message bodies, tool payloads, chat/thread/session IDs, secrets, or tokens. See [desktop status docs](./docs/desktop-status.md).
+
 ### Multiple profiles: Claude and Codex
 
 By default, the bridge starts with the currently selected profile. Use `profile use <name>` to change it. Each profile keeps its own app credentials, sessions, working directories, and logs. Create multiple profiles only when you need to connect multiple PersonalAgent apps, or run Claude and Codex as separate bots:

--- a/README.zh.md
+++ b/README.zh.md
@@ -88,6 +88,31 @@ lark-channel-bridge unregister [--profile <name>]
 
 daemon 日志在 `~/.lark-channel/profiles/<profile>/logs/daemon/`。
 
+### macOS 桌面悬浮状态球
+
+macOS 上默认会启动一个轻量桌面悬浮球。它置顶显示、可拖动并记住位置，鼠标 hover 时展开展示所有可见 profile；多 profile 同时运行时也只显示一个悬浮球，聚合状态取最高关注度状态。
+
+单次关闭：
+
+```bash
+lark-channel-bridge run --no-floating-ball
+lark-channel-bridge start --no-floating-ball
+```
+
+profile 配置中永久关闭：
+
+```json
+{
+  "desktop": {
+    "floatingBall": {
+      "enabled": false
+    }
+  }
+}
+```
+
+本地状态快照只包含 profile 名称、bot 显示名、agent、状态、计数、更新时间、appId 后缀和低敏错误类型；不会写入 prompt、消息正文、工具 payload、chat/thread/session ID、secret 或 token。开发与调试细节见 [desktop status docs](./docs/desktop-status.md)。
+
 ### 多 profile：分别运行 Claude 和 Codex
 
 默认情况下，bridge 使用当前激活的 profile；可以通过 `profile use <name>` 切换。每个 profile 会维护独立的应用凭据、会话、工作目录和日志。只有在需要同时连接多个 PersonalAgent 应用，或分别运行 Claude 和 Codex 时，才需要创建多个 profile：

--- a/desktop/macos-floating-ball/Package.swift
+++ b/desktop/macos-floating-ball/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "LarkChannelFloatingBall",
+    platforms: [.macOS(.v13)],
+    products: [
+        .executable(name: "LarkChannelFloatingBall", targets: ["LarkChannelFloatingBall"]),
+    ],
+    targets: [
+        .executableTarget(name: "LarkChannelFloatingBall"),
+    ]
+)

--- a/desktop/macos-floating-ball/Sources/LarkChannelFloatingBall/main.swift
+++ b/desktop/macos-floating-ball/Sources/LarkChannelFloatingBall/main.swift
@@ -1,0 +1,346 @@
+import AppKit
+import Foundation
+
+enum DesktopStatus: String, Codable {
+    case offline
+    case connecting
+    case idle
+    case queued
+    case thinking
+    case toolRunning = "tool_running"
+    case streaming
+    case reconnecting
+    case error
+
+    var label: String {
+        switch self {
+        case .offline: return "offline"
+        case .connecting: return "connecting"
+        case .idle: return "idle"
+        case .queued: return "queued"
+        case .thinking: return "thinking"
+        case .toolRunning: return "tool"
+        case .streaming: return "streaming"
+        case .reconnecting: return "reconnecting"
+        case .error: return "error"
+        }
+    }
+
+    var color: NSColor {
+        switch self {
+        case .offline: return NSColor.systemGray
+        case .connecting: return NSColor.systemBlue
+        case .idle: return NSColor.systemGreen
+        case .queued: return NSColor.systemYellow
+        case .thinking: return NSColor.systemPurple
+        case .toolRunning: return NSColor.systemOrange
+        case .streaming: return NSColor.systemTeal
+        case .reconnecting: return NSColor.systemIndigo
+        case .error: return NSColor.systemRed
+        }
+    }
+}
+
+struct ProfileStatus: Codable {
+    let profile: String
+    let botName: String?
+    let appIdSuffix: String?
+    let agent: String
+    let status: DesktopStatus
+    let activeRunCount: Int
+    let queuedMessageCount: Int
+    let updatedAt: String
+    let lastErrorKind: String?
+}
+
+struct StatusSnapshot: Codable {
+    let updatedAt: String
+    let aggregateStatus: DesktopStatus
+    let profiles: [ProfileStatus]
+}
+
+struct BallPosition: Codable {
+    let x: Double
+    let y: Double
+}
+
+final class StatusStore {
+    private let statusURL: URL
+    private let positionURL: URL
+
+    init(root: URL) {
+        self.statusURL = root.appendingPathComponent("desktop-status.json")
+        self.positionURL = root.appendingPathComponent("desktop-floating-ball.json")
+    }
+
+    func readSnapshot() -> StatusSnapshot {
+        guard let data = try? Data(contentsOf: statusURL),
+              let snapshot = try? JSONDecoder().decode(StatusSnapshot.self, from: data) else {
+            return StatusSnapshot(updatedAt: isoNow(), aggregateStatus: .offline, profiles: [])
+        }
+        return snapshot
+    }
+
+    func readPosition() -> NSPoint? {
+        guard let data = try? Data(contentsOf: positionURL),
+              let position = try? JSONDecoder().decode(BallPosition.self, from: data) else {
+            return nil
+        }
+        return NSPoint(x: position.x, y: position.y)
+    }
+
+    func writePosition(_ point: NSPoint) {
+        let position = BallPosition(x: point.x, y: point.y)
+        guard let data = try? JSONEncoder().encode(position) else { return }
+        try? FileManager.default.createDirectory(
+            at: positionURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try? data.write(to: positionURL, options: [.atomic])
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: positionURL.path)
+    }
+}
+
+final class SingleInstanceLock {
+    private let fd: Int32
+
+    init?(root: URL) {
+        let dir = root.appendingPathComponent("registry", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let path = dir.appendingPathComponent("desktop-floating-ball.lock").path
+        fd = open(path, O_CREAT | O_RDWR, S_IRUSR | S_IWUSR)
+        guard fd >= 0 else { return nil }
+        guard flock(fd, LOCK_EX | LOCK_NB) == 0 else {
+            close(fd)
+            return nil
+        }
+        ftruncate(fd, 0)
+        let pid = "\(ProcessInfo.processInfo.processIdentifier)\n"
+        _ = pid.withCString { write(fd, $0, strlen($0)) }
+    }
+
+    deinit {
+        flock(fd, LOCK_UN)
+        close(fd)
+    }
+}
+
+final class BallView: NSView {
+    var snapshot = StatusSnapshot(updatedAt: isoNow(), aggregateStatus: .offline, profiles: []) {
+        didSet { needsDisplay = true }
+    }
+    var expanded = false {
+        didSet { needsDisplay = true }
+    }
+    var onHoverChanged: ((Bool) -> Void)?
+    var onDragEnded: (() -> Void)?
+
+    private var tracking: NSTrackingArea?
+    private var dragStart: NSPoint?
+    private var windowStart: NSPoint?
+
+    override var isFlipped: Bool { true }
+
+    override func updateTrackingAreas() {
+        if let tracking { removeTrackingArea(tracking) }
+        let next = NSTrackingArea(
+            rect: bounds,
+            options: [.activeAlways, .mouseEnteredAndExited, .inVisibleRect],
+            owner: self
+        )
+        addTrackingArea(next)
+        tracking = next
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        onHoverChanged?(true)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        onHoverChanged?(false)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        dragStart = NSEvent.mouseLocation
+        windowStart = window?.frame.origin
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let window, let dragStart, let windowStart else { return }
+        let current = NSEvent.mouseLocation
+        let next = NSPoint(
+            x: windowStart.x + current.x - dragStart.x,
+            y: windowStart.y + current.y - dragStart.y
+        )
+        window.setFrameOrigin(next)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        dragStart = nil
+        windowStart = nil
+        onDragEnded?()
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        NSColor.clear.setFill()
+        dirtyRect.fill()
+        if expanded {
+            drawPanel(in: bounds)
+        }
+        drawBall(in: collapsedBallRect())
+    }
+
+    private func collapsedBallRect() -> NSRect {
+        let side: CGFloat = 44
+        return NSRect(x: (bounds.width - side) / 2, y: (bounds.height - side) / 2, width: side, height: side)
+    }
+
+    private func drawBall(in rect: NSRect) {
+        let path = NSBezierPath(ovalIn: rect.insetBy(dx: 3, dy: 3))
+        snapshot.aggregateStatus.color.setFill()
+        path.fill()
+        NSColor.white.withAlphaComponent(0.82).setStroke()
+        path.lineWidth = 2
+        path.stroke()
+    }
+
+    private func drawPanel(in rect: NSRect) {
+        let panel = NSBezierPath(roundedRect: rect.insetBy(dx: 2, dy: 2), xRadius: 18, yRadius: 18)
+        NSColor.windowBackgroundColor.withAlphaComponent(0.94).setFill()
+        panel.fill()
+        NSColor.separatorColor.withAlphaComponent(0.45).setStroke()
+        panel.lineWidth = 1
+        panel.stroke()
+
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 12, weight: .medium),
+            .foregroundColor: NSColor.labelColor,
+        ]
+        let profiles = snapshot.profiles.isEmpty
+            ? [ProfileStatus(profile: "bridge", botName: nil, appIdSuffix: nil, agent: "-", status: .offline, activeRunCount: 0, queuedMessageCount: 0, updatedAt: isoNow(), lastErrorKind: nil)]
+            : snapshot.profiles
+        for (idx, profile) in profiles.prefix(8).enumerated() {
+            let rowY = CGFloat(14 + idx * 26)
+            let dot = NSBezierPath(ovalIn: NSRect(x: 18, y: rowY + 4, width: 10, height: 10))
+            profile.status.color.setFill()
+            dot.fill()
+            let name = profile.botName ?? profile.profile
+            let counts = profile.activeRunCount > 0 ? " \(profile.activeRunCount) run" :
+                profile.queuedMessageCount > 0 ? " \(profile.queuedMessageCount) queued" : ""
+            let text = "\(name)  \(profile.status.label)\(counts)" as NSString
+            text.draw(in: NSRect(x: 36, y: rowY, width: rect.width - 54, height: 18), withAttributes: attrs)
+        }
+    }
+}
+
+final class BallController {
+    private let store: StatusStore
+    private let window: NSWindow
+    private let view: BallView
+    private var timer: Timer?
+    private var collapsedOrigin: NSPoint
+
+    init(store: StatusStore) {
+        self.store = store
+        self.view = BallView(frame: NSRect(x: 0, y: 0, width: 44, height: 44))
+        self.collapsedOrigin = BallController.safeOrigin(for: store.readPosition())
+        self.window = NSWindow(
+            contentRect: NSRect(origin: collapsedOrigin, size: NSSize(width: 44, height: 44)),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isOpaque = false
+        window.backgroundColor = .clear
+        window.level = .floating
+        window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
+        window.hasShadow = true
+        window.contentView = view
+        view.onHoverChanged = { [weak self] expanded in self?.setExpanded(expanded) }
+        view.onDragEnded = { [weak self] in self?.saveCollapsedPosition() }
+    }
+
+    func start() {
+        refresh()
+        window.orderFrontRegardless()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.35, repeats: true) { [weak self] _ in
+            self?.refresh()
+        }
+    }
+
+    private func refresh() {
+        view.snapshot = store.readSnapshot()
+    }
+
+    private func setExpanded(_ expanded: Bool) {
+        view.expanded = expanded
+        let size = expanded ? expandedSize() : NSSize(width: 44, height: 44)
+        let origin: NSPoint
+        if expanded {
+            let center = NSPoint(x: window.frame.midX, y: window.frame.midY)
+            origin = BallController.clamp(
+                origin: NSPoint(x: center.x - size.width / 2, y: center.y - size.height / 2),
+                size: size
+            )
+        } else {
+            origin = collapsedOrigin
+        }
+        window.setFrame(NSRect(origin: origin, size: size), display: true, animate: true)
+        view.frame = NSRect(origin: .zero, size: size)
+    }
+
+    private func expandedSize() -> NSSize {
+        let rows = max(1, min(8, view.snapshot.profiles.count))
+        return NSSize(width: 360, height: CGFloat(28 + rows * 26))
+    }
+
+    private func saveCollapsedPosition() {
+        collapsedOrigin = BallController.clamp(origin: window.frame.origin, size: NSSize(width: 44, height: 44))
+        window.setFrameOrigin(collapsedOrigin)
+        store.writePosition(collapsedOrigin)
+    }
+
+    private static func safeOrigin(for saved: NSPoint?) -> NSPoint {
+        let visible = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 900, height: 700)
+        let fallback = NSPoint(x: visible.maxX - 58, y: visible.maxY - 58)
+        return clamp(origin: saved ?? fallback, size: NSSize(width: 44, height: 44))
+    }
+
+    private static func clamp(origin: NSPoint, size: NSSize) -> NSPoint {
+        let frame = NSScreen.screens.first(where: { $0.visibleFrame.insetBy(dx: -200, dy: -200).contains(origin) })?.visibleFrame
+            ?? NSScreen.main?.visibleFrame
+            ?? NSRect(x: 0, y: 0, width: 900, height: 700)
+        let inset: CGFloat = 8
+        return NSPoint(
+            x: min(max(origin.x, frame.minX + inset), frame.maxX - size.width - inset),
+            y: min(max(origin.y, frame.minY + inset), frame.maxY - size.height - inset)
+        )
+    }
+}
+
+func isoNow() -> String {
+    ISO8601DateFormatter().string(from: Date())
+}
+
+func rootURL() -> URL {
+    let args = CommandLine.arguments
+    if let idx = args.firstIndex(of: "--root"), idx + 1 < args.count {
+        return URL(fileURLWithPath: args[idx + 1], isDirectory: true)
+    }
+    if let home = ProcessInfo.processInfo.environment["LARK_CHANNEL_HOME"] {
+        return URL(fileURLWithPath: home, isDirectory: true)
+    }
+    return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".lark-channel", isDirectory: true)
+}
+
+let root = rootURL()
+guard let instanceLock = SingleInstanceLock(root: root) else {
+    exit(0)
+}
+_ = instanceLock
+
+let app = NSApplication.shared
+app.setActivationPolicy(.accessory)
+let controller = BallController(store: StatusStore(root: root))
+controller.start()
+app.run()

--- a/desktop/macos-floating-ball/Sources/LarkChannelFloatingBall/main.swift
+++ b/desktop/macos-floating-ball/Sources/LarkChannelFloatingBall/main.swift
@@ -67,10 +67,12 @@ struct BallPosition: Codable {
 final class StatusStore {
     private let statusURL: URL
     private let positionURL: URL
+    private let logURL: URL
 
     init(root: URL) {
         self.statusURL = root.appendingPathComponent("desktop-status.json")
         self.positionURL = root.appendingPathComponent("desktop-floating-ball.json")
+        self.logURL = root.appendingPathComponent("desktop-floating-ball.log")
     }
 
     func readSnapshot() -> StatusSnapshot {
@@ -98,6 +100,24 @@ final class StatusStore {
         )
         try? data.write(to: positionURL, options: [.atomic])
         try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: positionURL.path)
+    }
+
+    func log(_ message: String) {
+        let line = "\(isoNow()) \(message)\n"
+        guard let data = line.data(using: .utf8) else { return }
+        try? FileManager.default.createDirectory(
+            at: logURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if FileManager.default.fileExists(atPath: logURL.path),
+           let handle = try? FileHandle(forWritingTo: logURL) {
+            _ = try? handle.seekToEnd()
+            try? handle.write(contentsOf: data)
+            try? handle.close()
+        } else {
+            try? data.write(to: logURL, options: [.atomic])
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: logURL.path)
+        }
     }
 }
 
@@ -192,6 +212,14 @@ final class BallView: NSView {
 
     private func collapsedBallRect() -> NSRect {
         let side: CGFloat = 44
+        if expanded {
+            return NSRect(
+                x: bounds.width - side,
+                y: (bounds.height - side) / 2,
+                width: side,
+                height: side
+            )
+        }
         return NSRect(x: (bounds.width - side) / 2, y: (bounds.height - side) / 2, width: side, height: side)
     }
 
@@ -233,36 +261,47 @@ final class BallView: NSView {
     }
 }
 
+final class FloatingPanel: NSPanel {
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+}
+
 final class BallController {
     private let store: StatusStore
-    private let window: NSWindow
+    private let window: FloatingPanel
     private let view: BallView
     private var timer: Timer?
+    private var collapseTimer: Timer?
     private var collapsedOrigin: NSPoint
 
     init(store: StatusStore) {
         self.store = store
         self.view = BallView(frame: NSRect(x: 0, y: 0, width: 44, height: 44))
         self.collapsedOrigin = BallController.safeOrigin(for: store.readPosition())
-        self.window = NSWindow(
+        self.window = FloatingPanel(
             contentRect: NSRect(origin: collapsedOrigin, size: NSSize(width: 44, height: 44)),
-            styleMask: [.borderless],
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
         window.isOpaque = false
         window.backgroundColor = .clear
-        window.level = .floating
+        window.level = .statusBar
         window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
         window.hasShadow = true
+        window.hidesOnDeactivate = false
+        window.isReleasedWhenClosed = false
+        window.ignoresMouseEvents = false
         window.contentView = view
-        view.onHoverChanged = { [weak self] expanded in self?.setExpanded(expanded) }
+        view.onHoverChanged = { [weak self] expanded in self?.handleHoverChanged(expanded) }
         view.onDragEnded = { [weak self] in self?.saveCollapsedPosition() }
     }
 
     func start() {
         refresh()
+        store.log("show window origin=\(window.frame.origin.x),\(window.frame.origin.y) size=\(window.frame.size.width),\(window.frame.size.height) screens=\(screenSummary())")
         window.orderFrontRegardless()
+        window.display()
         timer = Timer.scheduledTimer(withTimeInterval: 0.35, repeats: true) { [weak self] _ in
             self?.refresh()
         }
@@ -272,37 +311,80 @@ final class BallController {
         view.snapshot = store.readSnapshot()
     }
 
+    private func handleHoverChanged(_ hovering: Bool) {
+        if hovering {
+            collapseTimer?.invalidate()
+            collapseTimer = nil
+            setExpanded(true)
+            return
+        }
+        scheduleCollapseIfOutside()
+    }
+
+    private func scheduleCollapseIfOutside() {
+        collapseTimer?.invalidate()
+        collapseTimer = Timer.scheduledTimer(withTimeInterval: 0.18, repeats: false) { [weak self] _ in
+            guard let self else { return }
+            self.collapseTimer = nil
+            let mouse = NSEvent.mouseLocation
+            if self.window.frame.insetBy(dx: -4, dy: -4).contains(mouse) {
+                return
+            }
+            self.setExpanded(false)
+        }
+    }
+
     private func setExpanded(_ expanded: Bool) {
-        view.expanded = expanded
+        if view.expanded == expanded {
+            return
+        }
         let size = expanded ? expandedSize() : NSSize(width: 44, height: 44)
         let origin: NSPoint
         if expanded {
-            let center = NSPoint(x: window.frame.midX, y: window.frame.midY)
+            view.expanded = true
             origin = BallController.clamp(
-                origin: NSPoint(x: center.x - size.width / 2, y: center.y - size.height / 2),
+                origin: NSPoint(
+                    x: collapsedOrigin.x - (size.width - 44),
+                    y: collapsedOrigin.y - (size.height - 44) / 2
+                ),
                 size: size
             )
+            window.setFrame(NSRect(origin: origin, size: size), display: true, animate: true)
+            view.frame = NSRect(origin: .zero, size: size)
         } else {
-            origin = collapsedOrigin
+            let collapsedFrame = NSRect(origin: collapsedOrigin, size: size)
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.16
+                context.allowsImplicitAnimation = true
+                window.animator().setFrame(collapsedFrame, display: true)
+            } completionHandler: { [weak self] in
+                guard let self else { return }
+                self.view.frame = NSRect(origin: .zero, size: size)
+                self.view.expanded = false
+            }
         }
-        window.setFrame(NSRect(origin: origin, size: size), display: true, animate: true)
-        view.frame = NSRect(origin: .zero, size: size)
     }
 
     private func expandedSize() -> NSSize {
         let rows = max(1, min(8, view.snapshot.profiles.count))
-        return NSSize(width: 360, height: CGFloat(28 + rows * 26))
+        return NSSize(width: 180, height: CGFloat(28 + rows * 26))
     }
 
     private func saveCollapsedPosition() {
-        collapsedOrigin = BallController.clamp(origin: window.frame.origin, size: NSSize(width: 44, height: 44))
+        let origin = view.expanded
+            ? NSPoint(
+                x: window.frame.maxX - 44,
+                y: window.frame.midY - 22
+            )
+            : window.frame.origin
+        collapsedOrigin = BallController.clamp(origin: origin, size: NSSize(width: 44, height: 44))
         window.setFrameOrigin(collapsedOrigin)
         store.writePosition(collapsedOrigin)
     }
 
     private static func safeOrigin(for saved: NSPoint?) -> NSPoint {
-        let visible = NSScreen.main?.visibleFrame ?? NSRect(x: 0, y: 0, width: 900, height: 700)
-        let fallback = NSPoint(x: visible.maxX - 58, y: visible.maxY - 58)
+        let visible = defaultVisibleFrame()
+        let fallback = NSPoint(x: visible.midX - 22, y: visible.midY - 22)
         return clamp(origin: saved ?? fallback, size: NSSize(width: 44, height: 44))
     }
 
@@ -316,6 +398,21 @@ final class BallController {
             y: min(max(origin.y, frame.minY + inset), frame.maxY - size.height - inset)
         )
     }
+
+    private static func defaultVisibleFrame() -> NSRect {
+        let mouse = NSEvent.mouseLocation
+        return NSScreen.screens.first(where: { $0.visibleFrame.contains(mouse) })?.visibleFrame
+            ?? NSScreen.main?.visibleFrame
+            ?? NSScreen.screens.first?.visibleFrame
+            ?? NSRect(x: 0, y: 0, width: 900, height: 700)
+    }
+}
+
+func screenSummary() -> String {
+    NSScreen.screens.enumerated().map { idx, screen in
+        let frame = screen.visibleFrame
+        return "#\(idx)(x:\(Int(frame.minX)),y:\(Int(frame.minY)),w:\(Int(frame.width)),h:\(Int(frame.height)))"
+    }.joined(separator: ",")
 }
 
 func isoNow() -> String {
@@ -333,14 +430,34 @@ func rootURL() -> URL {
     return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".lark-channel", isDirectory: true)
 }
 
-let root = rootURL()
-guard let instanceLock = SingleInstanceLock(root: root) else {
-    exit(0)
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private let root: URL
+    private var instanceLock: SingleInstanceLock?
+    private var controller: BallController?
+
+    init(root: URL) {
+        self.root = root
+    }
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let store = StatusStore(root: root)
+        guard let lock = SingleInstanceLock(root: root) else {
+            store.log("another instance is already running")
+            NSApplication.shared.terminate(nil)
+            return
+        }
+        instanceLock = lock
+        store.log("application did finish launching root=\(root.path)")
+        let controller = BallController(store: store)
+        self.controller = controller
+        controller.start()
+    }
 }
-_ = instanceLock
+
+var retainedAppDelegate: AppDelegate?
 
 let app = NSApplication.shared
+retainedAppDelegate = AppDelegate(root: rootURL())
+app.delegate = retainedAppDelegate
 app.setActivationPolicy(.accessory)
-let controller = BallController(store: StatusStore(root: root))
-controller.start()
 app.run()

--- a/docs/desktop-status.md
+++ b/docs/desktop-status.md
@@ -1,0 +1,66 @@
+# macOS Floating Status Ball
+
+On macOS, `lark-channel-bridge` starts a small floating desktop status ball by default. It reads local status snapshots from `~/.lark-channel/desktop-status.json` and shows the most important state across all visible profiles.
+
+## User Behavior
+
+- The helper is macOS-only. Linux and Windows never start it.
+- `lark-channel-bridge run --no-floating-ball` disables it for the current foreground run.
+- `lark-channel-bridge start --no-floating-ball` writes the launchd service so that daemon run also disables it.
+- A profile can disable it persistently:
+
+```json
+{
+  "desktop": {
+    "floatingBall": {
+      "enabled": false
+    }
+  }
+}
+```
+
+When the config is missing, macOS treats the feature as enabled. The CLI flag wins over config. Non-macOS platforms are always disabled.
+
+## Snapshot Contract
+
+The bridge writes one aggregate snapshot with a whitelist-only schema:
+
+```json
+{
+  "updatedAt": "2026-07-12T10:00:00.000Z",
+  "aggregateStatus": "tool_running",
+  "profiles": [
+    {
+      "profile": "codex-dev",
+      "botName": "Ops Bot",
+      "appIdSuffix": "abc123",
+      "agent": "codex",
+      "status": "tool_running",
+      "activeRunCount": 1,
+      "queuedMessageCount": 0,
+      "updatedAt": "2026-07-12T10:00:00.000Z",
+      "lastErrorKind": "agent"
+    }
+  ]
+}
+```
+
+Status priority is:
+
+```text
+error > reconnecting > tool_running > streaming > thinking > queued > idle > connecting > offline
+```
+
+The snapshot must not include message bodies, prompts, assistant output, tool input/output, chat IDs, thread IDs, session IDs, sender IDs, app secrets, tokens, or full app IDs.
+
+## Helper Development
+
+The helper is a SwiftPM AppKit executable at `desktop/macos-floating-ball`.
+
+```bash
+cd desktop/macos-floating-ball
+swift build -c release
+LARK_CHANNEL_FLOATING_BALL_HELPER="$PWD/.build/release/LarkChannelFloatingBall" lark-channel-bridge run
+```
+
+The helper is single-instance per `LARK_CHANNEL_HOME`, polls the snapshot as a fallback to file events, saves drag position to `desktop-floating-ball.json`, and clamps restored or expanded windows into the current screen visible frame.

--- a/openspec/changes/add-macos-floating-status-ball/.openspec.yaml
+++ b/openspec/changes/add-macos-floating-status-ball/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-12

--- a/openspec/changes/add-macos-floating-status-ball/design.md
+++ b/openspec/changes/add-macos-floating-status-ball/design.md
@@ -1,0 +1,165 @@
+## Context
+
+`lark-coding-agent-bridge` 是 Node.js / TypeScript CLI 与后台服务。当前 macOS 后台运行由 launchd 适配层管理，Linux 使用 systemd，Windows 使用 Task Scheduler。bridge 运行时已经具备多层状态来源：
+
+- `runStart` 注册进程到本地 registry，并在 WS 握手成功后回填 `botName`。
+- `startChannel` 维护 WS 连接、重连、消息 intake、pending queue 与 active run。
+- `RunExecutor` 负责提交 agent run、注册 `ActiveRuns`、分发 agent event，并记录 started / completed / failed。
+- `processAgentStream` 将 agent event reduce 为 `RunState`，区分 `thinking`、`tool_running`、`streaming`、`done`、`interrupted`、`error`、`idle_timeout`。
+
+当前用户需要 macOS 桌面可见的状态反馈：默认开启、可拖动、多 profile 聚合为一个悬浮球，鼠标 hover 时左右展开所有 profile。
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- 在 macOS 上提供默认开启的桌面悬浮球，用颜色、动效或简短标签展示 bridge 当前聚合状态。
+- 同一用户同时运行多个 profile 时仅显示一个悬浮球，hover 时左右展开 profile 列表。
+- 悬浮球可拖动，并持久化最后位置。
+- CLI 支持 `--no-floating-ball`，配置支持永久关闭。
+- bridge 进程发布不含敏感正文的状态快照，桌面 helper 只消费状态，不反向控制 bot。
+- 非 macOS 平台不启动悬浮球，不改变现有 service 行为。
+
+**Non-Goals:**
+
+- 不实现 Electron 桌面应用。
+- 不做完整偏好设置窗口、菜单栏 App 或通知中心提醒。
+- 不展示 prompt、消息正文、工具输入输出、文件路径等敏感内容。
+- 不支持从悬浮球停止 run、发送命令或切换 profile。
+- 不做跨设备同步，不依赖远端服务保存状态。
+
+## Decisions
+
+### 1. macOS 使用轻量原生 helper，而不是 Electron
+
+悬浮球是一个很小的桌面常驻 UI，核心能力是无边框置顶窗口、拖动、hover 展开和读取本地状态文件。macOS 原生 AppKit / Swift helper 可以低资源实现这些能力，并可由 CLI 或 launchd 启动。
+
+备选方案：Electron。优点是实现快、可复用 Web 技术；缺点是体积和资源占用过高，对一个 CLI bridge 的状态指示器显得笨重。
+
+备选方案：AppleScript / JXA。优点是无需编译复杂工程；缺点是窗口交互、动画、长期维护和签名分发都脆弱。
+
+### 2. bridge 写状态快照，helper 只读快照
+
+bridge 进程内已经知道真实状态。新增 `DesktopStatusReporter` 或等价模块，将 profile 级状态写入本地 JSON 快照：
+
+```text
+~/.lark-channel/desktop-status.json
+  ├─ updatedAt
+  ├─ aggregateStatus
+  └─ profiles[]
+       ├─ profile
+       ├─ botName
+       ├─ appIdSuffix
+       ├─ agent
+       ├─ status
+       ├─ activeRunCount
+       ├─ queuedMessageCount
+       └─ lastErrorKind
+```
+
+快照 SHALL 使用原子写入，避免 helper 读到半截 JSON。helper 使用文件监听加兜底轮询读取该快照，不直接 import bridge 内部模块，不探测 agent 子进程。
+
+状态优先级建议：
+
+```text
+error > reconnecting > tool_running > streaming > thinking > queued > idle > connecting > offline
+```
+
+聚合状态取所有 profile 中最高优先级状态。hover 展开列表展示每个 profile 自身状态。
+
+### 3. 多 profile 聚合为单一悬浮球
+
+桌面上永远只出现一个悬浮球，避免多个 profile 同时运行时产生 UI 噪声。bridge 各 profile 进程写入同一个全局快照，由文件锁或原子读改写维护 `profiles[]`。
+
+helper 本身也应单实例运行。启动时通过 PID 文件、NSWorkspace bundle identifier 检查或 lockfile 避免重复 helper；若已有 helper 运行，新启动只更新状态快照并退出或 no-op。
+
+hover 行为：
+
+```text
+        idle
+         ●
+
+hover:
+
+  claude-prod  ● idle      ● thinking  codex-dev
+  ops-bot      ● error     ● queued    test-bot
+```
+
+左右展开时以悬浮球为中心，空间不足时向可用方向偏移，保证不超出当前屏幕 visible frame。
+
+### 4. 配置优先级：CLI 参数高于配置项，默认开启
+
+macOS 下 `start` 和 service start 默认尝试启动或唤醒 helper。关闭来源：
+
+1. `--no-floating-ball`：当前启动命令禁用悬浮球。
+2. profile 或 root 配置项：永久禁用悬浮球。
+3. 非 macOS：强制禁用，即使配置为开启。
+
+配置建议：
+
+```json
+{
+  "desktop": {
+    "floatingBall": {
+      "enabled": true
+    }
+  }
+}
+```
+
+若配置缺省，macOS 视为 `enabled: true`，其他平台视为不可用。
+
+### 5. 状态事件挂接点
+
+状态 reporter 在以下位置更新快照：
+
+- `runStart` 注册进程后：写入 `connecting`。
+- `channel.connect()` 成功后：写入 `idle`，补充 `botName`。
+- `reconnecting` / `reconnected` 事件：写入 `reconnecting` 或恢复到当前 run / queue 状态。
+- pending queue push / block / unblock：写入 `queued` 或恢复状态。
+- `RunExecutor.submit` 成功后：写入 `thinking`，记录 `runId` 与 scope 计数。
+- `processAgentStream` 状态变化：映射 `footer` 到 `thinking` / `tool_running` / `streaming`。
+- terminal 状态：根据 `done` / `interrupted` / `idle_timeout` / `error` 恢复 `idle` 或写入短暂错误状态。
+- disconnect / process exit：移除该 profile 或标记 `offline`。
+
+### 6. 隐私与安全边界
+
+快照只包含展示状态所需的低敏字段。不得写入：
+
+- 用户消息正文、prompt、assistant 输出。
+- 工具输入输出、命令参数、文件路径。
+- sessionId、threadId、chatId、senderId。
+- app secret、token、完整 appId。
+
+profile 识别可使用 profile 名、botName、agent 类型与 appId 后 6 位。状态文件权限使用 `0600`，位置偏好同样写入用户目录。
+
+### 7. 失败处理
+
+helper 启动失败不应阻断 bridge 启动。bridge SHALL 记录 warning，并继续正常接收消息。状态写入失败也只记录 warning，不影响 agent run。
+
+如果 helper 崩溃，后续 `start` / service restart 可再次启动；已经运行的 bridge 可继续写快照，用户也可通过 CLI 命令重新唤起 helper（若实现额外命令）。
+
+## Risks / Trade-offs
+
+- **[Risk] 多进程同时写全局状态快照产生竞争** → 使用 lockfile 或写入 profile 独立文件再由 helper 聚合；若采用全局文件，必须原子读改写。
+- **[Risk] helper 被 launchd 和多个 profile 重复启动** → helper 必须单实例化，新启动检测已有实例后退出。
+- **[Risk] 默认开启可能打扰用户** → 提供 `--no-floating-ball` 和配置项；首次出现保持小尺寸、无声音、无通知。
+- **[Risk] 状态快照泄露敏感信息** → 明确字段白名单，测试中断言不包含 message / prompt / tool payload。
+- **[Risk] helper 构建分发增加复杂度** → 将 helper 作为 macOS-only 子项目，非 macOS 构建路径跳过；CI 可拆出 macOS job。
+- **[Trade-off] 文件快照不是内存级实时** → 可接受，桌面状态指示对 100-500ms 延迟不敏感；实现简单、进程解耦。
+
+## Migration Plan
+
+1. 新增桌面状态 schema、状态 reporter 与原子写入工具。
+2. 在 bridge 生命周期、WS 事件、pending queue、RunExecutor 和 processAgentStream 挂接状态更新。
+3. 新增 macOS helper，实现悬浮球、拖动、hover 展开、单实例和位置持久化。
+4. 在 CLI / service start 中按配置与 `--no-floating-ball` 决定是否启动 helper。
+5. 添加单元测试覆盖状态映射、配置优先级、隐私字段与平台 gating。
+6. macOS 手动验证单 profile、多 profile、hover 展开、拖动持久化、重连、错误和关闭配置。
+
+回滚时可关闭配置项或移除 helper 启动调用；bridge 核心消息处理不依赖悬浮球。
+
+## Open Questions
+
+- helper 打包方式待实现时根据仓库现有发布流程确认：可选 SwiftPM 可执行、Xcode 子项目或预编译二进制随 npm 包发布。
+- 悬浮球视觉细节（颜色、尺寸、动画时长）可在实现阶段以最小可用版本确定，但不得改变本 change 的行为契约。

--- a/openspec/changes/add-macos-floating-status-ball/manual-verification.md
+++ b/openspec/changes/add-macos-floating-status-ball/manual-verification.md
@@ -1,0 +1,44 @@
+# Manual Verification: macOS Floating Status Ball
+
+## Single Profile
+
+- Start `lark-channel-bridge run` on macOS.
+- Confirm exactly one floating ball appears.
+- Confirm it changes from `connecting` to `idle` after the bot connects.
+- Send one message and confirm the ball enters `thinking`, `tool_running`, or `streaming`.
+- Let the run finish and confirm the ball returns to `idle`.
+
+## Multiple Profiles
+
+- Start two profiles with different names.
+- Confirm the desktop still shows one floating ball.
+- Hover over the ball and confirm both profile names appear.
+- Put one profile into a run and confirm aggregate state follows the busier profile.
+- Queue a message during an active run and confirm the profile row shows queued count.
+
+## Hover And Layout
+
+- Move the ball near the left, right, top, and bottom screen edges.
+- Hover and confirm the expanded list stays inside the visible screen frame.
+- Move the mouse out of the ball/list and confirm it collapses.
+
+## Drag Persistence
+
+- Drag the collapsed ball to a new location.
+- Stop and restart the helper.
+- Confirm the ball restores to the saved location.
+- Change displays or resolution so the old location is off-screen.
+- Restart and confirm the ball moves to a visible safe location.
+
+## Reconnect And Errors
+
+- Temporarily interrupt network connectivity.
+- Confirm the ball shows `reconnecting`.
+- Restore connectivity and confirm it returns to the current idle/queue/run state.
+- Trigger an agent error or idle timeout and confirm only a low-sensitive error state appears.
+
+## Disable And Failure Paths
+
+- Run `lark-channel-bridge run --no-floating-ball` and confirm no helper starts.
+- Configure `"desktop": { "floatingBall": { "enabled": false } }` and confirm no helper starts.
+- Set `LARK_CHANNEL_FLOATING_BALL_HELPER` to a missing path and confirm bridge startup continues with only a warning.

--- a/openspec/changes/add-macos-floating-status-ball/proposal.md
+++ b/openspec/changes/add-macos-floating-status-ball/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`lark-coding-agent-bridge` 以后台 bot 方式运行时，用户缺少一个无需切回终端或飞书即可判断 bot 当前状态的桌面入口。macOS 用户尤其需要一个轻量、可拖动、始终可见的状态指示器，快速确认 bot 是否在线、是否正在处理任务、是否发生重连或错误。
+
+## What Changes
+
+- 在 macOS 桌面新增默认开启的可视化悬浮球，用于指示当前 bridge / bot 运行状态。
+- 悬浮球支持拖动，并持久化用户最后放置的位置。
+- 多 profile 同时运行时聚合为一个悬浮球，而不是为每个 profile 创建独立悬浮球。
+- 鼠标移动到悬浮球上时，悬浮球 SHALL 左右展开，展示所有正在运行或最近可见的 profile 状态。
+- macOS 以外平台不启用悬浮球，也不影响现有 Linux / Windows 后台服务。
+- 默认开启该能力，同时提供 CLI 参数 `--no-floating-ball` 和配置项关闭。
+- 状态展示以 bridge 进程内的连接状态、队列状态、active run 状态与 agent stream 状态为准，不依赖桌面 helper 猜测进程。
+- 不在 v1 中提供完整偏好设置界面、系统菜单栏 App、通知中心提醒或跨设备状态同步。
+
+## Capabilities
+
+### New Capabilities
+
+- `desktop-status-indicator`: 定义 macOS 桌面悬浮球的状态展示、拖动、多 profile 聚合、hover 展开、默认开启与关闭规则。
+
+### Modified Capabilities
+
+<!-- 无 -->
+
+## Impact
+
+- **Platform**: 新增 macOS-only 桌面 helper 或等价原生桌面组件；非 macOS 平台保持无行为变化。
+- **Runtime**: bridge 运行时需要发布 profile 级状态快照，包括连接、排队、运行、工具执行、输出、重连、错误等状态。
+- **CLI**: `start` / service 启动路径新增 `--no-floating-ball` 参数，并读取配置项决定是否启动悬浮球。
+- **Config**: profile 或 root 配置新增悬浮球开关，默认值为开启；显式关闭后不启动桌面 UI。
+- **State Storage**: 新增本地状态快照与悬浮球位置持久化文件，避免泄露消息正文、prompt、工具输入输出等敏感内容。
+- **UX**: 提供常驻桌面状态反馈、hover 展开 profile 列表、错误/重连可见提示与拖动交互。
+- **Tests**: 覆盖状态快照映射、配置开关优先级、macOS 平台 gating、多 profile 聚合与悬浮球位置持久化。

--- a/openspec/changes/add-macos-floating-status-ball/specs/desktop-status-indicator/spec.md
+++ b/openspec/changes/add-macos-floating-status-ball/specs/desktop-status-indicator/spec.md
@@ -1,0 +1,142 @@
+## ADDED Requirements
+
+### Requirement: macOS 桌面悬浮球默认启用
+
+系统 SHALL 在 macOS 上默认启用桌面悬浮球，用于展示当前 bridge / bot 的运行状态。
+
+#### Scenario: macOS 默认启动悬浮球
+
+- **WHEN** 用户在 macOS 上启动 bridge
+- **AND** 未传入 `--no-floating-ball`
+- **AND** 配置项未显式关闭悬浮球
+- **THEN** 系统 SHALL 启动或唤醒桌面悬浮球
+- **AND** bridge SHALL 继续正常启动和连接 bot
+
+#### Scenario: 非 macOS 不启用悬浮球
+
+- **WHEN** 用户在 Linux 或 Windows 上启动 bridge
+- **THEN** 系统 SHALL NOT 启动桌面悬浮球
+- **AND** 系统 SHALL NOT 因悬浮球不可用而影响后台服务启动
+
+#### Scenario: 使用 CLI 参数关闭悬浮球
+
+- **WHEN** 用户启动 bridge 时传入 `--no-floating-ball`
+- **THEN** 系统 SHALL NOT 启动或唤醒桌面悬浮球
+- **AND** bridge SHALL 继续正常启动和连接 bot
+
+#### Scenario: 使用配置项关闭悬浮球
+
+- **WHEN** 用户配置悬浮球为关闭
+- **AND** 用户启动 bridge
+- **THEN** 系统 SHALL NOT 启动或唤醒桌面悬浮球
+- **AND** bridge SHALL 继续正常启动和连接 bot
+
+### Requirement: 悬浮球展示聚合运行状态
+
+桌面悬浮球 SHALL 展示所有本机可见 profile 的聚合状态，聚合状态 SHALL 由各 profile 状态中最高优先级状态决定。
+
+#### Scenario: 单 profile 空闲
+
+- **WHEN** 只有一个 profile 正在运行
+- **AND** bot 已连接
+- **AND** 没有排队消息或 active run
+- **THEN** 悬浮球 SHALL 展示空闲状态
+
+#### Scenario: 单 profile 正在处理任务
+
+- **WHEN** 任一 profile 的 agent run 进入 thinking、tool_running 或 streaming 状态
+- **THEN** 悬浮球 SHALL 展示对应的忙碌状态
+- **AND** 展示状态 SHALL 来源于 bridge 进程内的 run / stream 状态
+
+#### Scenario: 任一 profile 正在重连
+
+- **WHEN** 任一 profile 的 WS 连接进入 reconnecting 状态
+- **THEN** 悬浮球 SHALL 展示重连状态
+
+#### Scenario: 任一 profile 出错
+
+- **WHEN** 任一 profile 最近一次连接或 run 进入 error 状态
+- **THEN** 悬浮球 SHALL 展示错误状态
+- **AND** 错误状态 SHALL 不包含敏感错误上下文正文
+
+### Requirement: 多 profile 聚合为单一悬浮球
+
+系统 SHALL 在多 profile 同时运行时仅显示一个桌面悬浮球，并在悬浮球中聚合所有 profile 的状态。
+
+#### Scenario: 多 profile 同时运行
+
+- **WHEN** 本机同时运行两个或更多 profile
+- **THEN** 桌面 SHALL 只显示一个悬浮球
+- **AND** 悬浮球 SHALL 使用聚合状态表示所有 profile 中最需要关注的状态
+
+#### Scenario: hover 展开所有 profile
+
+- **WHEN** 鼠标移动到悬浮球上
+- **THEN** 悬浮球 SHALL 左右展开 profile 状态列表
+- **AND** 列表 SHALL 展示每个可见 profile 的名称和当前状态
+- **AND** 列表 SHALL 保持在当前屏幕可见区域内
+
+#### Scenario: 鼠标移出后收起
+
+- **WHEN** 鼠标离开悬浮球及其展开区域
+- **THEN** profile 状态列表 SHALL 收起
+- **AND** 桌面 SHALL 继续只显示聚合悬浮球
+
+### Requirement: 悬浮球可拖动并持久化位置
+
+桌面悬浮球 SHALL 支持用户拖动，并记住最后放置的位置。
+
+#### Scenario: 用户拖动悬浮球
+
+- **WHEN** 用户拖动悬浮球到屏幕上的新位置
+- **THEN** 悬浮球 SHALL 跟随鼠标移动
+- **AND** 系统 SHALL 保存新位置
+
+#### Scenario: 重启后恢复位置
+
+- **WHEN** 用户已拖动并保存悬浮球位置
+- **AND** 悬浮球 helper 重启
+- **THEN** 悬浮球 SHALL 恢复到上次保存的位置
+
+#### Scenario: 保存位置超出当前屏幕
+
+- **WHEN** 上次保存的位置不在当前屏幕可见区域内
+- **THEN** 悬浮球 SHALL 移动到当前主屏幕的可见安全位置
+
+### Requirement: 状态快照不得包含敏感内容
+
+bridge SHALL 只向桌面悬浮球发布展示所需的低敏状态字段，不得写入用户消息、agent 输出、工具 payload 或凭据。
+
+#### Scenario: 写入状态快照
+
+- **WHEN** bridge 更新桌面状态快照
+- **THEN** 快照 SHALL 包含 profile 名称、bot 显示名、agent 类型、状态、更新时间和必要的计数字段
+- **AND** 快照 SHALL NOT 包含用户消息正文、prompt、assistant 输出、工具输入输出、sessionId、threadId、chatId、senderId、app secret 或 token
+
+#### Scenario: 悬浮球读取状态快照
+
+- **WHEN** 桌面悬浮球读取状态快照
+- **THEN** 悬浮球 SHALL 只根据快照中的状态字段更新 UI
+- **AND** 悬浮球 SHALL NOT 直接读取 bridge 会话历史或 agent 工具输出文件
+
+### Requirement: 悬浮球失败不影响 bridge 核心功能
+
+悬浮球启动、读取或渲染失败 SHALL NOT 阻断 bridge 后台服务、WS 连接或 agent run。
+
+#### Scenario: helper 启动失败
+
+- **WHEN** macOS 桌面悬浮球 helper 启动失败
+- **THEN** bridge SHALL 记录 warning
+- **AND** bridge SHALL 继续启动并监听消息
+
+#### Scenario: 状态快照写入失败
+
+- **WHEN** bridge 写入桌面状态快照失败
+- **THEN** bridge SHALL 记录 warning
+- **AND** 当前 agent run SHALL 继续执行
+
+#### Scenario: helper 运行中崩溃
+
+- **WHEN** 桌面悬浮球 helper 在运行中崩溃
+- **THEN** bridge SHALL 继续写入状态快照或忽略快照写入失败
+- **AND** bot 消息处理 SHALL 不受影响

--- a/openspec/changes/add-macos-floating-status-ball/tasks.md
+++ b/openspec/changes/add-macos-floating-status-ball/tasks.md
@@ -1,0 +1,53 @@
+## 1. 状态模型与配置
+
+- [x] 1.1 新增桌面状态类型定义，覆盖 `offline`、`connecting`、`idle`、`queued`、`thinking`、`tool_running`、`streaming`、`reconnecting`、`error`
+- [x] 1.2 实现 profile 状态快照 schema，字段仅包含 profile、botName、agent、状态、计数、更新时间与低敏错误类型
+- [x] 1.3 实现聚合状态优先级计算，确保多 profile 时取最高关注度状态
+- [x] 1.4 新增原子状态写入能力，支持多 profile 安全更新全局状态快照或 profile 独立状态文件
+- [x] 1.5 新增悬浮球位置偏好读写能力，并处理保存位置超出当前屏幕的兜底策略
+- [x] 1.6 扩展配置 schema，新增 `desktop.floatingBall.enabled` 或等价配置项，缺省时 macOS 默认为开启
+
+## 2. CLI 与平台 gating
+
+- [x] 2.1 在 `start` 命令新增 `--no-floating-ball` 参数，并传递到运行时启动选项
+- [x] 2.2 在 service start 路径读取配置项与 `--no-floating-ball` 决定是否启用悬浮球
+- [x] 2.3 实现 macOS-only gating，确保 Linux / Windows 不启动悬浮球
+- [x] 2.4 实现 helper 启动失败降级逻辑，仅记录 warning，不阻断 bridge 启动
+- [x] 2.5 为配置优先级添加单元测试：CLI 参数高于配置项，非 macOS 强制禁用
+
+## 3. bridge 状态发布
+
+- [x] 3.1 在进程注册后写入 `connecting` 状态，并在 WS 握手成功后更新为 `idle`
+- [x] 3.2 在 WS `reconnecting` / `reconnected` 事件中更新 profile 状态
+- [x] 3.3 在 pending queue 入队、阻塞、解除阻塞时更新 `queued` 或恢复当前状态
+- [x] 3.4 在 `RunExecutor.submit` 成功后写入 active run 状态与 run 计数
+- [x] 3.5 在 agent stream 状态变化时映射 `thinking`、`tool_running`、`streaming`
+- [x] 3.6 在 run 终止、interrupt、idle timeout 或 error 后恢复 `idle` 或写入短暂错误状态
+- [x] 3.7 在 bridge disconnect、process exit 和 profile 停止时清理或标记该 profile 为 offline
+- [x] 3.8 添加状态快照隐私测试，断言不写入 message、prompt、tool payload、chatId、threadId、sessionId、secret 或 token
+
+## 4. macOS 悬浮球 helper
+
+- [x] 4.1 新增 macOS 原生 helper 工程或可执行目标，实现无边框置顶悬浮球窗口
+- [x] 4.2 实现单实例保护，避免多个 profile 启动多个悬浮球
+- [x] 4.3 实现状态快照监听与兜底轮询，驱动悬浮球颜色、动效或状态标签更新
+- [x] 4.4 实现悬浮球拖动，并在拖动结束后持久化位置
+- [x] 4.5 实现启动时恢复悬浮球位置，位置不可见时移动到主屏幕安全区域
+- [x] 4.6 实现 hover 左右展开 profile 状态列表，展示所有可见 profile 的名称和状态
+- [x] 4.7 实现鼠标移出悬浮球与展开区域后自动收起
+- [x] 4.8 确保展开列表保持在当前屏幕可见区域内
+
+## 5. 集成与发布
+
+- [x] 5.1 在 macOS `start` 和 launchd service 启动路径中启动或唤醒 helper
+- [x] 5.2 确认 helper 的打包方式，并纳入 macOS 发布产物或安装流程
+- [x] 5.3 更新用户文档，说明默认开启、`--no-floating-ball`、配置项关闭、多 profile 聚合和隐私边界
+- [x] 5.4 更新开发文档，说明状态快照字段、状态优先级与 helper 调试方式
+
+## 6. 验证
+
+- [x] 6.1 添加单元测试覆盖状态优先级、profile 聚合、快照写入与 profile 清理
+- [x] 6.2 添加单元测试覆盖 CLI 参数、配置项和平台 gating
+- [ ] 6.3 添加 macOS helper 可验证测试或最小 UI 自动化测试，覆盖读取快照、拖动位置和 hover 展开
+- [x] 6.4 编写 `manual-verification.md`，覆盖单 profile、多 profile、hover 左右展开、拖动持久化、重连、错误、helper 启动失败和关闭配置
+- [ ] 6.5 手动验证 macOS 桌面只出现一个悬浮球，并在多 profile 场景正确展开所有 profile

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   "files": [
     "dist",
     "bin",
+    "desktop",
+    "docs",
     "README.md",
     "README.zh.md",
     "LICENSE"
@@ -35,6 +37,7 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
+    "build:helper:macos": "swift build -c release --package-path desktop/macos-floating-ball",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:unit": "vitest run tests/unit --passWithNoTests",

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -66,6 +66,7 @@ import { lookupMessageThreadId } from './thread-id';
 import { addWorkingReaction, removeReaction } from './reaction';
 import { fetchKnownChats } from './lark-info';
 import type { AppPaths } from '../config/app-paths';
+import type { DesktopStatus, DesktopStatusReporter } from '../desktop/status';
 import {
   consumeCotEvents,
   CotClient,
@@ -177,10 +178,12 @@ export interface StartChannelDeps {
   workspaces: WorkspaceStore;
   controls: Controls;
   appPaths?: Pick<AppPaths, 'secretsFile' | 'keystoreSaltFile' | 'mediaDir'>;
+  desktopStatus?: DesktopStatusReporter;
 }
 
 export async function startChannel(deps: StartChannelDeps): Promise<BridgeChannel> {
   const { cfg, agent, sessions, sessionCatalog, workspaces, controls } = deps;
+  const desktopStatus = deps.desktopStatus;
   const activeRuns = new ActiveRuns();
   // ChatModeCache stays per-bridge-instance — invalidated on restart along
   // with everything else. Topic-mode chats only need one chat.get() call ever.
@@ -317,6 +320,9 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
           lastRunModelByScope,
           scope,
           mode,
+          activeRuns,
+          pending,
+          desktopStatus,
         });
       } catch (err) {
         log.fail('flush', err);
@@ -347,6 +353,7 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
           logThreadModeOverride,
           executor,
           pool,
+          desktopStatus,
         }),
       ).catch((err) => log.fail('intake', err));
     },
@@ -390,6 +397,12 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
     },
     reconnecting: () => {
       consecutiveReconnects++;
+      void desktopStatus?.update({
+        status: 'reconnecting',
+        activeRunCount: activeRuns.snapshot().length,
+        queuedMessageCount: pending.totalSize(),
+        lastErrorKind: 'connection',
+      });
       log.warn('ws', 'reconnecting', { consecutive: consecutiveReconnects });
       reportMetric('ws_reconnect', 1, { kind: 'ws' });
       // Stdout escalation — surface jitter that's hidden in the file log.
@@ -400,6 +413,7 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
       }
     },
     reconnected: () => {
+      void updateIdleOrQueuedStatus(desktopStatus, activeRuns, pending);
       if (consecutiveReconnects > 1) {
         log.info('ws', 'recovered', { afterAttempts: consecutiveReconnects });
       } else {
@@ -410,6 +424,7 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
     // Classify common WS errors into the `network` phase so /doctor and grep
     // can find them without scanning generic `ws.fail` entries.
     error: (err) => {
+      void desktopStatus?.errorThenIdle('connection');
       const msg = err?.message ?? String(err);
       if (/ENOTFOUND|getaddrinfo/.test(msg)) {
         log.fail('network', err, { kind: 'dns', code: err.code });
@@ -442,6 +457,12 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
       ...(identity.name ? { name: identity.name } : {}),
     });
   }
+  await desktopStatus?.update({
+    status: 'idle',
+    ...(identity?.name ? { botName: identity.name } : {}),
+    activeRunCount: activeRuns.snapshot().length,
+    queuedMessageCount: pending.totalSize(),
+  });
   log.info('ws', 'connected', {
     bot: identity?.name ?? 'unknown',
     openId: identity?.openId ?? '-',
@@ -515,6 +536,69 @@ function startKnownChatsRefreshTimer(
   };
 }
 
+async function updateIdleOrQueuedStatus(
+  desktopStatus: DesktopStatusReporter | undefined,
+  activeRuns: ActiveRuns,
+  pending: PendingQueue,
+  activeRunCount = activeRuns.snapshot().length,
+): Promise<void> {
+  if (!desktopStatus) return;
+  const queuedMessageCount = pending.totalSize();
+  const status: DesktopStatus = activeRunCount > 0
+    ? 'thinking'
+    : queuedMessageCount > 0
+      ? 'queued'
+      : 'idle';
+  await desktopStatus.update({
+    status,
+    activeRunCount,
+    queuedMessageCount,
+  });
+}
+
+function createDesktopRunStateReporter(input: {
+  desktopStatus?: DesktopStatusReporter;
+  activeRuns: ActiveRuns;
+  pending: PendingQueue;
+}): (state: RunState) => Promise<void> {
+  let lastStatus: DesktopStatus | undefined;
+  return async (state: RunState): Promise<void> => {
+    const { desktopStatus, activeRuns, pending } = input;
+    if (!desktopStatus) return;
+    if (state.terminal !== 'running') {
+      lastStatus = undefined;
+      if (state.terminal === 'error') {
+        await desktopStatus.errorThenIdle('agent');
+        return;
+      }
+      if (state.terminal === 'idle_timeout') {
+        await desktopStatus.errorThenIdle('timeout');
+        return;
+      }
+      if (state.terminal === 'interrupted') {
+        await desktopStatus.errorThenIdle('interrupted');
+        return;
+      }
+      await updateIdleOrQueuedStatus(desktopStatus, activeRuns, pending, 0);
+      return;
+    }
+    const next = desktopStatusForFooter(state.footer);
+    if (next === lastStatus) return;
+    lastStatus = next;
+    await desktopStatus.update({
+      status: next,
+      activeRunCount: Math.max(1, activeRuns.snapshot().length),
+      queuedMessageCount: pending.totalSize(),
+    });
+  };
+}
+
+function desktopStatusForFooter(footer: RunState['footer']): DesktopStatus {
+  if (footer === 'tool_running') return 'tool_running';
+  if (footer === 'streaming') return 'streaming';
+  return 'thinking';
+}
+
 async function sendNonAllowedGroupHint(
   channel: LarkChannel,
   chatId: string,
@@ -544,6 +628,7 @@ interface IntakeDeps {
   logThreadModeOverride: LogThreadModeOverride;
   executor: RunExecutor;
   pool: ProcessPool;
+  desktopStatus?: DesktopStatusReporter;
 }
 
 type LogThreadModeOverride = (input: {
@@ -567,6 +652,7 @@ async function intakeMessage(deps: IntakeDeps): Promise<void> {
     logThreadModeOverride,
     executor,
     pool,
+    desktopStatus,
   } = deps;
   const preview = msg.content.length > 80 ? `${msg.content.slice(0, 80)}…` : msg.content;
   // Resolve scope (and underlying chat mode) once at intake — every
@@ -683,6 +769,11 @@ async function intakeMessage(deps: IntakeDeps): Promise<void> {
   }
 
   const size = pending.push(scope, emsg);
+  await desktopStatus?.update({
+    status: 'queued',
+    activeRunCount: activeRuns.snapshot().length,
+    queuedMessageCount: pending.totalSize(),
+  });
   log.info('intake', 'queued', { scope, queueSize: size, debounceMs: DEBOUNCE_MS });
 }
 
@@ -701,6 +792,9 @@ interface RunBatchDeps {
   lastRunModelByScope: Map<string, string>;
   scope: string;
   mode: ChatMode;
+  activeRuns: ActiveRuns;
+  pending: PendingQueue;
+  desktopStatus?: DesktopStatusReporter;
 }
 
 async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
@@ -719,6 +813,9 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     lastRunModelByScope,
     scope,
     mode,
+    activeRuns,
+    pending,
+    desktopStatus,
   } = deps;
   if (batch.length === 0) return;
   const firstMsg = batch[0];
@@ -891,6 +988,11 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
   }
 
   const { execution, cwdRealpath: cwd } = flow;
+  await desktopStatus?.update({
+    status: 'thinking',
+    activeRunCount: Math.max(1, activeRuns.snapshot().length),
+    queuedMessageCount: pending.totalSize(),
+  });
   activePolicyFingerprints.set(scope, flow.policy.policyFingerprint);
   const handle = execution.handle;
   const eventStream = execution.subscribe();
@@ -925,6 +1027,11 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
       log.info('session', 'set-thread', { threadId: evt.threadId });
     }
   };
+  const reportRunState = createDesktopRunStateReporter({
+    desktopStatus,
+    activeRuns,
+    pending,
+  });
 
   // Resolve idle-timeout for this run: scope override (on SessionEntry) wins
   // over global default (preferences). 0 / undefined = no watchdog.
@@ -997,7 +1104,9 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
           scope,
           idleTimeoutMs,
           recordSession,
-          async () => {},
+          async (state) => {
+            await reportRunState(state);
+          },
         );
         await cotDone;
         if (cotPublisher.degradedReason) {
@@ -1036,6 +1145,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         idleTimeoutMs,
         recordSession,
         async (state) => {
+          await reportRunState(state);
           latestState = state;
           if (cardCtrl) {
             await cardCtrl.update(renderCard(filterForPrefs(state), cardRenderOptions));
@@ -1081,6 +1191,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         idleTimeoutMs,
         recordSession,
         async (state) => {
+          await reportRunState(state);
           latestState = state;
           if (markdownCtrl) {
             await markdownCtrl.setContent(renderText(filterForPrefs(state)));
@@ -1121,7 +1232,9 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         scope,
         idleTimeoutMs,
         recordSession,
-        async () => {},
+        async (state) => {
+          await reportRunState(state);
+        },
       );
       await sendFinalReply({
         channel,

--- a/src/bot/pending-queue.ts
+++ b/src/bot/pending-queue.ts
@@ -62,6 +62,12 @@ export class PendingQueue {
     this.blocked.clear();
   }
 
+  totalSize(): number {
+    let count = 0;
+    for (const entry of this.map.values()) count += entry.messages.length;
+    return count;
+  }
+
   /** Pause the debounce timer; pushed messages keep accumulating. */
   block(scope: string): void {
     if (this.blocked.has(scope)) return;

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -27,6 +27,7 @@ export interface ServiceStartOptions {
   tenant?: string;
   /** Skip lark-cli auto-install + bind during `start`. */
   skipCheckLarkCli?: boolean;
+  noFloatingBall?: boolean;
   confirmStopRuntimeLockProcess?: (meta: RuntimeLockMeta) => boolean | Promise<boolean>;
   stopRuntimeLockProcess?: (meta: RuntimeLockMeta) => StopProcessEntryResult | Promise<StopProcessEntryResult>;
 }
@@ -293,7 +294,7 @@ export async function runServiceStart(opts: ServiceStartOptions = {}): Promise<v
     },
   });
 
-  await adapter.install();
+  await adapter.install({ noFloatingBall: opts.noFloatingBall });
 
   // If already running, stop first so start operations don't race.
   if (adapter.isRunning()) {

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -45,6 +45,9 @@ import { refreshOwnerControls } from '../../policy/owner';
 import { SessionStore } from '../../session/store';
 import { SessionCatalog } from '../../session/catalog';
 import { WorkspaceStore } from '../../workspace/store';
+import { shouldEnableFloatingBall } from '../../desktop/config';
+import { startFloatingBallHelper } from '../../desktop/helper';
+import { DesktopStatusReporter } from '../../desktop/status';
 
 // Prefer IPv4 — Node 20+ defaults to "verbatim" which respects whatever
 // the resolver returns first; in IPv6-broken networks (WSL2, certain VPNs,
@@ -77,6 +80,7 @@ export interface StartOptions {
   appSecret?: string;
   tenant?: string;
   skipCheckLarkCli?: boolean;
+  noFloatingBall?: boolean;
   confirmStopRuntimeLockProcess?: (err: RuntimeLockConflictError) => boolean | Promise<boolean>;
   stopRuntimeLockProcess?: (meta: RuntimeLockMeta) => StopProcessEntryResult | Promise<StopProcessEntryResult>;
 }
@@ -98,6 +102,13 @@ export async function runStart(opts: StartOptions): Promise<void> {
   const appPaths = runtime.appPaths;
   let profileConfig = runtime.profileConfig;
   configureLogger({ logsDir: appPaths.logsDir });
+  const desktopStatus = new DesktopStatusReporter({
+    rootDir: appPaths.rootDir,
+    profile: appPaths.profile,
+    agent: profileConfig.agentKind,
+    appId: cfg.accounts.app.id,
+    onWarning: (message, fields) => log.warn('desktop-status', message, fields),
+  });
 
   await preFlightChecks({
     skipCheckLarkCli: opts.skipCheckLarkCli,
@@ -119,6 +130,12 @@ export async function runStart(opts: StartOptions): Promise<void> {
     tenant: cfg.accounts.app.tenant,
     hostname: os.hostname(),
   });
+  if (shouldEnableFloatingBall({ cfg, noFloatingBall: opts.noFloatingBall })) {
+    await startFloatingBallHelper({
+      rootDir: appPaths.rootDir,
+      onWarning: (message, fields) => log.warn('desktop-status', message, fields),
+    });
+  }
 
   let agent = createRuntimeAgent(profileConfig, { ...appPaths, configPath });
   const availability = await checkRuntimeAgentAvailability(agent);
@@ -176,6 +193,7 @@ export async function runStart(opts: StartOptions): Promise<void> {
           registryFile: appPaths.userRegistryFile,
         });
         log.info('registry', 'registered', { id: entry.id, pid: process.pid });
+        await desktopStatus.update({ status: 'connecting' });
 
         // `bridge` is mutable so /account can swap it on restart. `controls` carries
         // restart() and a snapshot of the current cfg so command handlers can read
@@ -193,6 +211,7 @@ export async function runStart(opts: StartOptions): Promise<void> {
           } catch (err) {
             console.error('[disconnect-failed]', err);
           }
+          await desktopStatus.clear();
           // unregister is best-effort sync — we're about to exit anyway.
           unregisterSync(entry.id, appPaths.userRegistryFile);
           await releaseRuntimeLocks(runtimeLocks);
@@ -274,6 +293,7 @@ export async function runStart(opts: StartOptions): Promise<void> {
                   workspaces,
                   controls: nextControls,
                   appPaths: nextRuntime.appPaths,
+                  desktopStatus,
                 });
                 console.log('[restart] disconnecting old bridge...');
                 try {
@@ -330,6 +350,7 @@ export async function runStart(opts: StartOptions): Promise<void> {
           workspaces,
           controls,
           appPaths,
+          desktopStatus,
         });
 
         // Backfill the bot's display name into the registry once WS handshake is
@@ -337,6 +358,7 @@ export async function runStart(opts: StartOptions): Promise<void> {
         // ("bot 尼莫 (cli_xxx)") instead of just a short id.
         const botName = bridge.channel.botIdentity?.name;
         if (botName) {
+          await desktopStatus.update({ botName, status: 'idle' });
           await updateEntry(entry.id, { botName }, appPaths.userRegistryFile).catch((err) =>
             log.warn('registry', 'update-failed', { step: 'botName', err: String(err) }),
           );

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -45,6 +45,7 @@ program
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')
   .option('--tenant <tenant>', 'tenant for --app-id (feishu or lark; default feishu)')
   .option('--skip-check-lark-cli', 'skip lark-cli pre-flight check (auto-install + bind)')
+  .option('--no-floating-ball', 'do not start the macOS desktop floating status ball')
   .action(async (opts: {
     config?: string;
     profile?: string;
@@ -54,8 +55,9 @@ program
     appSecret?: string;
     tenant?: string;
     skipCheckLarkCli?: boolean;
+    floatingBall?: boolean;
   }) => {
-    await runStart(opts);
+    await runStart({ ...opts, noFloatingBall: opts.floatingBall === false });
   });
 
 program
@@ -160,6 +162,7 @@ program
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')
   .option('--tenant <tenant>', 'tenant for --app-id (feishu or lark; default feishu)')
   .option('--skip-check-lark-cli', 'skip lark-cli pre-flight check (auto-install + bind)')
+  .option('--no-floating-ball', 'do not start the macOS desktop floating status ball')
   .action(async (opts: {
     profile?: string;
     agent?: string;
@@ -168,8 +171,9 @@ program
     appSecret?: string;
     tenant?: string;
     skipCheckLarkCli?: boolean;
+    floatingBall?: boolean;
   }) => {
-    await runServiceStart(opts);
+    await runServiceStart({ ...opts, noFloatingBall: opts.floatingBall === false });
   });
 
 program

--- a/src/config/profile-schema.ts
+++ b/src/config/profile-schema.ts
@@ -1,6 +1,7 @@
 import type {
   AppCredentials,
   AppPreferences,
+  DesktopConfig,
   MessageReplyMode,
   SecretsConfig,
 } from './schema';
@@ -82,6 +83,7 @@ export interface ProfileConfig {
   };
   secrets?: SecretsConfig;
   preferences: Omit<AppPreferences, 'access' | 'requireMentionInGroup'>;
+  desktop?: DesktopConfig;
   access: ProfileAccess;
   workspaces: {
     default?: string;
@@ -138,6 +140,7 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
     accounts?: unknown;
     secrets?: SecretsConfig;
     preferences?: (AppPreferences & { access?: Partial<ProfileAccess> }) | undefined;
+    desktop?: unknown;
     access?: Partial<ProfileAccess>;
     workspaces?: {
       default?: unknown;
@@ -167,6 +170,7 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
   }
 
   const preferences = normalizePreferences(raw.preferences);
+  const desktop = normalizeDesktop(raw.desktop);
   const access = normalizeAccess(
     raw.access ?? raw.preferences?.access,
     raw.preferences?.requireMentionInGroup,
@@ -186,6 +190,7 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
     accounts,
     ...(raw.secrets ? { secrets: raw.secrets } : {}),
     preferences,
+    ...(desktop ? { desktop } : {}),
     access,
     workspaces,
     sandbox,
@@ -239,6 +244,17 @@ function normalizePreferences(
     };
   }
   return rest;
+}
+
+function normalizeDesktop(input: unknown): DesktopConfig | undefined {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return undefined;
+  const raw = input as { floatingBall?: unknown };
+  if (!raw.floatingBall || typeof raw.floatingBall !== 'object' || Array.isArray(raw.floatingBall)) {
+    return undefined;
+  }
+  const floatingBall = raw.floatingBall as { enabled?: unknown };
+  if (typeof floatingBall.enabled !== 'boolean') return undefined;
+  return { floatingBall: { enabled: floatingBall.enabled } };
 }
 
 function isMessageReply(value: unknown): value is MessageReplyMode {

--- a/src/config/profile-store.ts
+++ b/src/config/profile-store.ts
@@ -52,6 +52,7 @@ type StoredProfileConfig = Pick<
   | 'accounts'
   | 'secrets'
   | 'preferences'
+  | 'desktop'
   | 'access'
   | 'workspaces'
   | 'permissions'
@@ -89,6 +90,7 @@ function serializeProfileConfig(profile: ProfileConfig): StoredProfileConfig {
     accounts: profile.accounts,
     ...(profile.secrets ? { secrets: profile.secrets } : {}),
     preferences: profile.preferences,
+    ...(profile.desktop ? { desktop: profile.desktop } : {}),
     access: profile.access,
     workspaces: profile.workspaces,
     permissions: profile.permissions,

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -154,6 +154,12 @@ export interface AppPreferences {
   agentStopGraceMs?: number;
 }
 
+export interface DesktopConfig {
+  floatingBall?: {
+    enabled?: boolean;
+  };
+}
+
 /**
  * Top-level config shape on disk.
  *
@@ -168,6 +174,7 @@ export interface AppConfig {
   };
   secrets?: SecretsConfig;
   preferences?: AppPreferences;
+  desktop?: DesktopConfig;
 }
 
 export function isComplete(cfg: Partial<AppConfig>): cfg is AppConfig {

--- a/src/daemon/launchd.ts
+++ b/src/daemon/launchd.ts
@@ -25,6 +25,8 @@ export interface PlistInputs {
   profile: string;
   /** Root directory for config/profile state. */
   channelHome: string;
+  /** Disable the macOS desktop floating status ball for this daemon run. */
+  noFloatingBall?: boolean;
 }
 
 export function buildPlist(inputs: PlistInputs): string {
@@ -47,6 +49,7 @@ export function buildPlist(inputs: PlistInputs): string {
         <string>run</string>
         <string>--profile</string>
         <string>${escape(inputs.profile)}</string>
+        ${inputs.noFloatingBall ? '<string>--no-floating-ball</string>' : ''}
     </array>
     <key>RunAtLoad</key>
     <true/>
@@ -68,7 +71,10 @@ export function buildPlist(inputs: PlistInputs): string {
 `;
 }
 
-export async function writePlist(profile: string): Promise<void> {
+export async function writePlist(
+  profile: string,
+  opts: { noFloatingBall?: boolean } = {},
+): Promise<void> {
   const bridgeEntryPath = process.argv[1];
   if (!bridgeEntryPath) {
     throw new Error('cannot determine bridge entry path (process.argv[1] is empty)');
@@ -79,6 +85,7 @@ export async function writePlist(profile: string): Promise<void> {
     envPath: process.env.PATH ?? '',
     profile,
     channelHome: paths.rootDir,
+    noFloatingBall: opts.noFloatingBall,
   });
   const plistPath = launchAgentPlistPath(profile);
   await mkdir(dirname(plistPath), { recursive: true });

--- a/src/daemon/service-adapter.ts
+++ b/src/daemon/service-adapter.ts
@@ -31,7 +31,7 @@ export interface ServiceAdapter {
   servicePath(): string;
 
   /** Write or overwrite the service definition. */
-  install(): Promise<void>;
+  install(opts?: { noFloatingBall?: boolean }): Promise<void>;
 
   /** Start the service (enables autostart where applicable). */
   start(): ServiceResultLike;
@@ -67,7 +67,7 @@ function makeLaunchdAdapter(profile: string): ServiceAdapter {
     fileExists: () => launchd.plistExists(profile),
     isRunning: () => launchd.isLoaded(profile),
     servicePath: () => launchAgentPlistPath(profile),
-    install: () => launchd.writePlist(profile),
+    install: (opts) => launchd.writePlist(profile, opts),
     start: () => launchd.bootstrap(profile),
     stop: () => launchd.bootout(profile),
     // launchd has no separate "disable" — bootout already removes the

--- a/src/desktop/config.ts
+++ b/src/desktop/config.ts
@@ -1,0 +1,20 @@
+import type { AppConfig } from '../config/schema';
+
+export interface DesktopConfig {
+  floatingBall?: {
+    enabled?: boolean;
+  };
+}
+
+export interface FloatingBallEnableInput {
+  platform?: NodeJS.Platform;
+  cfg?: Partial<AppConfig> & { desktop?: DesktopConfig };
+  noFloatingBall?: boolean;
+}
+
+export function shouldEnableFloatingBall(input: FloatingBallEnableInput = {}): boolean {
+  const platform = input.platform ?? process.platform;
+  if (platform !== 'darwin') return false;
+  if (input.noFloatingBall === true) return false;
+  return input.cfg?.desktop?.floatingBall?.enabled !== false;
+}

--- a/src/desktop/helper.ts
+++ b/src/desktop/helper.ts
@@ -13,12 +13,21 @@ export interface StartFloatingBallHelperInput {
 
 export function resolveFloatingBallHelperCandidates(env: NodeJS.ProcessEnv = process.env): string[] {
   const here = dirname(fileURLToPath(import.meta.url));
-  const packageRoot = resolve(here, '..', '..');
-  return [
+  const packageRoots = uniqueStrings([
+    // Built package: dist/cli.js -> package root.
+    resolve(here, '..'),
+    // Source/test execution: src/desktop/helper.ts -> package root.
+    resolve(here, '..', '..'),
+  ]);
+  const swiftBuildTriple = process.arch === 'arm64' ? 'arm64-apple-macosx' : 'x86_64-apple-macosx';
+  return uniqueStrings([
     env.LARK_CHANNEL_FLOATING_BALL_HELPER,
-    join(packageRoot, 'desktop', 'macos-floating-ball', 'LarkChannelFloatingBall'),
-    join(packageRoot, 'desktop', 'macos-floating-ball', '.build', 'release', 'LarkChannelFloatingBall'),
-  ].filter((value): value is string => Boolean(value));
+    ...packageRoots.flatMap((packageRoot) => [
+      join(packageRoot, 'desktop', 'macos-floating-ball', 'LarkChannelFloatingBall'),
+      join(packageRoot, 'desktop', 'macos-floating-ball', '.build', swiftBuildTriple, 'release', 'LarkChannelFloatingBall'),
+      join(packageRoot, 'desktop', 'macos-floating-ball', '.build', 'release', 'LarkChannelFloatingBall'),
+    ]),
+  ].filter((value): value is string => Boolean(value)));
 }
 
 export function resolveFloatingBallHelperPath(
@@ -58,4 +67,8 @@ export async function startFloatingBallHelper(
     });
     return false;
   }
+}
+
+function uniqueStrings(values: Array<string | undefined>): string[] {
+  return [...new Set(values.filter((value): value is string => Boolean(value)))];
 }

--- a/src/desktop/helper.ts
+++ b/src/desktop/helper.ts
@@ -1,0 +1,61 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface StartFloatingBallHelperInput {
+  rootDir: string;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  spawnHelper?: typeof spawn;
+  onWarning?: (message: string, fields?: Record<string, unknown>) => void;
+}
+
+export function resolveFloatingBallHelperCandidates(env: NodeJS.ProcessEnv = process.env): string[] {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const packageRoot = resolve(here, '..', '..');
+  return [
+    env.LARK_CHANNEL_FLOATING_BALL_HELPER,
+    join(packageRoot, 'desktop', 'macos-floating-ball', 'LarkChannelFloatingBall'),
+    join(packageRoot, 'desktop', 'macos-floating-ball', '.build', 'release', 'LarkChannelFloatingBall'),
+  ].filter((value): value is string => Boolean(value));
+}
+
+export function resolveFloatingBallHelperPath(
+  env: NodeJS.ProcessEnv = process.env,
+  exists: (path: string) => boolean = existsSync,
+): string | undefined {
+  return resolveFloatingBallHelperCandidates(env).find((candidate) => exists(candidate));
+}
+
+export async function startFloatingBallHelper(
+  input: StartFloatingBallHelperInput,
+): Promise<boolean> {
+  const platform = input.platform ?? process.platform;
+  if (platform !== 'darwin') return false;
+  const helperPath = resolveFloatingBallHelperPath(input.env);
+  if (!helperPath) {
+    input.onWarning?.('desktop floating ball helper not found', {
+      hint: 'Build desktop/macos-floating-ball or set LARK_CHANNEL_FLOATING_BALL_HELPER.',
+    });
+    return false;
+  }
+  try {
+    const child = (input.spawnHelper ?? spawn)(helperPath, ['--root', input.rootDir], {
+      detached: true,
+      stdio: 'ignore',
+      env: {
+        ...process.env,
+        ...input.env,
+        LARK_CHANNEL_HOME: input.rootDir,
+      },
+    });
+    child.unref();
+    return true;
+  } catch (err) {
+    input.onWarning?.('desktop floating ball helper failed to start', {
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return false;
+  }
+}

--- a/src/desktop/status.ts
+++ b/src/desktop/status.ts
@@ -1,0 +1,425 @@
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import * as lockfile from 'proper-lockfile';
+import { writeFileAtomic } from '../platform/atomic-write';
+
+export type DesktopStatus =
+  | 'offline'
+  | 'connecting'
+  | 'idle'
+  | 'queued'
+  | 'thinking'
+  | 'tool_running'
+  | 'streaming'
+  | 'reconnecting'
+  | 'error';
+
+export type DesktopStatusErrorKind =
+  | 'connection'
+  | 'agent'
+  | 'timeout'
+  | 'interrupted'
+  | 'unknown';
+
+export interface DesktopProfileStatusSnapshot {
+  profile: string;
+  botName?: string;
+  appIdSuffix?: string;
+  agent: string;
+  status: DesktopStatus;
+  activeRunCount: number;
+  queuedMessageCount: number;
+  updatedAt: string;
+  lastErrorKind?: DesktopStatusErrorKind;
+}
+
+export interface DesktopStatusSnapshot {
+  updatedAt: string;
+  aggregateStatus: DesktopStatus;
+  profiles: DesktopProfileStatusSnapshot[];
+}
+
+export interface DesktopStatusPaths {
+  statusFile: string;
+  lockFile: string;
+  positionFile: string;
+}
+
+export interface DesktopStatusReporterInput {
+  rootDir: string;
+  profile: string;
+  agent: string;
+  appId: string;
+  botName?: string;
+  now?: () => Date;
+  onWarning?: (message: string, fields?: Record<string, unknown>) => void;
+}
+
+export interface UpdateProfileStatusInput {
+  status?: DesktopStatus;
+  botName?: string;
+  activeRunCount?: number;
+  queuedMessageCount?: number;
+  lastErrorKind?: DesktopStatusErrorKind;
+}
+
+export interface FloatingBallPosition {
+  x: number;
+  y: number;
+}
+
+export interface VisibleFrame {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export const DESKTOP_STATUS_PRIORITY: Record<DesktopStatus, number> = {
+  offline: 0,
+  connecting: 1,
+  idle: 2,
+  queued: 3,
+  thinking: 4,
+  streaming: 5,
+  tool_running: 6,
+  reconnecting: 7,
+  error: 8,
+};
+
+const DEFAULT_BALL_SIZE = 44;
+const DEFAULT_SAFE_INSET = 12;
+
+export function desktopStatusPaths(rootDir: string): DesktopStatusPaths {
+  return {
+    statusFile: join(rootDir, 'desktop-status.json'),
+    lockFile: join(rootDir, 'registry', 'desktop-status.lock'),
+    positionFile: join(rootDir, 'desktop-floating-ball.json'),
+  };
+}
+
+export function aggregateDesktopStatus(
+  profiles: readonly Pick<DesktopProfileStatusSnapshot, 'status'>[],
+): DesktopStatus {
+  let selected: DesktopStatus = 'offline';
+  for (const profile of profiles) {
+    if (DESKTOP_STATUS_PRIORITY[profile.status] > DESKTOP_STATUS_PRIORITY[selected]) {
+      selected = profile.status;
+    }
+  }
+  return selected;
+}
+
+export function sanitizeProfileStatus(input: {
+  profile: string;
+  botName?: string;
+  appId?: string;
+  appIdSuffix?: string;
+  agent: string;
+  status: DesktopStatus;
+  activeRunCount?: number;
+  queuedMessageCount?: number;
+  updatedAt?: string;
+  lastErrorKind?: DesktopStatusErrorKind;
+}): DesktopProfileStatusSnapshot {
+  return {
+    profile: input.profile,
+    ...(input.botName ? { botName: input.botName } : {}),
+    ...(input.appIdSuffix ?? input.appId
+      ? { appIdSuffix: (input.appIdSuffix ?? input.appId ?? '').slice(-6) }
+      : {}),
+    agent: input.agent,
+    status: input.status,
+    activeRunCount: nonNegativeInteger(input.activeRunCount),
+    queuedMessageCount: nonNegativeInteger(input.queuedMessageCount),
+    updatedAt: input.updatedAt ?? new Date().toISOString(),
+    ...(input.lastErrorKind ? { lastErrorKind: input.lastErrorKind } : {}),
+  };
+}
+
+export async function readDesktopStatusSnapshot(
+  rootDir: string,
+): Promise<DesktopStatusSnapshot | undefined> {
+  try {
+    const parsed = JSON.parse(await readFile(desktopStatusPaths(rootDir).statusFile, 'utf8')) as unknown;
+    return normalizeSnapshot(parsed);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    return undefined;
+  }
+}
+
+export async function writeDesktopStatusSnapshot(
+  rootDir: string,
+  snapshot: DesktopStatusSnapshot,
+): Promise<void> {
+  await writeFileAtomic(desktopStatusPaths(rootDir).statusFile, `${JSON.stringify(snapshot, null, 2)}\n`, {
+    mode: 0o600,
+  });
+}
+
+export async function updateDesktopProfileStatus(
+  rootDir: string,
+  profileStatus: DesktopProfileStatusSnapshot,
+): Promise<DesktopStatusSnapshot> {
+  return withDesktopStatusLock(rootDir, async () => {
+    const current = await readDesktopStatusSnapshot(rootDir);
+    const profiles = [
+      ...(current?.profiles ?? []).filter((item) => item.profile !== profileStatus.profile),
+      profileStatus,
+    ].sort((a, b) => a.profile.localeCompare(b.profile));
+    const snapshot: DesktopStatusSnapshot = {
+      updatedAt: profileStatus.updatedAt,
+      aggregateStatus: aggregateDesktopStatus(profiles),
+      profiles,
+    };
+    await writeDesktopStatusSnapshot(rootDir, snapshot);
+    return snapshot;
+  });
+}
+
+export async function removeDesktopProfileStatus(
+  rootDir: string,
+  profile: string,
+  now: Date = new Date(),
+): Promise<DesktopStatusSnapshot> {
+  return withDesktopStatusLock(rootDir, async () => {
+    const current = await readDesktopStatusSnapshot(rootDir);
+    const profiles = (current?.profiles ?? []).filter((item) => item.profile !== profile);
+    const snapshot: DesktopStatusSnapshot = {
+      updatedAt: now.toISOString(),
+      aggregateStatus: aggregateDesktopStatus(profiles),
+      profiles,
+    };
+    await writeDesktopStatusSnapshot(rootDir, snapshot);
+    return snapshot;
+  });
+}
+
+export class DesktopStatusReporter {
+  private readonly rootDir: string;
+  private readonly profile: string;
+  private readonly agent: string;
+  private readonly appId: string;
+  private readonly now: () => Date;
+  private readonly onWarning?: (message: string, fields?: Record<string, unknown>) => void;
+  private snapshot: DesktopProfileStatusSnapshot;
+  private errorRecoveryTimer: NodeJS.Timeout | undefined;
+
+  constructor(input: DesktopStatusReporterInput) {
+    this.rootDir = input.rootDir;
+    this.profile = input.profile;
+    this.agent = input.agent;
+    this.appId = input.appId;
+    this.now = input.now ?? (() => new Date());
+    this.onWarning = input.onWarning;
+    this.snapshot = sanitizeProfileStatus({
+      profile: input.profile,
+      botName: input.botName,
+      appId: input.appId,
+      agent: input.agent,
+      status: 'offline',
+      updatedAt: this.now().toISOString(),
+    });
+  }
+
+  current(): DesktopProfileStatusSnapshot {
+    return { ...this.snapshot };
+  }
+
+  async update(input: UpdateProfileStatusInput): Promise<void> {
+    if (input.status !== 'error' && this.errorRecoveryTimer) {
+      clearTimeout(this.errorRecoveryTimer);
+      this.errorRecoveryTimer = undefined;
+    }
+    this.snapshot = sanitizeProfileStatus({
+      ...this.snapshot,
+      ...input,
+      profile: this.profile,
+      appId: this.appId,
+      agent: this.agent,
+      status: input.status ?? this.snapshot.status,
+      updatedAt: this.now().toISOString(),
+      lastErrorKind: input.status === 'error'
+        ? input.lastErrorKind ?? this.snapshot.lastErrorKind ?? 'unknown'
+        : input.lastErrorKind,
+    });
+    await this.safeWrite();
+  }
+
+  async errorThenIdle(kind: DesktopStatusErrorKind, delayMs = 5000): Promise<void> {
+    await this.update({ status: 'error', lastErrorKind: kind, activeRunCount: 0 });
+    if (this.errorRecoveryTimer) clearTimeout(this.errorRecoveryTimer);
+    this.errorRecoveryTimer = setTimeout(() => {
+      this.errorRecoveryTimer = undefined;
+      void this.update({ status: 'idle', lastErrorKind: undefined }).catch((err) =>
+        this.warn('desktop status recovery write failed', { err: String(err) }),
+      );
+    }, delayMs);
+  }
+
+  async clear(): Promise<void> {
+    if (this.errorRecoveryTimer) clearTimeout(this.errorRecoveryTimer);
+    this.errorRecoveryTimer = undefined;
+    await removeDesktopProfileStatus(this.rootDir, this.profile, this.now()).catch((err) =>
+      this.warn('desktop status clear failed', { err: String(err) }),
+    );
+  }
+
+  private async safeWrite(): Promise<void> {
+    await updateDesktopProfileStatus(this.rootDir, this.snapshot).catch((err) =>
+      this.warn('desktop status write failed', { err: String(err) }),
+    );
+  }
+
+  private warn(message: string, fields?: Record<string, unknown>): void {
+    this.onWarning?.(message, fields);
+  }
+}
+
+export async function readFloatingBallPosition(
+  rootDir: string,
+): Promise<FloatingBallPosition | undefined> {
+  try {
+    const parsed = JSON.parse(await readFile(desktopStatusPaths(rootDir).positionFile, 'utf8')) as unknown;
+    return isPosition(parsed) ? parsed : undefined;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    return undefined;
+  }
+}
+
+export async function writeFloatingBallPosition(
+  rootDir: string,
+  position: FloatingBallPosition,
+): Promise<void> {
+  const safe = clampFloatingBallPosition(position, {
+    x: Number.MIN_SAFE_INTEGER / 4,
+    y: Number.MIN_SAFE_INTEGER / 4,
+    width: Number.MAX_SAFE_INTEGER / 2,
+    height: Number.MAX_SAFE_INTEGER / 2,
+  });
+  await writeFileAtomic(desktopStatusPaths(rootDir).positionFile, `${JSON.stringify(safe, null, 2)}\n`, {
+    mode: 0o600,
+  });
+}
+
+export function clampFloatingBallPosition(
+  position: FloatingBallPosition | undefined,
+  frame: VisibleFrame,
+  ballSize = DEFAULT_BALL_SIZE,
+  inset = DEFAULT_SAFE_INSET,
+): FloatingBallPosition {
+  const minX = frame.x + inset;
+  const minY = frame.y + inset;
+  const maxX = frame.x + Math.max(inset, frame.width - ballSize - inset);
+  const maxY = frame.y + Math.max(inset, frame.height - ballSize - inset);
+  const fallback = {
+    x: maxX,
+    y: minY,
+  };
+  if (!position || !Number.isFinite(position.x) || !Number.isFinite(position.y)) {
+    return fallback;
+  }
+  return {
+    x: Math.min(Math.max(position.x, minX), maxX),
+    y: Math.min(Math.max(position.y, minY), maxY),
+  };
+}
+
+async function withDesktopStatusLock<T>(rootDir: string, fn: () => Promise<T>): Promise<T> {
+  const { lockFile } = desktopStatusPaths(rootDir);
+  await mkdir(dirname(lockFile), { recursive: true });
+  await writeFile(lockFile, '', { flag: 'a', mode: 0o600 });
+  await chmod(lockFile, 0o600).catch(() => {});
+  const release = await lockfile.lock(lockFile, {
+    realpath: false,
+    stale: 30_000,
+    update: 10_000,
+    retries: {
+      retries: 10,
+      minTimeout: 10,
+      maxTimeout: 100,
+    },
+  });
+  try {
+    return await fn();
+  } finally {
+    await release();
+  }
+}
+
+function normalizeSnapshot(value: unknown): DesktopStatusSnapshot | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const raw = value as Partial<DesktopStatusSnapshot>;
+  if (!Array.isArray(raw.profiles)) return undefined;
+  const profiles = raw.profiles
+    .map((item) => normalizeProfileSnapshot(item))
+    .filter((item): item is DesktopProfileStatusSnapshot => Boolean(item));
+  const updatedAt = typeof raw.updatedAt === 'string' ? raw.updatedAt : new Date().toISOString();
+  return {
+    updatedAt,
+    aggregateStatus: aggregateDesktopStatus(profiles),
+    profiles,
+  };
+}
+
+function normalizeProfileSnapshot(value: unknown): DesktopProfileStatusSnapshot | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const raw = value as Partial<DesktopProfileStatusSnapshot>;
+  if (
+    typeof raw.profile !== 'string' ||
+    typeof raw.agent !== 'string' ||
+    !isDesktopStatus(raw.status) ||
+    typeof raw.updatedAt !== 'string'
+  ) {
+    return undefined;
+  }
+  return sanitizeProfileStatus({
+    profile: raw.profile,
+    botName: typeof raw.botName === 'string' ? raw.botName : undefined,
+    appIdSuffix: typeof raw.appIdSuffix === 'string' ? raw.appIdSuffix : undefined,
+    agent: raw.agent,
+    status: raw.status,
+    activeRunCount: raw.activeRunCount,
+    queuedMessageCount: raw.queuedMessageCount,
+    updatedAt: raw.updatedAt,
+    lastErrorKind: isErrorKind(raw.lastErrorKind) ? raw.lastErrorKind : undefined,
+  });
+}
+
+function isDesktopStatus(value: unknown): value is DesktopStatus {
+  return (
+    value === 'offline' ||
+    value === 'connecting' ||
+    value === 'idle' ||
+    value === 'queued' ||
+    value === 'thinking' ||
+    value === 'tool_running' ||
+    value === 'streaming' ||
+    value === 'reconnecting' ||
+    value === 'error'
+  );
+}
+
+function isErrorKind(value: unknown): value is DesktopStatusErrorKind {
+  return (
+    value === 'connection' ||
+    value === 'agent' ||
+    value === 'timeout' ||
+    value === 'interrupted' ||
+    value === 'unknown'
+  );
+}
+
+function isPosition(value: unknown): value is FloatingBallPosition {
+  if (!value || typeof value !== 'object') return false;
+  const raw = value as Partial<FloatingBallPosition>;
+  return typeof raw.x === 'number' && Number.isFinite(raw.x) &&
+    typeof raw.y === 'number' && Number.isFinite(raw.y);
+}
+
+function nonNegativeInteger(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return 0;
+  return Math.floor(value);
+}

--- a/tests/unit/desktop/config.test.ts
+++ b/tests/unit/desktop/config.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { shouldEnableFloatingBall } from '../../../src/desktop/config';
+
+describe('floating ball gating', () => {
+  it('defaults on for macOS when unset', () => {
+    expect(shouldEnableFloatingBall({ platform: 'darwin', cfg: {} })).toBe(true);
+  });
+
+  it('lets CLI disable override config', () => {
+    expect(shouldEnableFloatingBall({
+      platform: 'darwin',
+      noFloatingBall: true,
+      cfg: { desktop: { floatingBall: { enabled: true } } },
+    })).toBe(false);
+  });
+
+  it('lets config disable macOS helper', () => {
+    expect(shouldEnableFloatingBall({
+      platform: 'darwin',
+      cfg: { desktop: { floatingBall: { enabled: false } } },
+    })).toBe(false);
+  });
+
+  it('forces non-macOS off', () => {
+    expect(shouldEnableFloatingBall({
+      platform: 'linux',
+      cfg: { desktop: { floatingBall: { enabled: true } } },
+    })).toBe(false);
+    expect(shouldEnableFloatingBall({
+      platform: 'win32',
+      cfg: { desktop: { floatingBall: { enabled: true } } },
+    })).toBe(false);
+  });
+});

--- a/tests/unit/desktop/helper.test.ts
+++ b/tests/unit/desktop/helper.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { resolveFloatingBallHelperCandidates } from '../../../src/desktop/helper';
+
+describe('floating ball helper resolution', () => {
+  it('includes env override, packaged helper, and SwiftPM release paths', () => {
+    const candidates = resolveFloatingBallHelperCandidates({
+      LARK_CHANNEL_FLOATING_BALL_HELPER: '/tmp/custom-helper',
+    });
+
+    expect(candidates[0]).toBe('/tmp/custom-helper');
+    expect(candidates.some((path) => path.endsWith('desktop/macos-floating-ball/LarkChannelFloatingBall'))).toBe(true);
+    expect(candidates.some((path) =>
+      /desktop\/macos-floating-ball\/\.build\/(arm64|x86_64)-apple-macosx\/release\/LarkChannelFloatingBall$/.test(path),
+    )).toBe(true);
+  });
+});

--- a/tests/unit/desktop/status.test.ts
+++ b/tests/unit/desktop/status.test.ts
@@ -1,0 +1,103 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  DesktopStatusReporter,
+  aggregateDesktopStatus,
+  clampFloatingBallPosition,
+  readDesktopStatusSnapshot,
+} from '../../../src/desktop/status';
+
+const tmpRoots: string[] = [];
+
+async function tmpRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'desktop-status-'));
+  tmpRoots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(tmpRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('desktop status snapshot', () => {
+  it('aggregates to the highest-priority profile status', () => {
+    expect(aggregateDesktopStatus([
+      { status: 'idle' },
+      { status: 'streaming' },
+      { status: 'reconnecting' },
+      { status: 'tool_running' },
+    ])).toBe('reconnecting');
+    expect(aggregateDesktopStatus([{ status: 'idle' }, { status: 'error' }])).toBe('error');
+    expect(aggregateDesktopStatus([])).toBe('offline');
+  });
+
+  it('atomically writes one global snapshot for multiple profiles', async () => {
+    const root = await tmpRoot();
+    const first = new DesktopStatusReporter({
+      rootDir: root,
+      profile: 'claude-prod',
+      agent: 'claude',
+      appId: 'cli_1234567890',
+    });
+    const second = new DesktopStatusReporter({
+      rootDir: root,
+      profile: 'codex-dev',
+      agent: 'codex',
+      appId: 'cli_abcdef',
+    });
+
+    await first.update({ status: 'idle', botName: 'Ops Bot' });
+    await second.update({ status: 'tool_running', activeRunCount: 1 });
+
+    const snapshot = await readDesktopStatusSnapshot(root);
+    expect(snapshot?.aggregateStatus).toBe('tool_running');
+    expect(snapshot?.profiles.map((profile) => profile.profile)).toEqual(['claude-prod', 'codex-dev']);
+
+    await second.clear();
+    const cleaned = await readDesktopStatusSnapshot(root);
+    expect(cleaned?.aggregateStatus).toBe('idle');
+    expect(cleaned?.profiles.map((profile) => profile.profile)).toEqual(['claude-prod']);
+  });
+
+  it('does not serialize message bodies, ids, payloads, or credentials', async () => {
+    const root = await tmpRoot();
+    const reporter = new DesktopStatusReporter({
+      rootDir: root,
+      profile: 'safe',
+      agent: 'codex',
+      appId: 'cli_sensitive_app_id',
+    });
+    await reporter.update({
+      status: 'error',
+      botName: 'Bridge',
+      activeRunCount: 1,
+      queuedMessageCount: 2,
+      lastErrorKind: 'agent',
+    });
+
+    const raw = await readFile(join(root, 'desktop-status.json'), 'utf8');
+    for (const forbidden of [
+      'message',
+      'prompt',
+      'payload',
+      'chatId',
+      'threadId',
+      'sessionId',
+      'senderId',
+      'secret',
+      'token',
+      'cli_sensitive_app_id',
+    ]) {
+      expect(raw).not.toContain(forbidden);
+    }
+    expect(raw).toContain('"appIdSuffix": "app_id"');
+  });
+
+  it('clamps saved positions back into the visible frame', () => {
+    const frame = { x: 100, y: 50, width: 400, height: 300 };
+    expect(clampFloatingBallPosition({ x: 10, y: 900 }, frame)).toEqual({ x: 112, y: 294 });
+    expect(clampFloatingBallPosition(undefined, frame)).toEqual({ x: 444, y: 62 });
+  });
+});


### PR DESCRIPTION
Adds a macOS desktop floating status ball to lark-coding-agent-bridge. It shows bridge/bot runtime state by default, aggregates multiple profiles into one indicator, expands left on hover to show profile status, persists drag position, and surfaces reconnecting, error, and active-run states.
Includes a Swift AppKit helper, privacy-safe local status snapshots, CLI/service integration, --no-floating-ball and config-based disable options, plus verification docs.