### PR TITLE
feat: 支持在共享长连接上注册可选的原始事件 Hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,34 @@ pnpm build
 
 `pnpm test` includes unit, integration, and process-level adapter tests. CI runs on macOS, Ubuntu, and Windows with `pnpm install --frozen-lockfile`, `pnpm test`, `pnpm typecheck`, and `pnpm build`.
 
+## Optional event hooks
+
+The bridge owns one Lark long connection. If you need events that the framework does not handle itself, do not start a second local consumer for the same app. Point `LARK_CHANNEL_EVENT_HOOK_MODULE` at a module that default-exports (or exports `createEventHooks`) an `EventHookFactory`; the bridge will add those EventKeys to its existing dispatcher after SDK/channel handlers are known and before the WebSocket starts.
+
+```bash
+LARK_CHANNEL_EVENT_HOOK_MODULE=file:///opt/lark-hooks/rejoin.mjs lark-channel-bridge start
+```
+
+The configured module is imported directly by Node.js, so `.mjs` files must contain JavaScript. If you write the hook in TypeScript, compile it to ESM JavaScript first and point the environment variable at the generated `.mjs` file.
+
+```ts
+import type { EventHookFactory } from 'lark-channel-bridge';
+
+const createEventHooks: EventHookFactory = () => ({
+  handlers: {
+    async 'im.chat.member.user.deleted_v1'(event, { channel }) {
+      // Inspect event.chat_id / event.users here and perform local policy.
+      // The hook runs inside the bridge process and can use channel.rawClient.
+    },
+  },
+});
+export default createEventHooks;
+```
+
+Event hooks do not change the Lark app configuration. Before enabling a hook, add its required permissions and event subscriptions in the Lark Developer Console and select long-connection delivery.
+
+Event hooks are additive only. Any EventKey already owned by the SDK or channel is rejected with a warning. A missing module, bad factory, unavailable channel hook point, or throwing handler is logged and contained so the bridge keeps running.
+
 ## Optional telemetry
 
 By default the bridge reports **nothing**: no metrics, no logs leave your machine, and it pulls in zero telemetry dependencies. The hook below is inert unless you opt in.

--- a/README.zh.md
+++ b/README.zh.md
@@ -323,6 +323,34 @@ pnpm build
 
 `pnpm test` 包含 unit、integration 和 process-level adapter 测试。CI 在 macOS、Ubuntu、Windows 上执行 `pnpm install --frozen-lockfile`、`pnpm test`、`pnpm typecheck` 和 `pnpm build`。
 
+## 可选：事件 Hook
+
+bridge 自己持有一条 Lark 长连接。如果要处理框架内置逻辑没有覆盖的事件，不要为同一个应用再启动第二个本地 consumer。用 `LARK_CHANNEL_EVENT_HOOK_MODULE` 指向一个 default export（或导出 `createEventHooks`）`EventHookFactory` 的模块；bridge 会在 SDK/channel Handler 就绪后、WebSocket 启动前，把这些 EventKey 添加到现有 dispatcher。
+
+```bash
+LARK_CHANNEL_EVENT_HOOK_MODULE=file:///opt/lark-hooks/rejoin.mjs lark-channel-bridge start
+```
+
+bridge 会用 Node.js 直接加载这个模块，所以 `.mjs` 里必须是 JavaScript。如果用 TypeScript 编写，请先编译成 ESM JavaScript，再让环境变量指向生成的 `.mjs` 文件。
+
+```ts
+import type { EventHookFactory } from 'lark-channel-bridge';
+
+const createEventHooks: EventHookFactory = () => ({
+  handlers: {
+    async 'im.chat.member.user.deleted_v1'(event, { channel }) {
+      // 在这里读取 event.chat_id / event.users，并执行你自己的策略。
+      // hook 运行在 bridge 进程内，可以使用 channel.rawClient。
+    },
+  },
+});
+export default createEventHooks;
+```
+
+事件 hook 不会修改飞书应用配置。启用前，请先在飞书开放平台为应用添加所需权限和事件订阅，并选择长连接接收事件。
+
+事件 Hook 只能做增量注册。任何已经由 SDK 或 channel 占用的 EventKey 都会被拒绝并记录警告。模块不存在、工厂函数不合法、channel 注册点不可用或 handler 抛错都会被记录并隔离，bridge 会继续运行。
+
 ## 可选：遥测（Telemetry）
 
 默认情况下 bridge **不上报任何数据**：没有指标、没有日志离开你的机器，也不引入任何遥测依赖。下面这个钩子在你主动开启前完全是空操作。

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -66,6 +66,11 @@ import { lookupMessageThreadId } from './thread-id';
 import { addWorkingReaction, removeReaction } from './reaction';
 import { fetchKnownChats } from './lark-info';
 import type { AppPaths } from '../config/app-paths';
+import type {
+  EventHookAdapter,
+  EventHookMeta,
+} from '../core/event-hooks';
+import { installEventHookHandlers } from './event-hooks';
 import {
   consumeCotEvents,
   CotClient,
@@ -177,9 +182,35 @@ export interface StartChannelDeps {
   workspaces: WorkspaceStore;
   controls: Controls;
   appPaths?: Pick<AppPaths, 'secretsFile' | 'keystoreSaltFile' | 'mediaDir'>;
+  eventHooks?: EventHookAdapter;
+  eventHookMeta?: EventHookMeta;
 }
 
 export async function startChannel(deps: StartChannelDeps): Promise<BridgeChannel> {
+  let startupChannel: LarkChannel | undefined;
+  try {
+    return await startChannelImpl(deps, (channel) => {
+      startupChannel = channel;
+    });
+  } catch (err) {
+    try {
+      await startupChannel?.disconnect();
+    } catch (disconnectErr) {
+      log.fail('eventHook', disconnectErr, { step: 'disconnect-after-start-failure' });
+    }
+    try {
+      await deps.eventHooks?.close?.();
+    } catch (closeErr) {
+      log.fail('eventHook', closeErr, { step: 'close-after-start-failure' });
+    }
+    throw err;
+  }
+}
+
+async function startChannelImpl(
+  deps: StartChannelDeps,
+  onChannelCreated: (channel: LarkChannel) => void,
+): Promise<BridgeChannel> {
   const { cfg, agent, sessions, sessionCatalog, workspaces, controls } = deps;
   const activeRuns = new ActiveRuns();
   // ChatModeCache stays per-bridge-instance — invalidated on restart along
@@ -268,6 +299,12 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
   };
 
   const channel = createLarkChannel(opts);
+  onChannelCreated(channel);
+  installEventHookHandlers(
+    channel,
+    deps.eventHooks,
+    deps.eventHookMeta ?? { version: 'unknown' },
+  );
   const media = new MediaCache(channel, deps.appPaths?.mediaDir);
 
   // Pending → run handoff: while a run is active on a chat, block its pending
@@ -480,8 +517,14 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
         callbackNonceStore?.flush(),
         workspaces.flush(),
       ]);
+      const [eventHookCloseResult] = await Promise.allSettled([
+        Promise.resolve().then(() => deps.eventHooks?.close?.()),
+      ]);
       if (stopAllResult.status === 'rejected') {
         log.fail('disconnect', stopAllResult.reason, { step: 'stopAll' });
+      }
+      if (eventHookCloseResult.status === 'rejected') {
+        log.fail('disconnect', eventHookCloseResult.reason, { step: 'eventHooks.close' });
       }
       for (const [idx, result] of flushResults.entries()) {
         if (result.status === 'rejected') {

--- a/src/bot/event-hooks.ts
+++ b/src/bot/event-hooks.ts
@@ -1,0 +1,126 @@
+import type { LarkChannel } from '@larksuite/channel';
+import type {
+  EventHookAdapter,
+  EventHookContext,
+  EventHookHandler,
+} from '../core/event-hooks';
+import { log } from '../core/logger';
+
+interface EventDispatcherLike {
+  handles?: {
+    has(eventType: string): boolean;
+    get?(eventType: string): unknown;
+  };
+  register(handles: Record<string, (event: unknown) => unknown>): unknown;
+}
+
+interface HookableChannel {
+  dispatcher?: EventDispatcherLike;
+  registerDispatcherHandlers?: () => void;
+}
+
+/**
+ * Install custom handlers at the channel's dispatcher-registration boundary.
+ *
+ * LarkChannel creates an EventDispatcher (which already owns `app_ticket`) in
+ * its constructor, then registers its normalized built-in handlers inside
+ * `doConnect()`, immediately before starting the WebSocket. Hook handlers must
+ * be added after those built-ins so the dispatcher's actual key set is the
+ * source of truth: every occupied key is rejected, including SDK internals and
+ * future channel events this bridge does not know about.
+ *
+ * @larksuite/channel does not expose this boundary publicly yet, so this is a
+ * feature-detected compatibility shim. If the private shape changes, hooks are
+ * disabled rather than risking an overwrite.
+ */
+export function installEventHookHandlers(
+  channel: LarkChannel,
+  adapter: EventHookAdapter | undefined,
+  context: Omit<EventHookContext, 'channel' | 'eventType'>,
+): void {
+  const handlers = adapter?.handlers;
+  if (!handlers) return;
+
+  const hookable = channel as unknown as HookableChannel;
+  const dispatcher = hookable.dispatcher;
+  const registerChannelHandlers = hookable.registerDispatcherHandlers;
+  if (
+    !dispatcher ||
+    typeof dispatcher.register !== 'function' ||
+    !dispatcher.handles ||
+    typeof dispatcher.handles.has !== 'function' ||
+    typeof registerChannelHandlers !== 'function'
+  ) {
+    log.warn('eventHook', 'channel-hook-point-unavailable');
+    return;
+  }
+
+  let installed = false;
+  hookable.registerDispatcherHandlers = () => {
+    registerChannelHandlers.call(channel);
+    if (installed) return;
+    installed = true;
+    registerAvailableHandlers(channel, dispatcher, handlers, context);
+  };
+}
+
+function registerAvailableHandlers(
+  channel: LarkChannel,
+  dispatcher: EventDispatcherLike,
+  handlers: Record<string, EventHookHandler>,
+  context: Omit<EventHookContext, 'channel' | 'eventType'>,
+): void {
+  const registry = dispatcher.handles;
+  if (!registry) return;
+
+  const handles: Record<string, (event: unknown) => Promise<void>> = {};
+  for (const [eventType, handler] of Object.entries(handlers)) {
+    if (typeof handler !== 'function') {
+      log.warn('eventHook', 'skip-invalid-handler', { eventType });
+      continue;
+    }
+    if (registry.has(eventType)) {
+      log.warn('eventHook', 'skip-reserved', { eventType });
+      continue;
+    }
+    handles[eventType] = wrapEventHookHandler(channel, eventType, handler, context);
+  }
+
+  const events = Object.keys(handles);
+  if (events.length === 0) return;
+
+  try {
+    dispatcher.register(handles);
+    const registered = typeof registry.get === 'function'
+      ? events.filter((eventType) => registry.get?.(eventType) === handles[eventType])
+      : events;
+    const missing = events.filter((eventType) => !registered.includes(eventType));
+    if (missing.length > 0) {
+      log.warn('eventHook', 'registration-not-installed', { events: missing });
+    }
+    if (registered.length > 0) {
+      log.info('eventHook', 'registered', { events: registered });
+    }
+  } catch (err) {
+    log.fail('eventHook', err, { step: 'register', events });
+  }
+}
+
+function wrapEventHookHandler(
+  channel: LarkChannel,
+  eventType: string,
+  handler: EventHookHandler,
+  context: Omit<EventHookContext, 'channel' | 'eventType'>,
+): (event: unknown) => Promise<void> {
+  return async (event: unknown) => {
+    try {
+      await handler(event, {
+        ...context,
+        eventType,
+        channel,
+      });
+    } catch (err) {
+      log.fail('eventHook', err, { eventType });
+    }
+  };
+}

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -21,6 +21,10 @@ import type { AppConfig } from '../../config/schema';
 import { isComplete } from '../../config/schema';
 import { configureLogger, gcOldLogs, log, reportError } from '../../core/logger';
 import { loadTelemetryAdapter, telemetry } from '../../core/telemetry';
+import {
+  loadEventHookAdapter,
+  type EventHookMeta,
+} from '../../core/event-hooks';
 import { gcMediaCache } from '../../media/cache';
 import { preFlightChecks } from '../preflight';
 import { promptAndStopActiveBridgeMigrationConflict } from './migrate';
@@ -258,7 +262,17 @@ export async function runStart(opts: StartOptions): Promise<void> {
                 console.log(
                   `[restart] connecting new bridge with appId=${next.accounts.app.id} tenant=${next.accounts.app.tenant}...`,
                 );
-                const nextControls = makeControls(nextRuntime.appPaths, next, nextRuntime.profileConfig);
+                const nextControls = makeControls(
+                  nextRuntime.appPaths,
+                  next,
+                  nextRuntime.profileConfig,
+                );
+                const nextEventHookMeta = eventHookMeta(
+                  next,
+                  nextRuntime.appPaths,
+                  nextRuntime.configPath,
+                );
+                const nextEventHooks = await loadEventHookAdapter(nextEventHookMeta);
                 // Connect-before-disconnect: if the new bridge fails to come up
                 // (e.g. network outage during a force-reconnect), throwing here
                 // leaves the old bridge — and its keepalive timer — untouched, so
@@ -274,6 +288,8 @@ export async function runStart(opts: StartOptions): Promise<void> {
                   workspaces,
                   controls: nextControls,
                   appPaths: nextRuntime.appPaths,
+                  eventHooks: nextEventHooks,
+                  eventHookMeta: nextEventHookMeta,
                 });
                 console.log('[restart] disconnecting old bridge...');
                 try {
@@ -321,6 +337,8 @@ export async function runStart(opts: StartOptions): Promise<void> {
           return currentControls;
         };
         controls = makeControls(appPaths, cfg, profileConfig);
+        const initialEventHookMeta = eventHookMeta(cfg, appPaths, configPath);
+        const initialEventHooks = await loadEventHookAdapter(initialEventHookMeta);
 
         bridge = await startChannel({
           cfg,
@@ -330,6 +348,8 @@ export async function runStart(opts: StartOptions): Promise<void> {
           workspaces,
           controls,
           appPaths,
+          eventHooks: initialEventHooks,
+          eventHookMeta: initialEventHookMeta,
         });
 
         // Backfill the bot's display name into the registry once WS handshake is
@@ -557,6 +577,21 @@ async function releaseRuntimeLocks(locks: AcquiredRuntimeLock[]): Promise<void> 
       }),
     );
   }
+}
+
+function eventHookMeta(
+  cfg: AppConfig,
+  appPaths: Pick<AppPaths, 'profile'>,
+  configPath: string,
+): EventHookMeta {
+  return {
+    version: pkg.version,
+    appId: cfg.accounts.app.id,
+    tenant: cfg.accounts.app.tenant,
+    profile: appPaths.profile,
+    configPath,
+    hostname: os.hostname(),
+  };
 }
 
 async function flushTelemetry(timeoutMs = 2000): Promise<void> {

--- a/src/core/event-hooks.ts
+++ b/src/core/event-hooks.ts
@@ -1,0 +1,103 @@
+import type { LarkChannel } from '@larksuite/channel';
+import { log } from './logger';
+import { normalizeModuleSpecifier } from './module-specifier';
+
+/**
+ * Optional raw Lark event hooks.
+ *
+ * The bridge has built-in handlers for message/card/reaction/comment events.
+ * Operators can point `LARK_CHANNEL_EVENT_HOOK_MODULE` at an external module to
+ * add handlers for other EventKeys on the same long-connection dispatcher.
+ */
+
+export interface EventHookMeta {
+  version: string;
+  appId?: string;
+  tenant?: string;
+  profile?: string;
+  configPath?: string;
+  hostname?: string;
+}
+
+export interface EventHookContext extends EventHookMeta {
+  eventType: string;
+  channel: LarkChannel;
+}
+
+export type EventHookHandler = (
+  event: unknown,
+  context: EventHookContext,
+) => void | Promise<void>;
+
+export interface EventHookAdapter {
+  /** EventKey -> raw event handler. */
+  handlers?: Record<string, EventHookHandler>;
+  /** Release resources on bridge shutdown. Optional. */
+  close?(): void | Promise<void>;
+}
+
+/**
+ * Create the adapter for one bridge instance.
+ *
+ * The bridge can briefly overlap old and replacement connections during
+ * reconnect, so every invocation must return a fresh, independently closeable
+ * adapter. Returning a cached singleton is unsupported.
+ */
+export type EventHookFactory = (
+  meta: EventHookMeta,
+) => EventHookAdapter | Promise<EventHookAdapter>;
+
+function diag(event: string, fields: Record<string, unknown>): void {
+  log.warn('eventHook', event, fields);
+}
+
+/**
+ * Load the optional event hook adapter named by
+ * `LARK_CHANNEL_EVENT_HOOK_MODULE`.
+ *
+ * Missing/bad modules degrade to undefined: a custom hook must never stop the
+ * bridge from starting.
+ */
+export async function loadEventHookAdapter(
+  meta: EventHookMeta,
+): Promise<EventHookAdapter | undefined> {
+  const mod = process.env.LARK_CHANNEL_EVENT_HOOK_MODULE;
+  if (!mod) return undefined;
+  try {
+    const imported = (await import(normalizeModuleSpecifier(mod))) as {
+      default?: unknown;
+      createEventHooks?: unknown;
+    };
+    const factory = (imported.default ?? imported.createEventHooks) as
+      | EventHookFactory
+      | undefined;
+    if (typeof factory !== 'function') {
+      diag('bad_module', { module: mod });
+      return undefined;
+    }
+    const adapter = await factory(meta);
+    if (!adapter || typeof adapter !== 'object') {
+      diag('bad_adapter', { module: mod });
+      return undefined;
+    }
+    if (adapter.handlers !== undefined && !isRecord(adapter.handlers)) {
+      diag('bad_handlers', { module: mod });
+      return undefined;
+    }
+    if (adapter.close !== undefined && typeof adapter.close !== 'function') {
+      diag('bad_close', { module: mod });
+      return undefined;
+    }
+    return adapter;
+  } catch (err) {
+    diag('load_fail', {
+      module: mod,
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return undefined;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, EventHookHandler> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}

--- a/src/core/module-specifier.ts
+++ b/src/core/module-specifier.ts
@@ -1,0 +1,4 @@
+/** Normalize module URLs before passing them to dynamic import(). */
+export function normalizeModuleSpecifier(specifier: string): string {
+  return specifier.startsWith('file:') ? specifier.replace(/%7E/gi, '~') : specifier;
+}

--- a/src/core/telemetry.ts
+++ b/src/core/telemetry.ts
@@ -1,4 +1,5 @@
 import type { LogContext, LogFields } from './logger';
+import { normalizeModuleSpecifier } from './module-specifier';
 
 /**
  * Optional telemetry hook.
@@ -144,10 +145,6 @@ export async function loadTelemetryAdapter(meta: AdapterMeta): Promise<void> {
       err: err instanceof Error ? err.message : String(err),
     });
   }
-}
-
-function normalizeModuleSpecifier(specifier: string): string {
-  return specifier.startsWith('file:') ? specifier.replace(/%7E/gi, '~') : specifier;
 }
 
 /** The active adapter — noop until/unless `loadTelemetryAdapter` installs one. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,4 +18,14 @@ export type {
   AdapterMeta,
   TelemetryEvent,
 } from './core/telemetry';
+
+// Optional raw event hooks (see README "Optional event hooks"). Types let an
+// external hook package implement custom EventKey handlers.
+export type {
+  EventHookAdapter,
+  EventHookContext,
+  EventHookFactory,
+  EventHookHandler,
+  EventHookMeta,
+} from './core/event-hooks';
 export { reportMetric, reportError } from './core/logger';

--- a/tests/integration/bot/event-hooks-wiring.test.ts
+++ b/tests/integration/bot/event-hooks-wiring.test.ts
@@ -1,0 +1,254 @@
+import { realpath } from 'node:fs/promises';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { LarkChannel } from '@larksuite/channel';
+import { startChannel } from '../../../src/bot/channel.js';
+import { createDefaultProfileConfig } from '../../../src/config/profile-schema.js';
+import { SessionStore } from '../../../src/session/store.js';
+import { WorkspaceStore } from '../../../src/workspace/store.js';
+import { FakeAgentAdapter } from '../../helpers/fake-agent.js';
+import { createTmpProfile } from '../../helpers/tmp-profile.js';
+
+const sdkMock = vi.hoisted(() => ({
+  channel: undefined as FakeLarkChannel | undefined,
+  createLarkChannel: vi.fn(() => {
+    if (!sdkMock.channel) throw new Error('fake channel not configured');
+    return sdkMock.channel;
+  }),
+}));
+
+vi.mock('@larksuite/channel', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@larksuite/channel')>();
+  return {
+    ...actual,
+    createLarkChannel: sdkMock.createLarkChannel,
+  };
+});
+
+interface FakeLarkChannel {
+  registered: Record<string, (event: unknown) => Promise<void> | void>;
+  phases: string[];
+  dispatcher: {
+    handles: Map<string, (event: unknown) => Promise<void> | void>;
+    register: ReturnType<typeof vi.fn>;
+  };
+  registerDispatcherHandlers: ReturnType<typeof vi.fn>;
+  botIdentity: { openId: string; name: string };
+  rawClient: {
+    request: ReturnType<typeof vi.fn>;
+    im: {
+      v1: {
+        messageReaction: {
+          create: ReturnType<typeof vi.fn>;
+          delete: ReturnType<typeof vi.fn>;
+        };
+      };
+    };
+  };
+  getAppInfo: ReturnType<typeof vi.fn>;
+  listChats: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  getConnectionStatus(): { state: 'connected'; reconnectAttempts: number };
+}
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  sdkMock.channel = undefined;
+  sdkMock.createLarkChannel.mockClear();
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+describe('event hook channel wiring', () => {
+  it('registers custom hooks after channel handlers and before WebSocket startup', async () => {
+    const { channel, deps } = await createHarness();
+    const close = vi.fn(() => {
+      channel.phases.push('hook:close');
+    });
+
+    const bridge = await startChannel({
+      ...deps,
+      eventHooks: {
+        handlers: {
+          'im.chat.member.user.deleted_v1': vi.fn(),
+        },
+        close,
+      },
+      eventHookMeta: { version: 'test' },
+    });
+
+    expect(channel.connect).toHaveBeenCalled();
+    expect(channel.phases).toEqual([
+      'connect:start',
+      'channel:register',
+      'hook:register',
+      'websocket:start',
+    ]);
+    expect(channel.dispatcher.handles.has('app_ticket')).toBe(true);
+    expect(channel.dispatcher.handles.has('im.message.receive_v1')).toBe(true);
+    expect(channel.dispatcher.handles.has('im.chat.member.user.deleted_v1')).toBe(true);
+
+    await bridge.disconnect();
+    expect(channel.phases.slice(-2)).toEqual(['websocket:stop', 'hook:close']);
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the hook when channel startup fails', async () => {
+    const { channel, deps } = await createHarness();
+    const close = vi.fn(() => {
+      channel.phases.push('hook:close');
+    });
+    channel.connect.mockImplementationOnce(async () => {
+      channel.phases.push('connect:start');
+      throw new Error('connect failed');
+    });
+
+    await expect(startChannel({
+      ...deps,
+      eventHooks: {
+        handlers: { 'custom.event_v1': vi.fn() },
+        close,
+      },
+      eventHookMeta: { version: 'test' },
+    })).rejects.toThrow('connect failed');
+
+    expect(channel.disconnect).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(channel.phases).toEqual([
+      'connect:start',
+      'websocket:stop',
+      'hook:close',
+    ]);
+  });
+
+  it('contains a synchronous hook close failure during normal shutdown', async () => {
+    const { channel, deps } = await createHarness();
+    const sessionsFlush = vi.spyOn(deps.sessions, 'flush');
+    const workspacesFlush = vi.spyOn(deps.workspaces, 'flush');
+    const close = vi.fn(() => {
+      channel.phases.push('hook:close');
+      throw new Error('close failed');
+    });
+
+    const bridge = await startChannel({
+      ...deps,
+      eventHooks: { handlers: {}, close },
+      eventHookMeta: { version: 'test' },
+    });
+
+    await expect(bridge.disconnect()).resolves.toBeUndefined();
+    expect(channel.disconnect).toHaveBeenCalledTimes(1);
+    expect(sessionsFlush).toHaveBeenCalledTimes(1);
+    expect(workspacesFlush).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(channel.phases.slice(-2)).toEqual(['websocket:stop', 'hook:close']);
+  });
+});
+
+async function createHarness(): Promise<{
+  channel: FakeLarkChannel;
+  deps: Parameters<typeof startChannel>[0];
+}> {
+  const tmp = await createTmpProfile('event-hooks-wiring-');
+  cleanups.push(tmp.cleanup);
+  const workspace = await realpath(tmp.workspace);
+  const baseCfg = createDefaultProfileConfig({
+    agentKind: 'claude',
+    accounts: {
+      app: {
+        id: 'cli_test',
+        secret: 'secret',
+        tenant: 'feishu',
+      },
+    },
+  });
+  const cfg = {
+    ...baseCfg,
+    workspaces: {
+      ...baseCfg.workspaces,
+      default: workspace,
+    },
+  };
+  const channel = createFakeLarkChannel();
+  sdkMock.channel = channel;
+  return {
+    channel,
+    deps: {
+      cfg,
+      agent: new FakeAgentAdapter(),
+      sessions: new SessionStore(join(tmp.profile, 'sessions.json')),
+      workspaces: new WorkspaceStore(join(tmp.profile, 'workspaces.json')),
+      controls: {
+        profile: 'test',
+        profileConfig: cfg,
+        ownerRefreshState: 'unknown',
+        async refreshOwner() {},
+        async restart() {},
+        async exit() {},
+        configPath: '/tmp/config.json',
+        cfg,
+        processId: 'proc_test',
+      },
+    },
+  };
+}
+
+function createFakeLarkChannel(): FakeLarkChannel {
+  const registered: Record<string, (event: unknown) => Promise<void> | void> = {};
+  const phases: string[] = [];
+  const appTicketHandler = vi.fn();
+  const handles = new Map<string, (event: unknown) => Promise<void> | void>([
+    ['app_ticket', appTicketHandler],
+  ]);
+  const channel = {
+    registered,
+    phases,
+    dispatcher: {
+      handles,
+      register: vi.fn((next: Record<string, (event: unknown) => Promise<void> | void>) => {
+        const eventTypes = Object.keys(next);
+        phases.push(eventTypes.includes('im.message.receive_v1')
+          ? 'channel:register'
+          : 'hook:register');
+        Object.assign(registered, next);
+        for (const [eventType, handler] of Object.entries(next)) {
+          channel.dispatcher.handles.set(eventType, handler);
+        }
+      }),
+    },
+    registerDispatcherHandlers: vi.fn(() => {
+      channel.dispatcher.register({
+        'im.message.receive_v1': vi.fn(),
+      });
+    }),
+    botIdentity: { openId: 'ou_bot', name: 'Bridge' },
+    rawClient: {
+      request: vi.fn(async () => ({ data: { items: [] } })),
+      im: {
+        v1: {
+          messageReaction: {
+            create: vi.fn(async () => ({ data: { reaction_id: 'reaction_1' } })),
+            delete: vi.fn(async () => ({})),
+          },
+        },
+      },
+    },
+    getAppInfo: vi.fn(async () => ({ ownerId: 'ou_owner' })),
+    listChats: vi.fn(async () => []),
+    on: vi.fn(),
+    connect: vi.fn(async () => {
+      phases.push('connect:start');
+      channel.registerDispatcherHandlers();
+      phases.push('websocket:start');
+    }),
+    disconnect: vi.fn(async () => {
+      phases.push('websocket:stop');
+    }),
+    getConnectionStatus() {
+      return { state: 'connected', reconnectAttempts: 0 };
+    },
+  } as unknown as FakeLarkChannel;
+  return channel;
+}

--- a/tests/integration/commands/reconnect-profile.test.ts
+++ b/tests/integration/commands/reconnect-profile.test.ts
@@ -47,9 +47,18 @@ describe('/reconnect profile lifecycle', () => {
   it('starts the replacement bridge with replacement controls before swapping globals', async () => {
     const source = await readFile(new URL('../../../src/cli/commands/start.ts', import.meta.url), 'utf8');
 
-    expect(source).toContain('const nextControls = makeControls(nextRuntime.appPaths, next, nextRuntime.profileConfig)');
+    expect(source).toMatch(
+      /const nextControls = makeControls\(\s*nextRuntime\.appPaths,\s*next,\s*nextRuntime\.profileConfig,\s*\);/,
+    );
+    expect(source).toContain('const nextEventHookMeta = eventHookMeta(');
+    expect(source).toContain('const nextEventHooks = await loadEventHookAdapter(nextEventHookMeta)');
+    expect(source).toContain('eventHooks: nextEventHooks');
+    expect(source).toContain('eventHookMeta: nextEventHookMeta');
     expect(source).toContain('controls: nextControls');
     expect(source).toContain('controls = nextControls');
+    expect(source.indexOf('const nextControls = makeControls(')).toBeLessThan(
+      source.indexOf('const nextEventHooks = await loadEventHookAdapter(nextEventHookMeta)'),
+    );
   });
 
   it('guards direct bridge disconnects and IM commands with the current profile runtime context', async () => {

--- a/tests/unit/bot/event-hooks.test.ts
+++ b/tests/unit/bot/event-hooks.test.ts
@@ -1,0 +1,163 @@
+import { createLarkChannel, type LarkChannel } from '@larksuite/channel';
+import { describe, expect, it, vi } from 'vitest';
+import { installEventHookHandlers } from '../../../src/bot/event-hooks.js';
+
+describe('event hook dispatcher registration', () => {
+  it('preserves the real SDK app_ticket handler while installing custom handlers', () => {
+    const channel = createLarkChannel({ appId: 'cli_test', appSecret: 'secret' });
+    const internals = channel as unknown as {
+      dispatcher: { handles: Map<string, RawHandler> };
+      registerDispatcherHandlers(): void;
+    };
+    const appTicketHandler = internals.dispatcher.handles.get('app_ticket');
+
+    installEventHookHandlers(channel, {
+      handlers: {
+        app_ticket: vi.fn(),
+        'custom.available.event_v1': vi.fn(),
+      },
+    }, { version: 'test' });
+
+    internals.registerDispatcherHandlers();
+
+    expect(appTicketHandler).toEqual(expect.any(Function));
+    expect(internals.dispatcher.handles.get('app_ticket')).toBe(appTicketHandler);
+    expect(internals.dispatcher.handles.has('im.message.receive_v1')).toBe(true);
+    expect(internals.dispatcher.handles.has('custom.available.event_v1')).toBe(true);
+  });
+
+  it('registers custom handlers after channel handlers and before event delivery', async () => {
+    const channel = fakeChannel({
+      'im.message.receive_v1': vi.fn(),
+    });
+    const handler = vi.fn();
+
+    installEventHookHandlers(channel as unknown as LarkChannel, {
+      handlers: {
+        'im.chat.member.user.deleted_v1': handler,
+      },
+    }, {
+      version: 'test',
+      appId: 'cli_test',
+      tenant: 'feishu',
+      profile: 'default',
+      configPath: '/tmp/config.json',
+    });
+
+    expect(channel.dispatcher.handles.has('im.chat.member.user.deleted_v1')).toBe(false);
+    channel.registerDispatcherHandlers();
+    expect(channel.dispatcher.handles.has('im.message.receive_v1')).toBe(true);
+
+    const installed = channel.dispatcher.handles.get('im.chat.member.user.deleted_v1');
+    expect(installed).toEqual(expect.any(Function));
+
+    const event = {
+      chat_id: 'oc_chat',
+      users: [{ user_id: { open_id: 'ou_left' } }],
+    };
+    await installed?.(event);
+
+    expect(handler).toHaveBeenCalledWith(event, expect.objectContaining({
+      eventType: 'im.chat.member.user.deleted_v1',
+      channel,
+      appId: 'cli_test',
+      tenant: 'feishu',
+      profile: 'default',
+      configPath: '/tmp/config.json',
+    }));
+  });
+
+  it('rejects app_ticket and every channel-owned event from the live registry', () => {
+    const appTicketHandler = vi.fn();
+    const futureBuiltInHandler = vi.fn();
+    const channel = fakeChannel({
+      'future.channel.event_v1': futureBuiltInHandler,
+    }, appTicketHandler);
+
+    installEventHookHandlers(channel as unknown as LarkChannel, {
+      handlers: {
+        app_ticket: vi.fn(),
+        'future.channel.event_v1': vi.fn(),
+        'custom.available.event_v1': vi.fn(),
+      },
+    }, { version: 'test' });
+
+    channel.registerDispatcherHandlers();
+
+    expect(channel.dispatcher.handles.get('app_ticket')).toBe(appTicketHandler);
+    expect(channel.dispatcher.handles.get('future.channel.event_v1')).toBe(
+      futureBuiltInHandler,
+    );
+    expect(channel.dispatcher.handles.get('custom.available.event_v1')).toEqual(
+      expect.any(Function),
+    );
+  });
+
+  it('contains hook failures and keeps the dispatcher alive', async () => {
+    const channel = fakeChannel();
+
+    installEventHookHandlers(channel as unknown as LarkChannel, {
+      handlers: {
+        'im.chat.member.user.deleted_v1': () => {
+          throw new Error('hook boom');
+        },
+      },
+    }, { version: 'test' });
+
+    channel.registerDispatcherHandlers();
+    await expect(
+      channel.dispatcher.handles.get('im.chat.member.user.deleted_v1')?.({
+        chat_id: 'oc_chat',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('fails closed when the private channel hook point is unavailable', () => {
+    const appTicketHandler = vi.fn();
+    const customHandler = vi.fn();
+    const channel = {
+      dispatcher: {
+        handles: new Map([['app_ticket', appTicketHandler]]),
+        register: vi.fn(),
+      },
+    } as unknown as LarkChannel;
+
+    installEventHookHandlers(channel, {
+      handlers: { 'custom.event_v1': customHandler },
+    }, { version: 'test' });
+
+    expect((channel as unknown as {
+      dispatcher: { register: ReturnType<typeof vi.fn> };
+    }).dispatcher.register).not.toHaveBeenCalled();
+  });
+});
+
+type RawHandler = (event: unknown) => Promise<void> | void;
+
+interface FakeHookableChannel {
+  dispatcher: {
+    handles: Map<string, RawHandler>;
+    register(handles: Record<string, RawHandler>): void;
+  };
+  registerDispatcherHandlers(): void;
+}
+
+function fakeChannel(
+  channelHandlers: Record<string, RawHandler> = {},
+  appTicketHandler: RawHandler = vi.fn(),
+): FakeHookableChannel {
+  const handles = new Map<string, RawHandler>([['app_ticket', appTicketHandler]]);
+  return {
+    dispatcher: {
+      handles,
+      register(next) {
+        for (const [eventType, handler] of Object.entries(next)) {
+          handles.set(eventType, handler);
+        }
+      },
+    },
+    registerDispatcherHandlers() {
+      this.dispatcher.register(channelHandlers);
+    },
+  };
+}

--- a/tests/unit/core/event-hooks.test.ts
+++ b/tests/unit/core/event-hooks.test.ts
@@ -1,0 +1,100 @@
+import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { loadEventHookAdapter } from '../../../src/core/event-hooks.js';
+import { log } from '../../../src/core/logger.js';
+import { createTmpProfile } from '../../helpers/tmp-profile.js';
+
+const cleanups: Array<() => Promise<void>> = [];
+
+describe('optional event hook adapter loading', () => {
+  afterEach(async () => {
+    delete process.env.LARK_CHANNEL_EVENT_HOOK_MODULE;
+    vi.restoreAllMocks();
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+  });
+
+  it('stays disabled when no module is configured', async () => {
+    await expect(loadEventHookAdapter({ version: 'test' })).resolves.toBeUndefined();
+  });
+
+  it('loads handlers from an external module', async () => {
+    const tmp = await createTmpProfile('event-hooks-');
+    cleanups.push(tmp.cleanup);
+    const adapterPath = join(tmp.root, 'event-hooks.mjs');
+    await writeFile(
+      adapterPath,
+      `
+        globalThis.__eventHookMeta = undefined;
+        export function createEventHooks(meta) {
+          globalThis.__eventHookMeta = meta;
+          return {
+            handlers: {
+              'im.chat.member.user.deleted_v1': () => {},
+            },
+          };
+        }
+      `,
+    );
+
+    process.env.LARK_CHANNEL_EVENT_HOOK_MODULE = pathToFileURL(adapterPath).href;
+
+    const adapter = await loadEventHookAdapter({
+      version: '0.0.0-test',
+      appId: 'cli_test',
+      tenant: 'feishu',
+      profile: 'default',
+      configPath: '/tmp/config.json',
+      hostname: 'host-a',
+    });
+
+    expect(globalThis.__eventHookMeta).toMatchObject({
+      version: '0.0.0-test',
+      appId: 'cli_test',
+      tenant: 'feishu',
+      profile: 'default',
+      configPath: '/tmp/config.json',
+      hostname: 'host-a',
+    });
+    expect(adapter?.handlers?.['im.chat.member.user.deleted_v1']).toEqual(expect.any(Function));
+  });
+
+  it('diagnoses bad modules without throwing', async () => {
+    const warn = vi.spyOn(log, 'warn').mockImplementation(() => {});
+    const tmp = await createTmpProfile('event-hooks-bad-');
+    cleanups.push(tmp.cleanup);
+    const adapterPath = join(tmp.root, 'bad-event-hooks.mjs');
+    await writeFile(adapterPath, 'export default { not: "a factory" };');
+
+    process.env.LARK_CHANNEL_EVENT_HOOK_MODULE = pathToFileURL(adapterPath).href;
+
+    await expect(loadEventHookAdapter({ version: 'test' })).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith('eventHook', 'bad_module', {
+      module: pathToFileURL(adapterPath).href,
+    });
+  });
+
+  it('rejects a non-function close method', async () => {
+    const warn = vi.spyOn(log, 'warn').mockImplementation(() => {});
+    const tmp = await createTmpProfile('event-hooks-bad-close-');
+    cleanups.push(tmp.cleanup);
+    const adapterPath = join(tmp.root, 'bad-close-event-hooks.mjs');
+    await writeFile(
+      adapterPath,
+      'export default function () { return { handlers: {}, close: true }; }',
+    );
+
+    process.env.LARK_CHANNEL_EVENT_HOOK_MODULE = pathToFileURL(adapterPath).href;
+
+    await expect(loadEventHookAdapter({ version: 'test' })).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalledWith('eventHook', 'bad_close', {
+      module: pathToFileURL(adapterPath).href,
+    });
+  });
+});
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __eventHookMeta: unknown;
+}


### PR DESCRIPTION
## 背景
bridge 持有飞书应用的唯一长连接状态下，只处理 `@larksuite/channel` 和 bridge 已经**内置支持**的事件。
对于没有内置 Handler 的事件，底层长连接虽然能够收到，但 bridge 没有提供消费入口，这些事件实际上**无法被用户利用**。
开启多个长连接可能会导致事件被分发到不同实例，因此本PR旨在增加一个可选的Event Hook扩展点，利用这些事件。

## 方案
通过环境变量指定外部ESM模块（复用了Telemetry Adapter 的模式）：
```bash
LARK_CHANNEL_EVENT_HOOK_MODULE=file:///opt/lark-hooks/index.mjs \
    lark-channel-bridge start
```

模块  **默认导出工厂函数** 或者  **命名导出** 均可，冲突时 **默认导出** 优先
```mjs
const createEventHooks = () => ({
  handlers: {
    async 'im.chat.member.user.deleted_v1'(event, { channel }) {
      // 处理事件
    },
  },

  async close() {
    // 释放资源
  },
});

export default createEventHooks;

```

## 使用限制
- Hook 只补充 bridge 没处理的事件。已经被 SDK 或 channel 注册的 EventKey 会直接跳过，不能用 Hook 覆盖。
- 工厂不要返回缓存的 Adapter 单例（为了兼容/reconnect）

## 风险项
因为 `@larksuite/channel`目前未提供RAW模式EventHandlers注册接口，我目前只能强制访问它的私有dispatcher，这种方式不是很优雅
```
declare class LarkChannel {
  private readonly dispatcher;
  private registerDispatcherHandlers; 
}
```
为了更好的兼容性，我在这里代码里添加了运行时的能力检测，保证bridge正常运行。但也希望larksuite能开放相关接口，
- channel.dispatcher 存在
- dispatcher.register 是函数
- dispatcher.handles 存在
- dispatcher.handles.has 是函数
- channel.registerDispatcherHandlers 是函数

## 当前状态
已通过 `pnpm test`、`pnpm typecheck` 和 `pnpm build`