### PR TITLE
fix(codex): 在回合结束前发送生成图片

### DIFF
--- a/src/agent/codex/adapter.ts
+++ b/src/agent/codex/adapter.ts
@@ -1,5 +1,6 @@
 import { createInterface } from 'node:readline';
 import type { Readable, Writable } from 'node:stream';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { SandboxMode } from '../../config/profile-schema';
 import { log } from '../../core/logger';
@@ -61,6 +62,15 @@ export class CodexAdapter implements AgentAdapter {
 
   setBotIdentity(identity: AgentBotIdentity): void {
     this.botIdentity = identity;
+  }
+
+  getGeneratedImagesDir(): string {
+    const home =
+      this.codexHome ??
+      (!this.inheritCodexHome
+        ? join(this.profileStateDir, 'codex-home')
+        : process.env.CODEX_HOME || join(homedir(), '.codex'));
+    return join(home, 'generated_images');
   }
 
   async isAvailable(): Promise<boolean> {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -88,4 +88,9 @@ export interface AgentAdapter {
    * Adapters that don't bake identity into their prompts may omit it.
    */
   setBotIdentity?(identity: AgentBotIdentity): void;
+  /**
+   * Directory where this adapter writes generated image artifacts. The bridge
+   * uses this optional hint for fast-path delivery while a run is still active.
+   */
+  getGeneratedImagesDir?(): string | undefined;
 }

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -56,6 +56,7 @@ import type { WorkspaceStore } from '../workspace/store';
 import { ActiveRuns, type RunHandle } from './active-runs';
 import { ChatModeCache, type ChatMode } from './chat-mode-cache';
 import { handleCommentMention } from './comments';
+import { GeneratedImageDelivery } from './generated-image-delivery';
 import { recordRunSessionEvent, startRunFlow } from './run-flow';
 import { commandSessionCatalogIdentity } from './session-catalog-identity';
 import { startKeepalive } from './keepalive';
@@ -76,6 +77,8 @@ import {
 const DEBOUNCE_MS = 600;
 const STREAM_TERMINAL_GRACE_MS = 3000;
 const REACTION_CLEANUP_GRACE_MS = 1000;
+const CODEX_GENERATED_IMAGE_INSTRUCTION =
+  '当你通过 imagegen 生成或编辑图片时，只负责完成图片生成；不要读取飞书发送技能，也不要调用 lark-cli 发送该图片。bridge 会监控 Codex generated_images 目录并自动把新图片回复到当前消息。';
 
 const BRIDGE_AGENT_INSTRUCTIONS = [
   '你在 bridge 进程中运行，普通 lark-cli 会继承 LARK_CHANNEL=1 并进入 bridge-bound 模式。',
@@ -189,6 +192,7 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
   // so /config bumps take effect for the next run.
   const pool = new ProcessPool(() => getMaxConcurrentRuns(controls.cfg));
   const executor = new RunExecutor({ agent, pool, activeRuns });
+  const generatedImagesDir = agent.getGeneratedImagesDir?.();
 
   // Resolve the App Secret to plaintext. The config field can be a literal
   // string, a "${VAR}" template, or a {source, id} SecretRef referencing
@@ -250,6 +254,7 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
     includeRawEvent: true,
     outbound: {
       streamThrottleMs: 400,
+      ...(generatedImagesDir ? { allowedFileDirs: [generatedImagesDir] } : {}),
     },
     // SDK 1.65.0-alpha.3+ knobs.
     wsConfig: {
@@ -315,6 +320,7 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
           callbackAuth,
           activePolicyFingerprints,
           lastRunModelByScope,
+          generatedImagesDir,
           scope,
           mode,
         });
@@ -699,6 +705,7 @@ interface RunBatchDeps {
   callbackAuth?: CallbackAuth;
   activePolicyFingerprints: Map<string, string>;
   lastRunModelByScope: Map<string, string>;
+  generatedImagesDir?: string;
   scope: string;
   mode: ChatMode;
 }
@@ -717,6 +724,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     callbackAuth,
     activePolicyFingerprints,
     lastRunModelByScope,
+    generatedImagesDir,
     scope,
     mode,
   } = deps;
@@ -806,12 +814,15 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
   const prevModel = lastRunModelByScope.get(scope);
   const modelSwitched = prevModel !== undefined && prevModel !== modelSelection;
   lastRunModelByScope.set(scope, modelSelection);
-  const extraInstructions = modelSwitched
-    ? [
+  const extraInstructions = [
+    ...(modelSwitched
+      ? [
         `用户刚把本会话使用的模型切换为「${modelLabel(agentKind, modelPref)}」。` +
           '之前的对话里可能提到别的模型,请以当前模型为准;若被问到你用的是什么模型,据此回答。',
-      ]
-    : undefined;
+        ]
+      : []),
+    ...(agentKind === 'codex' && generatedImagesDir ? [CODEX_GENERATED_IMAGE_INSTRUCTION] : []),
+  ];
 
   const prompt = buildPrompt(
     batch,
@@ -819,7 +830,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     quotes,
     topicContext,
     channel.botIdentity,
-    extraInstructions,
+    extraInstructions.length > 0 ? extraInstructions : undefined,
   );
   log.info('prompt', 'built', {
     promptChars: prompt.length,
@@ -858,6 +869,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     controls.profileConfig.agentKind === 'codex'
       ? codexCapability(controls.profileConfig)
       : claudeCapability(controls.profileConfig);
+  const runRequestedAt = Date.now();
   const flow = await startRunFlow({
     scopeId: scope,
     scope: scopeContext,
@@ -894,6 +906,20 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
   activePolicyFingerprints.set(scope, flow.policy.policyFingerprint);
   const handle = execution.handle;
   const eventStream = execution.subscribe();
+  const generatedImageDelivery =
+    agentKind === 'codex' && generatedImagesDir
+      ? new GeneratedImageDelivery({
+          channel,
+          chatId,
+          sendOpts,
+          rootDir: generatedImagesDir,
+          runId: execution.runId,
+          startedAt: runRequestedAt,
+          imageMaxBytes: controls.profileConfig.attachments.imageMaxBytes,
+          initialThreadId: flow.resumeFrom,
+        })
+      : undefined;
+  generatedImageDelivery?.start();
   if (flow.resumeFrom) {
     log.info('session', 'resume', { sessionId: flow.resumeFrom, cwd });
   } else {
@@ -923,6 +949,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     }
     if (evt.type === 'system' && evt.threadId) {
       log.info('session', 'set-thread', { threadId: evt.threadId });
+      generatedImageDelivery?.setThreadId(evt.threadId);
     }
   };
 
@@ -1139,6 +1166,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
   } catch (err) {
     log.fail('stream', err);
   } finally {
+    await generatedImageDelivery?.stop();
     activePolicyFingerprints.delete(scope);
     scheduleWorkingReactionCleanup(channel, lastMsg.messageId, reactionPromise);
   }

--- a/src/bot/generated-image-delivery.ts
+++ b/src/bot/generated-image-delivery.ts
@@ -1,0 +1,260 @@
+import type { LarkChannel, SendOptions } from '@larksuite/channel';
+import { readdir, realpath, stat } from 'node:fs/promises';
+import { extname, resolve, sep } from 'node:path';
+import { log } from '../core/logger';
+
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp']);
+const DEFAULT_POLL_INTERVAL_MS = 750;
+const DEFAULT_STABLE_POLLS = 2;
+const DEFAULT_MAX_IMAGES = 6;
+
+interface CandidateState {
+  size: number;
+  mtimeMs: number;
+  stablePolls: number;
+}
+
+export interface GeneratedImageDeliveryOptions {
+  channel: Pick<LarkChannel, 'send'>;
+  chatId: string;
+  sendOpts: SendOptions;
+  rootDir: string;
+  runId: string;
+  startedAt: number;
+  imageMaxBytes: number;
+  initialThreadId?: string;
+  pollIntervalMs?: number;
+  stablePolls?: number;
+  maxImages?: number;
+}
+
+/**
+ * Watches the current Codex thread's generated_images directory and sends new
+ * images directly to Feishu. This path is intentionally independent of Codex's
+ * JSONL completion: image-generation tool output can contain several megabytes
+ * of base64 and may take minutes to POST back to the model after the PNG is
+ * already safely on disk.
+ */
+export class GeneratedImageDelivery {
+  private readonly channel: Pick<LarkChannel, 'send'>;
+  private readonly chatId: string;
+  private readonly sendOpts: SendOptions;
+  private readonly rootDir: string;
+  private readonly runId: string;
+  private readonly startedAt: number;
+  private readonly imageMaxBytes: number;
+  private readonly pollIntervalMs: number;
+  private readonly requiredStablePolls: number;
+  private readonly maxImages: number;
+  private readonly candidates = new Map<string, CandidateState>();
+  private readonly delivered = new Set<string>();
+  private readonly failed = new Set<string>();
+  private readonly ignored = new Set<string>();
+  private threadId: string | undefined;
+  private timer: NodeJS.Timeout | undefined;
+  private polling: Promise<void> | undefined;
+  private started = false;
+  private stopped = false;
+  private failureNoticeSent = false;
+
+  constructor(options: GeneratedImageDeliveryOptions) {
+    this.channel = options.channel;
+    this.chatId = options.chatId;
+    this.sendOpts = options.sendOpts;
+    this.rootDir = resolve(options.rootDir);
+    this.runId = options.runId;
+    this.startedAt = options.startedAt;
+    this.imageMaxBytes = options.imageMaxBytes;
+    this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    this.requiredStablePolls = options.stablePolls ?? DEFAULT_STABLE_POLLS;
+    this.maxImages = options.maxImages ?? DEFAULT_MAX_IMAGES;
+    if (options.initialThreadId) this.setThreadId(options.initialThreadId);
+  }
+
+  start(): void {
+    if (this.started || this.stopped) return;
+    this.started = true;
+    this.schedule(0);
+  }
+
+  setThreadId(threadId: string): void {
+    if (!isSafeThreadId(threadId)) {
+      log.warn('media', 'generated-image-thread-rejected', { runId: this.runId });
+      return;
+    }
+    if (this.threadId === threadId) return;
+    this.threadId = threadId;
+    this.candidates.clear();
+    this.ignored.clear();
+    if (this.started && !this.stopped) this.schedule(0);
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = undefined;
+    await this.polling;
+    // A run can terminate immediately after image creation. Finish the same
+    // stability checks synchronously so that the last image is not missed, but
+    // never bypass them: sending a file that is still being written would be
+    // worse than omitting it.
+    await this.pollOnce();
+    for (
+      let poll = 1;
+      poll < this.requiredStablePolls && this.candidates.size > 0;
+      poll++
+    ) {
+      await delay(this.pollIntervalMs);
+      await this.pollOnce();
+    }
+  }
+
+  private schedule(delayMs: number): void {
+    if (this.stopped) return;
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      this.polling = this.pollOnce()
+        .catch((err) => {
+          log.fail('media', err, { step: 'generated-image-poll', runId: this.runId });
+        })
+        .finally(() => {
+          this.polling = undefined;
+          this.schedule(this.pollIntervalMs);
+        });
+    }, delayMs);
+  }
+
+  private async pollOnce(): Promise<void> {
+    if (!this.threadId || this.delivered.size >= this.maxImages) return;
+    const unresolvedThreadDir = resolveThreadDir(this.rootDir, this.threadId);
+    if (!unresolvedThreadDir) return;
+
+    // Canonicalize both sides before the containment check. On macOS, paths
+    // created below /var resolve to /private/var; comparing one canonical path
+    // with one lexical path would reject every legitimate generated image.
+    // Checking the canonical thread directory also prevents a symlinked thread
+    // directory from escaping generated_images.
+    const [canonicalRootDir, threadDir] = await Promise.all([
+      realpath(this.rootDir).catch(() => undefined),
+      realpath(unresolvedThreadDir).catch(() => undefined),
+    ]);
+    if (!canonicalRootDir || !threadDir || !isPathInside(threadDir, canonicalRootDir)) return;
+
+    let entries;
+    try {
+      entries = await readdir(threadDir, { withFileTypes: true });
+    } catch (err) {
+      if (errorCode(err) === 'ENOENT') return;
+      throw err;
+    }
+
+    for (const entry of entries) {
+      if (this.delivered.size >= this.maxImages) return;
+      if (!entry.isFile() || !IMAGE_EXTENSIONS.has(extname(entry.name).toLowerCase())) continue;
+      const candidatePath = resolve(threadDir, entry.name);
+      if (
+        this.delivered.has(candidatePath) ||
+        this.failed.has(candidatePath) ||
+        this.ignored.has(candidatePath)
+      ) {
+        continue;
+      }
+
+      const info = await stat(candidatePath).catch(() => undefined);
+      if (!info?.isFile()) continue;
+      if (info.size <= 0) continue;
+      if (info.size > this.imageMaxBytes || info.mtimeMs < this.startedAt) {
+        this.ignored.add(candidatePath);
+        this.candidates.delete(candidatePath);
+        continue;
+      }
+
+      const previous = this.candidates.get(candidatePath);
+      const stablePolls =
+        previous && previous.size === info.size && previous.mtimeMs === info.mtimeMs
+          ? previous.stablePolls + 1
+          : 1;
+      this.candidates.set(candidatePath, {
+        size: info.size,
+        mtimeMs: info.mtimeMs,
+        stablePolls,
+      });
+      if (stablePolls < this.requiredStablePolls) continue;
+
+      const imagePath = await realpath(candidatePath).catch(() => undefined);
+      if (!imagePath || !isPathInside(imagePath, threadDir)) {
+        this.failed.add(candidatePath);
+        this.candidates.delete(candidatePath);
+        continue;
+      }
+
+      try {
+        const result = await this.channel.send(
+          this.chatId,
+          { image: { source: imagePath } },
+          this.sendOpts,
+        );
+        this.delivered.add(candidatePath);
+        this.candidates.delete(candidatePath);
+        log.info('media', 'generated-image-sent', {
+          runId: this.runId,
+          bytes: info.size,
+          messageId: result?.messageId,
+          replyTo: this.sendOpts.replyTo,
+          replyInThread: this.sendOpts.replyInThread === true,
+        });
+      } catch (err) {
+        // Do not retry here: an HTTP timeout can mean Feishu accepted the
+        // message but the acknowledgement was lost, and retrying would create
+        // the duplicate-image failure this fast path is meant to avoid.
+        this.failed.add(candidatePath);
+        this.candidates.delete(candidatePath);
+        log.fail('media', err, {
+          step: 'generated-image-send',
+          runId: this.runId,
+          bytes: info.size,
+        });
+        await this.sendFailureNotice();
+      }
+    }
+  }
+
+  private async sendFailureNotice(): Promise<void> {
+    if (this.failureNoticeSent) return;
+    this.failureNoticeSent = true;
+    await this.channel
+      .send(
+        this.chatId,
+        { markdown: '图片已经生成，但自动上传到飞书失败。为避免重复发送，Bot 没有自动重试。' },
+        this.sendOpts,
+      )
+      .catch(() => undefined);
+  }
+}
+
+function resolveThreadDir(rootDir: string, threadId: string): string | undefined {
+  const resolved = resolve(rootDir, threadId);
+  return isPathInside(resolved, rootDir) ? resolved : undefined;
+}
+
+function isPathInside(path: string, root: string): boolean {
+  const resolvedRoot = resolve(root);
+  const resolvedPath = resolve(path);
+  return resolvedPath === resolvedRoot || resolvedPath.startsWith(`${resolvedRoot}${sep}`);
+}
+
+function isSafeThreadId(value: string): boolean {
+  return value !== '.' && value !== '..' && /^[A-Za-z0-9._-]+$/.test(value);
+}
+
+function errorCode(err: unknown): string | undefined {
+  return typeof err === 'object' && err !== null && 'code' in err
+    ? String((err as { code?: unknown }).code)
+    : undefined;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolvePromise) => setTimeout(resolvePromise, ms));
+}

--- a/tests/unit/agent/codex-generated-images-dir.test.ts
+++ b/tests/unit/agent/codex-generated-images-dir.test.ts
@@ -1,0 +1,38 @@
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CodexAdapter } from '../../../src/agent/codex/adapter.js';
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe('CodexAdapter generated image directory', () => {
+  it('uses an explicit Codex home when configured', () => {
+    const adapter = new CodexAdapter({
+      binary: '/bin/codex',
+      profileStateDir: '/profile',
+      codexHome: '/custom-codex-home',
+    });
+    expect(adapter.getGeneratedImagesDir()).toBe(join('/custom-codex-home', 'generated_images'));
+  });
+
+  it('uses the profile-local Codex home when inheritance is disabled', () => {
+    const adapter = new CodexAdapter({
+      binary: '/bin/codex',
+      profileStateDir: '/profile',
+      inheritCodexHome: false,
+    });
+    expect(adapter.getGeneratedImagesDir()).toBe(
+      join('/profile', 'codex-home', 'generated_images'),
+    );
+  });
+
+  it('uses inherited CODEX_HOME when no profile override is configured', () => {
+    vi.stubEnv('CODEX_HOME', '/env-codex-home');
+    const adapter = new CodexAdapter({
+      binary: '/bin/codex',
+      profileStateDir: '/profile',
+    });
+    expect(adapter.getGeneratedImagesDir()).toBe(join('/env-codex-home', 'generated_images'));
+  });
+});

--- a/tests/unit/bot/generated-image-delivery.test.ts
+++ b/tests/unit/bot/generated-image-delivery.test.ts
@@ -1,0 +1,200 @@
+import { mkdir, mkdtemp, realpath, rm, symlink, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { GeneratedImageDelivery } from '../../../src/bot/generated-image-delivery.js';
+
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+});
+
+describe('GeneratedImageDelivery', () => {
+  it('sends a new stable image once and replies to the triggering message', async () => {
+    const h = await createHarness();
+    const delivery = h.delivery();
+    delivery.start();
+
+    const image = join(h.threadDir, 'exec-new.png');
+    await writeFile(image, Buffer.from([1, 2, 3]));
+    await waitFor(() => h.sent.some((item) => hasImage(item.content)));
+    await delivery.stop();
+
+    const imageMessages = h.sent.filter((item) => hasImage(item.content));
+    expect(imageMessages).toEqual([
+      {
+        chatId: 'oc_test',
+        content: { image: { source: image } },
+        options: { replyTo: 'om_trigger' },
+      },
+    ]);
+  });
+
+  it('uses the final stop scan when a run ends immediately after image creation', async () => {
+    const h = await createHarness();
+    const delivery = h.delivery();
+    delivery.start();
+
+    const image = join(h.threadDir, 'exec-at-exit.png');
+    await writeFile(image, Buffer.from([1, 2, 3]));
+    await delivery.stop();
+
+    expect(h.sent.filter((item) => hasImage(item.content))).toEqual([
+      {
+        chatId: 'oc_test',
+        content: { image: { source: image } },
+        options: { replyTo: 'om_trigger' },
+      },
+    ]);
+  });
+
+  it('ignores images that predate the current run', async () => {
+    const h = await createHarness();
+    const image = join(h.threadDir, 'exec-old.png');
+    await writeFile(image, Buffer.from([1, 2, 3]));
+    const old = new Date(Date.now() - 500);
+    await utimes(image, old, old);
+
+    const delivery = h.delivery({ startedAt: Date.now() });
+    delivery.start();
+    await delay(40);
+    await delivery.stop();
+
+    expect(h.sent).toEqual([]);
+  });
+
+  it('only observes the active Codex thread directory', async () => {
+    const h = await createHarness();
+    const otherDir = join(h.root, 'thread-other');
+    await mkdir(otherDir);
+    const delivery = h.delivery();
+    delivery.start();
+
+    await writeFile(join(otherDir, 'wrong.png'), Buffer.from([1]));
+    await writeFile(join(h.threadDir, 'right.png'), Buffer.from([2]));
+    await waitFor(() => h.sent.some((item) => hasImage(item.content)));
+    await delivery.stop();
+
+    expect(h.sent.filter((item) => hasImage(item.content))).toHaveLength(1);
+    expect(h.sent[0]?.content).toEqual({ image: { source: join(h.threadDir, 'right.png') } });
+  });
+
+  it('rejects a thread directory symlink that escapes generated_images', async () => {
+    const h = await createHarness();
+    const outside = await realpath(await mkdtemp(join(tmpdir(), 'generated-image-outside-')));
+    cleanups.push(() => rm(outside, { recursive: true, force: true }));
+    await writeFile(join(outside, 'escape.png'), Buffer.from([1, 2, 3]));
+    await symlink(outside, join(h.root, 'thread-link'), 'dir');
+
+    const delivery = h.delivery({ initialThreadId: 'thread-link' });
+    delivery.start();
+    await delay(40);
+    await delivery.stop();
+
+    expect(h.sent).toEqual([]);
+  });
+
+  it('does not retry an ambiguous failed upload and emits one failure notice', async () => {
+    const h = await createHarness({ failImages: true });
+    const delivery = h.delivery();
+    delivery.start();
+    await writeFile(join(h.threadDir, 'failed.png'), Buffer.from([1, 2, 3]));
+
+    await waitFor(() => h.sent.some((item) => hasMarkdown(item.content)));
+    await delay(30);
+    await delivery.stop();
+
+    expect(h.imageAttempts).toBe(1);
+    expect(h.sent.filter((item) => hasMarkdown(item.content))).toHaveLength(1);
+  });
+});
+
+interface SentMessage {
+  chatId: string;
+  content: unknown;
+  options: unknown;
+}
+
+interface DeliveryOverrides {
+  startedAt?: number;
+  initialThreadId?: string;
+  stablePolls?: number;
+}
+
+async function createHarness(options: { failImages?: boolean } = {}): Promise<{
+  root: string;
+  threadDir: string;
+  sent: SentMessage[];
+  readonly imageAttempts: number;
+  delivery(overrides?: DeliveryOverrides): GeneratedImageDelivery;
+}> {
+  const root = await realpath(await mkdtemp(join(tmpdir(), 'generated-image-delivery-')));
+  const threadDir = join(root, 'thread-current');
+  await mkdir(threadDir);
+  cleanups.push(() => rm(root, { recursive: true, force: true }));
+  const sent: SentMessage[] = [];
+  let imageAttempts = 0;
+  const channel = {
+    async send(chatId: string, content: unknown, optionsArg?: unknown): Promise<{ messageId: string }> {
+      if (hasImage(content)) {
+        imageAttempts++;
+        if (options.failImages) throw new Error('ambiguous timeout');
+      }
+      sent.push({ chatId, content, options: optionsArg });
+      return { messageId: `om_${sent.length}` };
+    },
+  };
+
+  return {
+    root,
+    threadDir,
+    sent,
+    get imageAttempts() {
+      return imageAttempts;
+    },
+    delivery(overrides = {}) {
+      return new GeneratedImageDelivery({
+        channel,
+        chatId: 'oc_test',
+        sendOpts: { replyTo: 'om_trigger' },
+        rootDir: root,
+        runId: 'run-test',
+        startedAt: overrides.startedAt ?? Date.now() - 100,
+        imageMaxBytes: 25 * 1024 * 1024,
+        initialThreadId: overrides.initialThreadId ?? 'thread-current',
+        pollIntervalMs: 5,
+        stablePolls: overrides.stablePolls ?? 2,
+      });
+    },
+  };
+}
+
+function hasImage(value: unknown): value is { image: { source: string } } {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      'image' in value &&
+      (value as { image?: unknown }).image,
+  );
+}
+
+function hasMarkdown(value: unknown): value is { markdown: string } {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      typeof (value as { markdown?: unknown }).markdown === 'string',
+  );
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('timed out waiting for condition');
+    await delay(5);
+  }
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## 背景

Codex 通过 `imagegen` 生成图片后，文件会先写入
`$CODEX_HOME/generated_images/<thread-id>/`。当前 Bridge 在 Codex 回合仍在运行时没有把这些文件发送到飞书的路径，因此图片即使已经生成完毕，也可能继续等待模型后续响应、网络重试或整个回合结束。

在网络不稳定或图片工具结果较大时，这段额外等待可能从数秒扩大到数分钟。一次实际排查中，图片已经落盘，但直到约 47 分钟后才被发送；瓶颈发生在图片生成之后，而不是图片生成本身。

## 根因

现有 Codex 适配器会处理文本和命令执行事件，但不会在运行过程中把 `generated_images` 中的新文件交给 channel 层。channel 层因此无法在图片准备好时直接调用已有的图片发送接口，只能依赖 Codex 后续行为或最终输出。

## 修改内容

- 由 Codex 适配器暴露实际使用的 `generated_images` 目录，兼容显式 `codexHome`、profile 隔离目录、`CODEX_HOME` 和默认用户目录。
- 在 Codex IM 回合运行期间，仅监控当前 Codex thread 对应的图片目录。
- 图片大小和修改时间连续稳定后，通过现有 channel SDK 回复到触发该回合的消息。
- 在回合结束时补做稳定性检查，避免刚生成的最后一张图片被遗漏。
- 告知 Codex 图片由 Bridge 负责发送，避免同时调用 `lark-cli` 导致重复。

## 安全与去重

- 校验 thread id，并使用 `realpath` 做根目录和 thread 目录的路径包含检查。
- 拒绝通过符号链接逃逸 `generated_images` 的目录或文件。
- 仅允许 PNG、JPEG、GIF 和 WebP，并沿用配置中的图片大小上限。
- 仅处理当前回合开始后修改的文件，每个回合最多发送 6 张。
- 同一路径最多发送一次。
- 对结果不确定的上传超时不自动重试，因为飞书可能已收到请求，盲目重试会产生重复图片；此时最多发送一次失败提示。

## 与 #113 的区别

#113 从最终 Markdown 回复中提取并发送工作区产物，执行时机在 Agent 产生最终输出之后。本 PR 针对 Codex 的 `generated_images/<thread-id>`，在回合结束前即可发送稳定的图片文件，因此能覆盖“图片已生成，但后续 Codex 响应或网络重试仍然很慢”的场景。

如果未来合并 #113，两个发送路径应统一去重语义，避免同一图片同时被快速路径和最终 Markdown 路径发送。

## 验证

- `pnpm test`：93 个测试文件、560 项测试全部通过。
- `pnpm typecheck`：通过。
- `pnpm build`：通过。
- `git diff --check`：通过。
- 在真实 Git checkout 和部署构建中均完成了上述验证。
- 最终代码已部署到真实飞书 Bot，并确认部署的 `dist/cli.js` 与本分支源码构建产物逐字节一致。
- 第一次最终版实测：图片发送时间为 `12:03:57.767`，回合结束时间为 `12:04:00.878`，提前约 3.1 秒，仅发送一次。
- 第二次最终版实测（同一会话继续编辑图片）：图片发送时间为 `12:07:11.921`，回合结束时间为 `12:08:44.389`，提前约 92.5 秒，仅发送一次。

## 影响范围

该快速发送路径仅对能提供 `generated_images` 目录的 Codex 适配器启用；Claude 和其他未实现该可选能力的 Agent 行为不变。
