### PR TITLE
fix(codex): deliver final replies outside progress streams

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lark-channel-bridge",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Bridge Feishu/Lark messenger with local CLI coding agents",
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/src/agent/codex/adapter.ts
+++ b/src/agent/codex/adapter.ts
@@ -250,7 +250,7 @@ async function* createEventStream(
 
   const earlyRuntimeError = getError();
   if (earlyRuntimeError && child.exitCode === null && child.signalCode === null) {
-    yield terminalError(`codex runtime error: ${earlyRuntimeError.message}`);
+    yield* translator.fail(`codex runtime error: ${earlyRuntimeError.message}`);
     return;
   }
 
@@ -266,24 +266,16 @@ async function* createEventStream(
     if (!translator.terminalEmitted()) {
       const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
       const detail = stderr ? `: ${stderr.slice(0, 500)}` : '';
-      yield terminalError(`codex exited with code ${exitCode}${detail}`);
+      yield* translator.fail(`codex exited with code ${exitCode}${detail}`);
     }
     return;
   }
   if (runtimeError && !translator.terminalEmitted()) {
-    yield terminalError(`codex runtime error: ${runtimeError.message}`);
+    yield* translator.fail(`codex runtime error: ${runtimeError.message}`);
     return;
   }
 
   yield* translator.finish();
-}
-
-function terminalError(message: string): AgentEvent {
-  return {
-    type: 'error',
-    message,
-    terminationReason: 'failed',
-  };
 }
 
 async function waitForExitCode(child: CodexChild): Promise<number | null> {

--- a/src/agent/codex/jsonl.ts
+++ b/src/agent/codex/jsonl.ts
@@ -12,6 +12,7 @@ export class CodexJsonlTranslator {
   private threadId: string | undefined;
   private terminal = false;
   private lastNonTerminalError: string | undefined;
+  private pendingAgentMessage: string | undefined;
   private readonly startedItems = new Set<string>();
   private drift: ProtocolDriftState = {
     unknownEvents: 0,
@@ -31,7 +32,7 @@ export class CodexJsonlTranslator {
       case 'turn.started':
         return [];
       case 'item.started':
-        return this.translateItemStarted(raw);
+        return this.prependPendingText(this.translateItemStarted(raw));
       case 'item.completed':
         return this.translateItemCompleted(raw);
       case 'agent_message':
@@ -39,7 +40,9 @@ export class CodexJsonlTranslator {
       case 'turn.completed':
         return this.translateTurnCompleted(raw);
       case 'turn.failed':
-        return this.translateTerminalError(raw, 'codex turn failed');
+        return this.prependPendingText(
+          this.translateTerminalError(raw, 'codex turn failed'),
+        );
       case 'error':
         return this.translateNonTerminalError(raw, 'codex error');
       default:
@@ -54,15 +57,25 @@ export class CodexJsonlTranslator {
     this.terminal = true;
     if (reason === 'failed') {
       const detail = this.lastNonTerminalError ? `: ${this.lastNonTerminalError}` : '';
-      return [
+      return this.prependPendingText([
         {
           type: 'error',
           message: truncate(`codex stream ended before a terminal event${detail}`, 4096),
           terminationReason: 'failed',
         },
-      ];
+      ]);
     }
-    return [{ type: 'done', threadId: this.threadId, terminationReason: reason }];
+    return this.prependPendingText([
+      { type: 'done', threadId: this.threadId, terminationReason: reason },
+    ]);
+  }
+
+  fail(message: string): AgentEvent[] {
+    if (this.terminal) return [];
+    this.terminal = true;
+    return this.prependPendingText([
+      { type: 'error', message: truncate(message, 4096), terminationReason: 'failed' },
+    ]);
   }
 
   protocolDrift(): ProtocolDriftState {
@@ -109,7 +122,7 @@ export class CodexJsonlTranslator {
     if (!item) return [];
     if (item.type === 'agent_message') {
       const message = stringValue(item.text ?? item.message);
-      return message ? [{ type: 'text', delta: message }] : [];
+      return message ? this.queueAgentMessage(message) : [];
     }
     if (item.type !== 'command_execution') return [];
     const id = stringValue(item.id);
@@ -122,25 +135,29 @@ export class CodexJsonlTranslator {
     }
     this.startedItems.delete(id);
     const exitCode = numberValue(item.exit_code);
-    return [
+    return this.prependPendingText([
       {
         type: 'tool_result',
         id,
         output: stringValue(item.output ?? item.aggregated_output ?? item.stdout) ?? '',
         isError: exitCode !== undefined && exitCode !== 0,
       },
-    ];
+    ]);
   }
 
   private translateAgentMessage(raw: Record<string, unknown>): AgentEvent[] {
     const message = stringValue(raw.message ?? raw.text);
     if (!message) return [];
-    return [{ type: 'text', delta: message }];
+    return this.queueAgentMessage(message);
   }
 
   private translateTurnCompleted(raw: Record<string, unknown>): AgentEvent[] {
     this.terminal = true;
     const events: AgentEvent[] = [];
+    if (this.pendingAgentMessage) {
+      events.push({ type: 'final_text', content: this.pendingAgentMessage });
+      this.pendingAgentMessage = undefined;
+    }
     const usage = recordValue(raw.usage);
     if (usage) {
       events.push({
@@ -155,6 +172,21 @@ export class CodexJsonlTranslator {
     }
     events.push({ type: 'done', threadId: this.threadId, terminationReason: 'normal' });
     return events;
+  }
+
+  private queueAgentMessage(message: string): AgentEvent[] {
+    const events = this.pendingAgentMessage
+      ? [{ type: 'text' as const, delta: this.pendingAgentMessage }]
+      : [];
+    this.pendingAgentMessage = message;
+    return events;
+  }
+
+  private prependPendingText(events: AgentEvent[]): AgentEvent[] {
+    if (events.length === 0 || !this.pendingAgentMessage) return events;
+    const pending = this.pendingAgentMessage;
+    this.pendingAgentMessage = undefined;
+    return [{ type: 'text', delta: pending }, ...events];
   }
 
   private translateTerminalError(raw: Record<string, unknown>, fallback: string): AgentEvent[] {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -6,6 +6,7 @@ export type { ClaudePermissionMode } from '../config/permissions';
 export type AgentEvent =
   | { type: 'system'; sessionId?: string; threadId?: string; cwd?: string; model?: string }
   | { type: 'text'; delta: string }
+  | { type: 'final_text'; content: string }
   | { type: 'thinking'; delta: string }
   | { type: 'tool_use'; id: string; name: string; input: unknown }
   | { type: 'tool_result'; id: string; output: string; isError: boolean }

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -1101,19 +1101,36 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         },
         sendOpts,
       );
-      await awaitRenderAwareStream({
-        mode: replyMode,
-        streamDone,
-        renderDone,
-        producerStarted: () => producerStarted,
-        fallback: async (state) => {
-          const body = renderText(filterForPrefs(state));
-          if (body.trim()) {
-            await channel.send(chatId, { markdown: body }, sendOpts);
-          }
-        },
-      });
+      try {
+        await awaitRenderAwareStream({
+          mode: replyMode,
+          streamDone,
+          renderDone,
+          producerStarted: () => producerStarted,
+          fallback: async (state) => {
+            if (controls.profileConfig.agentKind === 'codex') return;
+            const body = renderText(filterForPrefs(state));
+            if (body.trim()) {
+              await channel.send(chatId, { markdown: body }, sendOpts);
+            }
+          },
+        });
+      } catch (err) {
+        if (controls.profileConfig.agentKind !== 'codex') throw err;
+        log.fail('stream', err, { mode: replyMode, step: 'progress-stream' });
+      }
       await recallIfEmptyStreamedReply(channel, streamDone, filterForPrefs(latestState), scope);
+      if (controls.profileConfig.agentKind === 'codex') {
+        await sendFinalReply({
+          channel,
+          chatId,
+          scope,
+          state: finalAnswerOnlyState(filterForPrefs(latestState)),
+          replyMode,
+          sendOpts,
+          cardRenderOptions,
+        });
+      }
     } else {
       // text mode: drain the agent stream without sending anything during
       // the run, then post the final rendered text once as a plain markdown
@@ -1130,7 +1147,10 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         channel,
         chatId,
         scope,
-        state: filterForPrefs(finalState),
+        state:
+          controls.profileConfig.agentKind === 'codex'
+            ? finalAnswerOnlyState(filterForPrefs(finalState))
+            : filterForPrefs(finalState),
         replyMode,
         sendOpts,
         cardRenderOptions,
@@ -1200,31 +1220,17 @@ async function sendFinalReply(input: {
       { card: renderCard(input.state, input.cardRenderOptions) },
       input.sendOpts,
     );
+    requireMessageReceipt(result, 'card');
     log.info('outbound', 'sent', outboundLogFields(input, 'card', body, result));
   } else if (input.replyMode === 'markdown') {
     if (body.trim()) {
-      try {
-        await input.channel.stream(
-          input.chatId,
-          {
-            markdown: async (ctrl) => {
-              await ctrl.setContent(body);
-            },
-          },
-          input.sendOpts,
-        );
-        log.info('outbound', 'sent', outboundLogFields(input, 'markdown-stream', body));
-      } catch (err) {
-        log.warn('outbound', 'markdown-stream-fallback', {
-          err: err instanceof Error ? err.message : String(err),
-        });
-        const result = await input.channel.send(
-          input.chatId,
-          { markdown: body },
-          input.sendOpts,
-        );
-        log.info('outbound', 'sent', outboundLogFields(input, 'markdown', body, result));
-      }
+      const result = await input.channel.send(
+        input.chatId,
+        { markdown: body },
+        input.sendOpts,
+      );
+      requireMessageReceipt(result, 'markdown');
+      log.info('outbound', 'sent', outboundLogFields(input, 'markdown', body, result));
     }
   } else if (body.trim()) {
     const result = await input.channel.send(
@@ -1232,7 +1238,14 @@ async function sendFinalReply(input: {
       { markdown: body },
       input.sendOpts,
     );
+    requireMessageReceipt(result, 'text');
     log.info('outbound', 'sent', outboundLogFields(input, 'text', body, result));
+  }
+}
+
+function requireMessageReceipt(result: { messageId?: string }, type: string): void {
+  if (!result.messageId?.trim()) {
+    throw new Error(`final ${type} reply missing message receipt`);
   }
 }
 

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -1057,21 +1057,38 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         },
         sendOpts,
       );
-      await awaitRenderAwareStream({
-        mode: replyMode,
-        streamDone,
-        renderDone,
-        producerStarted: () => producerStarted,
-        fallback: async (state) => {
-          if (renderText(filterForPrefs(state)).trim() === '') return;
-          await channel.send(
-            chatId,
-            { card: renderCard(filterForPrefs(state), cardRenderOptions) },
-            sendOpts,
-          );
-        },
-      });
+      try {
+        await awaitRenderAwareStream({
+          mode: replyMode,
+          streamDone,
+          renderDone,
+          producerStarted: () => producerStarted,
+          fallback: async (state) => {
+            if (controls.profileConfig.agentKind === 'codex') return;
+            if (renderText(filterForPrefs(state)).trim() === '') return;
+            await channel.send(
+              chatId,
+              { card: renderCard(filterForPrefs(state), cardRenderOptions) },
+              sendOpts,
+            );
+          },
+        });
+      } catch (err) {
+        if (controls.profileConfig.agentKind !== 'codex') throw err;
+        log.fail('stream', err, { mode: replyMode, step: 'progress-stream' });
+      }
       await recallIfEmptyStreamedReply(channel, streamDone, filterForPrefs(latestState), scope);
+      if (controls.profileConfig.agentKind === 'codex') {
+        await sendFinalReply({
+          channel,
+          chatId,
+          scope,
+          state: finalAnswerOnlyState(filterForPrefs(latestState)),
+          replyMode,
+          sendOpts,
+          cardRenderOptions,
+        });
+      }
     } else if (replyMode === 'markdown') {
       let latestState: RunState = initialState;
       let producerStarted = false;

--- a/src/bot/comments.ts
+++ b/src/bot/comments.ts
@@ -335,6 +335,9 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
             case 'text':
               answer += e.delta;
               break;
+            case 'final_text':
+              answer = e.content;
+              break;
             case 'tool_use':
             case 'tool_result':
               answer = '';

--- a/src/bot/cot.ts
+++ b/src/bot/cot.ts
@@ -252,7 +252,9 @@ export class CotPublisher {
 export function finalAnswerOnlyState(state: RunState): RunState {
   return {
     ...state,
-    blocks: state.blocks.filter((b) => b.kind === 'text'),
+    blocks: state.finalText
+      ? [{ kind: 'text', content: state.finalText, streaming: false }]
+      : state.blocks.filter((b) => b.kind === 'text'),
     reasoning: { content: '', active: false },
     footer: null,
   };
@@ -350,6 +352,7 @@ export async function consumeCotEvents(
         });
         continue;
       }
+      if (evt.type === 'final_text') continue;
       if (evt.type === 'done' || evt.type === 'error') {
         closeReasoningIfNeeded();
         closeTextIfNeeded();

--- a/src/card/run-state.ts
+++ b/src/card/run-state.ts
@@ -19,6 +19,7 @@ export type Terminal = 'running' | 'done' | 'interrupted' | 'error' | 'idle_time
 
 export interface RunState {
   blocks: Block[];
+  finalText?: string;
   reasoning: { content: string; active: boolean };
   footer: FooterStatus;
   terminal: Terminal;
@@ -61,6 +62,9 @@ export function reduce(state: RunState, evt: AgentEvent): RunState {
         footer: 'streaming',
       };
     }
+
+    case 'final_text':
+      return { ...state, finalText: evt.content };
 
     case 'thinking': {
       return {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -1222,6 +1222,7 @@ async function handleDoctor(args: string, ctx: CommandContext): Promise<void> {
                   continue;
                 }
                 if (evt.type === 'text') echoText += evt.delta;
+                if (evt.type === 'final_text') echoText = evt.content;
                 state = reduce(state, evt);
                 await flush();
                 // Don't wait for stdout to close — some claude versions hang
@@ -1248,6 +1249,7 @@ async function handleDoctor(args: string, ctx: CommandContext): Promise<void> {
           continue;
         }
         if (evt.type === 'text') echoText += evt.delta;
+        if (evt.type === 'final_text') echoText = evt.content;
         state = reduce(state, evt);
         if (state.terminal !== 'running') break;
       }

--- a/tests/integration/bot/markdown-stream-startup-failure.test.ts
+++ b/tests/integration/bot/markdown-stream-startup-failure.test.ts
@@ -2,6 +2,7 @@ import type { NormalizedMessage } from '@larksuite/channel';
 import { realpath } from 'node:fs/promises';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AgentEvent } from '../../../src/agent/types.js';
 import { createDefaultProfileConfig } from '../../../src/config/profile-schema.js';
 import { log } from '../../../src/core/logger.js';
 import { SessionStore } from '../../../src/session/store.js';
@@ -61,13 +62,14 @@ interface FakeLarkChannel {
   disconnect(): Promise<void>;
   getChatMode(chatId: string): Promise<'group' | 'topic'>;
   getConnectionStatus(): { state: 'connected'; reconnectAttempts: number };
-  send(chatId: string, content: unknown, options?: unknown): Promise<void>;
+  send(chatId: string, content: unknown, options?: unknown): Promise<{ messageId: string }>;
   stream(chatId: string, input: unknown, options?: unknown): Promise<void>;
   addReaction(messageId: string, emojiType: string): Promise<string>;
   removeReaction(messageId: string, reactionId: string): Promise<void>;
 }
 
 type StreamFn = FakeLarkChannel['stream'];
+type SendFn = FakeLarkChannel['send'];
 
 const cleanups: Array<() => Promise<void>> = [];
 
@@ -156,11 +158,106 @@ describe('markdown stream startup failures', () => {
       ),
     );
   }, 10_000);
+
+  it('sends one dedicated non-streaming final reply after progress completes', async () => {
+    const visibleProgress: string[] = [];
+    const h = await createHarness({
+      events: [
+        { type: 'text', delta: 'progress update' },
+        { type: 'final_text', content: 'FINAL_SENTINEL' },
+        { type: 'done', terminationReason: 'normal' },
+      ],
+      stream: async (_chatId, input) => {
+        const producer = (input as {
+          markdown?: (ctrl: { setContent(markdown: string): Promise<void> }) => Promise<void>;
+        }).markdown;
+        await producer?.({
+          setContent: vi.fn(async (markdown: string) => {
+            visibleProgress.push(markdown);
+          }),
+        });
+      },
+    });
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(message('om_final', 'run'));
+    await waitFor(() => h.channel.sent.length === 1);
+
+    expect(visibleProgress.some((markdown) => markdown.includes('progress update'))).toBe(true);
+    expect(h.channel.sent).toHaveLength(1);
+    expect(lastMarkdown(h.channel)).toContain('FINAL_SENTINEL');
+    expect(h.channel.sent[0]?.options).toMatchObject({ replyTo: 'om_final' });
+  });
+
+  it('still sends the final reply when the progress stream fails at completion', async () => {
+    const fail = vi.spyOn(log, 'fail').mockImplementation(() => {});
+    const h = await createHarness({
+      events: [
+        { type: 'text', delta: 'progress update' },
+        { type: 'final_text', content: 'FINAL_AFTER_STREAM_FAILURE' },
+        { type: 'done', terminationReason: 'normal' },
+      ],
+      stream: async (_chatId, input) => {
+        const producer = (input as {
+          markdown?: (ctrl: { setContent(markdown: string): Promise<void> }) => Promise<void>;
+        }).markdown;
+        await producer?.({ setContent: vi.fn(async () => {}) });
+        throw new Error('progress stream failed');
+      },
+    });
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(message('om_stream_fail', 'run'));
+    await waitFor(() => h.channel.sent.length === 1);
+
+    expect(lastMarkdown(h.channel)).toContain('FINAL_AFTER_STREAM_FAILURE');
+    expect(
+      fail.mock.calls.some(
+        (call) =>
+          call[0] === 'stream' &&
+          call[1] instanceof Error &&
+          call[1].message === 'progress stream failed' &&
+          (call[2] as { step?: string } | undefined)?.step === 'progress-stream',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not record delivery when the final send has no message receipt', async () => {
+    const fail = vi.spyOn(log, 'fail').mockImplementation(() => {});
+    const info = vi.spyOn(log, 'info').mockImplementation(() => {});
+    const h = await createHarness({
+      events: [
+        { type: 'final_text', content: 'FINAL_WITHOUT_RECEIPT' },
+        { type: 'done', terminationReason: 'normal' },
+      ],
+      send: async () => ({ messageId: '' }),
+      stream: async (_chatId, input) => {
+        const producer = (input as {
+          markdown?: (ctrl: { setContent(markdown: string): Promise<void> }) => Promise<void>;
+        }).markdown;
+        await producer?.({ setContent: vi.fn(async () => {}) });
+      },
+    });
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(message('om_no_receipt', 'run'));
+    await waitFor(() =>
+      fail.mock.calls.some(
+        (call) => call[1] instanceof Error && call[1].message.includes('missing message receipt'),
+      ),
+    );
+
+    expect(
+      info.mock.calls.some((call) => call[0] === 'outbound' && call[1] === 'sent'),
+    ).toBe(false);
+  });
 });
 
 async function createHarness(options: {
   reactionCreate?: () => Promise<{ data: { reaction_id: string } }>;
   stream?: StreamFn;
+  send?: SendFn;
+  events?: readonly AgentEvent[];
 } = {}): Promise<{
   tmp: TmpProfile;
   channel: FakeLarkChannel;
@@ -200,16 +297,18 @@ async function createHarness(options: {
   const agent = new FakeAgentAdapter({
     id: 'codex',
     displayName: 'Codex',
-    events: [
-      [
-        {
-          type: 'error',
-          message: 'codex exited with code 1: Error loading config.toml',
-          terminationReason: 'failed',
-        },
-      ],
-      [{ type: 'done', terminationReason: 'normal' }],
-    ],
+    events: options.events
+      ? [options.events]
+      : [
+          [
+            {
+              type: 'error',
+              message: 'codex exited with code 1: Error loading config.toml',
+              terminationReason: 'failed',
+            },
+          ],
+          [{ type: 'done', terminationReason: 'normal' }],
+        ],
   });
   const channel = createFakeLarkChannel(options);
   sdkMock.channel = channel;
@@ -246,9 +345,10 @@ async function startTestBridge(h: {
   cleanups.push(() => bridge.disconnect());
 }
 
-function createFakeLarkChannel(options: {
+function createFakeLarkChannel(harnessOptions: {
   reactionCreate?: () => Promise<{ data: { reaction_id: string } }>;
   stream?: StreamFn;
+  send?: SendFn;
 } = {}): FakeLarkChannel {
   const handlers: MessageHandlerMap = {};
   const sent: FakeLarkChannel['sent'] = [];
@@ -273,7 +373,7 @@ function createFakeLarkChannel(options: {
             get: vi.fn(async () => ({ data: { items: [] } })),
           },
           messageReaction: {
-            create: vi.fn(options.reactionCreate ?? (async () => ({ data: { reaction_id: 'reaction_1' } }))),
+            create: vi.fn(harnessOptions.reactionCreate ?? (async () => ({ data: { reaction_id: 'reaction_1' } }))),
             delete: vi.fn(async () => ({})),
           },
         },
@@ -292,8 +392,10 @@ function createFakeLarkChannel(options: {
     },
     async send(chatId, content, options) {
       sent.push({ chatId, content, options });
+      if (harnessOptions.send) return harnessOptions.send(chatId, content, options);
+      return { messageId: `sent_${sent.length}` };
     },
-    stream: options.stream ?? (async () => {
+    stream: harnessOptions.stream ?? (async () => {
       await new Promise<void>(() => {});
     }),
     async addReaction(messageId, emojiType) {

--- a/tests/integration/bot/markdown-stream-startup-failure.test.ts
+++ b/tests/integration/bot/markdown-stream-startup-failure.test.ts
@@ -251,6 +251,45 @@ describe('markdown stream startup failures', () => {
       info.mock.calls.some((call) => call[0] === 'outbound' && call[1] === 'sent'),
     ).toBe(false);
   });
+
+  it('sends one dedicated final reply card after progress completes in card mode', async () => {
+    const progressCards: unknown[] = [];
+    const h = await createHarness({
+      messageReply: 'card',
+      events: [
+        { type: 'text', delta: 'progress update' },
+        { type: 'final_text', content: 'FINAL_SENTINEL' },
+        { type: 'done', terminationReason: 'normal' },
+      ],
+      stream: async (_chatId, input) => {
+        const producer = (input as {
+          card?: { producer?: (ctrl: { update(next: unknown): Promise<void> }) => Promise<void> };
+        }).card?.producer;
+        await producer?.({
+          update: vi.fn(async (next: unknown) => {
+            progressCards.push(next);
+          }),
+        });
+      },
+    });
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(message('om_card_final', 'run'));
+    await waitFor(() => h.channel.sent.length === 1);
+
+    // Intermediate agent messages stream as progress; the final answer never
+    // leaks into the progress card (it is held back for the dedicated reply).
+    const progressJson = JSON.stringify(progressCards);
+    expect(progressJson).toContain('progress update');
+    expect(progressJson).not.toContain('FINAL_SENTINEL');
+
+    // The terminal answer arrives as exactly one non-streaming card send.
+    expect(h.channel.sent).toHaveLength(1);
+    const finalJson = JSON.stringify(h.channel.sent[0]?.content);
+    expect(finalJson).toContain('FINAL_SENTINEL');
+    expect(finalJson).not.toContain('progress update');
+    expect(h.channel.sent[0]?.options).toMatchObject({ replyTo: 'om_card_final' });
+  });
 });
 
 async function createHarness(options: {
@@ -258,6 +297,7 @@ async function createHarness(options: {
   stream?: StreamFn;
   send?: SendFn;
   events?: readonly AgentEvent[];
+  messageReply?: 'card' | 'markdown' | 'text';
 } = {}): Promise<{
   tmp: TmpProfile;
   channel: FakeLarkChannel;
@@ -284,6 +324,7 @@ async function createHarness(options: {
     codex: {
       binaryPath: '/usr/local/bin/codex',
     },
+    ...(options.messageReply ? { preferences: { messageReply: options.messageReply } } : {}),
   });
   const profileConfig = {
     ...baseProfileConfig,

--- a/tests/integration/comments/comment-run-flow.test.ts
+++ b/tests/integration/comments/comment-run-flow.test.ts
@@ -252,7 +252,9 @@ async function createHarness(options: {
           : { sessionId: sessionIds[index] ?? `session-${index}` }),
         cwd: tmp.workspace,
       },
-      { type: 'text', delta: text },
+      agentKind === 'codex'
+        ? { type: 'final_text', content: text }
+        : { type: 'text', delta: text },
       {
         type: 'done',
         ...(agentKind === 'codex'
@@ -579,7 +581,7 @@ function codexRunWithProgress(threadId: string, progress: string, finalAnswer: s
       input: { command: 'lark-cli docs +fetch --api-version v2 --doc doc-token --doc-format markdown' },
     },
     { type: 'tool_result', id: `${threadId}-tool`, output: 'doc body', isError: false },
-    { type: 'text', delta: finalAnswer },
+    { type: 'final_text', content: finalAnswer },
     { type: 'done', threadId, terminationReason: 'normal' },
   ];
 }

--- a/tests/process/codex-adapter.test.ts
+++ b/tests/process/codex-adapter.test.ts
@@ -61,7 +61,7 @@ describe('CodexAdapter process contract', () => {
     expect(run.runId).toBe('run-fresh');
     expect(await collect(run.events)).toEqual([
       { type: 'system', threadId: 'thread-fresh' },
-      { type: 'text', delta: 'hello user' },
+      { type: 'final_text', content: 'hello user' },
       { type: 'done', threadId: 'thread-fresh', terminationReason: 'normal' },
     ]);
     const record = await readRecord(fake.recordPath);
@@ -340,7 +340,7 @@ describe('CodexAdapter process contract', () => {
 
     expect(await collect(run.events)).toEqual([
       { type: 'system', threadId: 'thread-retry' },
-      { type: 'text', delta: 'after retry' },
+      { type: 'final_text', content: 'after retry' },
       { type: 'done', threadId: 'thread-retry', terminationReason: 'normal' },
     ]);
   });

--- a/tests/unit/agent/codex-jsonl.test.ts
+++ b/tests/unit/agent/codex-jsonl.test.ts
@@ -44,9 +44,7 @@ describe('Codex JSONL translator', () => {
         isError: false,
       },
     ]);
-    expect(t.translate({ type: 'agent_message', message: 'hello' })).toEqual([
-      { type: 'text', delta: 'hello' },
-    ]);
+    expect(t.translate({ type: 'agent_message', message: 'hello' })).toEqual([]);
     expect(
       t.translate({
         type: 'turn.completed',
@@ -58,6 +56,7 @@ describe('Codex JSONL translator', () => {
         },
       }),
     ).toEqual([
+      { type: 'final_text', content: 'hello' },
       {
         type: 'usage',
         inputTokens: 12,
@@ -90,7 +89,39 @@ describe('Codex JSONL translator', () => {
           text: 'hello from item',
         },
       }),
-    ).toEqual([{ type: 'text', delta: 'hello from item' }]);
+    ).toEqual([]);
+    expect(t.translate({ type: 'turn.completed' })).toEqual([
+      { type: 'final_text', content: 'hello from item' },
+      { type: 'done', terminationReason: 'normal' },
+    ]);
+  });
+
+  it('streams earlier agent messages but reserves the last one as the final answer', () => {
+    const t = new CodexJsonlTranslator();
+
+    expect(t.translate({ type: 'agent_message', message: 'progress one' })).toEqual([]);
+    expect(t.translate({ type: 'agent_message', message: 'progress two' })).toEqual([
+      { type: 'text', delta: 'progress one' },
+    ]);
+    expect(
+      t.translate({
+        type: 'item.started',
+        item: { id: 'cmd-after-progress', type: 'command_execution', command: 'pwd' },
+      }),
+    ).toEqual([
+      { type: 'text', delta: 'progress two' },
+      {
+        type: 'tool_use',
+        id: 'cmd-after-progress',
+        name: 'command_execution',
+        input: { command: 'pwd' },
+      },
+    ]);
+    expect(t.translate({ type: 'agent_message', message: 'final answer' })).toEqual([]);
+    expect(t.translate({ type: 'turn.completed' })).toEqual([
+      { type: 'final_text', content: 'final answer' },
+      { type: 'done', terminationReason: 'normal' },
+    ]);
   });
 
   it('treats missing command exit codes as successful command results', () => {
@@ -147,10 +178,9 @@ describe('Codex JSONL translator', () => {
       }),
     ).toEqual([]);
     expect(t.terminalEmitted()).toBe(false);
-    expect(t.translate({ type: 'agent_message', message: 'after retry' })).toEqual([
-      { type: 'text', delta: 'after retry' },
-    ]);
+    expect(t.translate({ type: 'agent_message', message: 'after retry' })).toEqual([]);
     expect(t.translate({ type: 'turn.completed' })).toEqual([
+      { type: 'final_text', content: 'after retry' },
       { type: 'done', threadId: 'thread-retry', terminationReason: 'normal' },
     ]);
   });


### PR DESCRIPTION
## Summary

- add a distinct `final_text` event for Codex and reserve the last agent message until `turn.completed`
- keep Markdown streaming for intermediate progress, then deliver the terminal answer with an independent non-streaming `send`
- continue final delivery even when the progress stream fails, and only log delivery after a non-empty Lark message receipt is returned
- preserve the same final-answer semantics for cloud-document comments, CoT output, and `/doctor`

## Why

Long Codex runs, especially runs that fan out to sub-agents, can complete locally while the Feishu/Lark progress stream remains on “generating”. The final answer previously shared the same streaming lifecycle, so a stream finalization failure could prevent the completed answer from reaching the user.

This change separates progress transport from terminal delivery. Earlier Codex agent messages remain progress; the last message becomes the final answer only after the turn has completed.

## Validation

- `vitest run`: 91 test files, 555 tests passed
- `tsc --noEmit`: passed
- `tsup`: passed
- `git diff --check`: passed
- live Feishu E2E: a 13m40s Codex run using 7 sub-agents completed, returned a non-empty message ID, and the final reply was read back from the message API with the correct parent reply and complete start/end sentinels

## Scope and related work

This PR addresses the Codex Markdown final-reply path and leaves Claude behavior unchanged. It is related to #152. PR #183 focuses on oversized card payloads and async fallback budgets; this change is complementary and focuses on Codex final-message semantics plus receipt-backed terminal delivery.

No environment-specific deployment code, identifiers, or private workspace data is included.
