### PR TITLE
fix(config): persist profile deployment mode

### DIFF
--- a/src/config/profile-store.ts
+++ b/src/config/profile-store.ts
@@ -49,6 +49,7 @@ type StoredProfileConfig = Pick<
   ProfileConfig,
   | 'schemaVersion'
   | 'agentKind'
+  | 'mode'
   | 'accounts'
   | 'secrets'
   | 'preferences'
@@ -86,6 +87,7 @@ function serializeProfileConfig(profile: ProfileConfig): StoredProfileConfig {
   return {
     schemaVersion: profile.schemaVersion,
     agentKind: profile.agentKind,
+    mode: profile.mode,
     accounts: profile.accounts,
     ...(profile.secrets ? { secrets: profile.secrets } : {}),
     preferences: profile.preferences,

--- a/tests/integration/commands/profile-config-command.test.ts
+++ b/tests/integration/commands/profile-config-command.test.ts
@@ -59,6 +59,7 @@ describe('profile-aware account and config commands', () => {
     const h = await createHarness();
 
     await h.command('/config submit', {
+      deploy_mode: 'team',
       message_reply: 'text',
       show_tool_calls: 'hide',
       max_concurrent_runs: '7',
@@ -73,6 +74,7 @@ describe('profile-aware account and config commands', () => {
     expect(root.schemaVersion).toBe(2);
     expect(root.activeProfile).toBe('claude');
     expect(root.profiles['codex-dev']).toBeDefined();
+    expect(root.profiles.claude?.mode).toBe('team');
     expect(root.profiles.claude?.preferences).toMatchObject({
       messageReply: 'text',
       messageReplyMigrated: true,


### PR DESCRIPTION
## Summary

Fixes #194.

- Persist the profile `mode` field when saving root v2 config.
- Extend the `/config submit` regression test to cover saving `deploy_mode: "team"`.

## Verification

- `pnpm exec vitest run --config vitest.local.config.ts tests/integration/commands/profile-config-command.test.ts tests/unit/config/profile-store.test.ts tests/unit/config/profile-schema.test.ts` (41 passed)
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

Note: I also ran the full local suite with a temporary Vitest config because this clone lives under another repo with its own `vitest.config.ts`. It reported 553 passed and 3 failures in `tests/integration/cli/start-codex-legacy-config.test.ts` from the existing Windows codex shim issue (`'sh' is not recognized...`), which appears unrelated to this change and is already covered by open PR #197.