### PR TITLE
fix(wizard): don't print the creator line twice

### DIFF
--- a/src/bot/wizard.ts
+++ b/src/bot/wizard.ts
@@ -93,13 +93,6 @@ export async function runRegistrationWizard(): Promise<AppConfig> {
   // unconditional bypass on the very first message — no config edit needed.
   // `allowedUsers` / `allowedChats` / `admins` stay empty (= nobody outside
   // the creator) until the operator tightens via `/config`.
-  if (operatorOpenId) {
-    console.log(`  Creator: ${operatorOpenId} (Lark 应用 owner，自动豁免所有访问控制)`);
-  } else {
-    console.log(
-      '  ⚠️ 未拿到扫码用户的 open_id；首次启动时 bridge 会自行调 application/v6 API 解析当前 owner。',
-    );
-  }
 
   const cfg: AppConfig = {
     accounts: {


### PR DESCRIPTION
## What

`runRegistrationWizard` prints the `Creator:` line — and its `open_id` fallback warning — twice, in two consecutive blocks with slightly different wording.

## What the user sees

After a successful QR scan:

```
✓ 应用创建成功
  App ID:  cli_xxx
  Tenant:  feishu
  Creator: ou_xxx (Lark 应用 owner，自动豁免访问控制)
  Creator: ou_xxx (Lark 应用 owner，自动豁免所有访问控制)
```

It's the last thing a new user reads before the bot starts, so it's a slightly unfortunate first impression — it reads like something went wrong.

## Root cause

`ee6218c` ("feat: optimize access control") added the block that sits **after** the access-control comment. `8addd57` ("feat: add Codex support with profile runtime and access controls") then added a second block in the **summary** position, next to `App ID` / `Tenant`, without removing the first. Every commit since has carried both.

To confirm on `main`:

```bash
grep -c "Creator:" src/bot/wizard.ts   # → 2
```

## The fix

Removes the block after the comment; keeps the one grouped with `App ID` / `Tenant`, where it reads as part of the same summary. Nothing else changes — no behaviour change beyond the line printing once.

## One thing worth your call

The two blocks aren't identical, so this does pick a winner:

|  | Kept (summary position) | Removed (after the comment) |
|---|---|---|
| Creator line | `自动豁免访问控制` | `自动豁免所有访问控制` |
| `open_id` fallback | `启动后会通过应用 owner API 解析创建者。` | `首次启动时 bridge 会自行调 application/v6 API 解析当前 owner。` |

I kept the summary-position one because it reads as part of the `App ID` / `Tenant` block, and because the comment just above it already names `application/v6/applications` — so the detail in the removed wording isn't lost to a reader of the code.

If you'd rather keep the other wording (`所有` is arguably more precise), I'm happy to flip it — just say which and I'll update the PR.

## Testing

- `pnpm typecheck` — clean
- `pnpm test` — 556 tests pass, unchanged
- Ran the wizard path locally against an isolated `LARK_CHANNEL_HOME`; the creator line now prints once.

---

<sub>Found while reading the wizard for an unrelated downstream change. Thanks for open-sourcing this — the QR registration flow is genuinely nice to use.</sub>
