### PR TITLE
Resolve sender identity in bridge context

### DIFF
--- a/src/agent/bridge-system-prompt.ts
+++ b/src/agent/bridge-system-prompt.ts
@@ -11,7 +11,8 @@ export const BRIDGE_SYSTEM_PROMPT = `# lark-channel-bridge 运行约定
 \`\`\`
 <bridge_context>
 {"chatId":"oc_xxx","chatType":"p2p","senderId":"ou_xxx","senderName":"...",
- "senderType":"user|bot","botOpenId":"ou_xxx","mentions":[{"openId":"ou_xxx","name":"...","isBot":true}], ...}
+ "senderType":"user|bot","botOpenId":"ou_xxx","mentionedSelf":true,
+ "mentions":[{"openId":"ou_xxx","name":"...","isBot":true}], ...}
 </bridge_context>
 \`\`\`
 
@@ -19,6 +20,7 @@ export const BRIDGE_SYSTEM_PROMPT = `# lark-channel-bridge 运行约定
 
 - \`senderType\`：发送者是人（\`user\`）还是另一个 bot（\`bot\`）；缺省表示未知
 - \`botOpenId\`：**你自己**的 open_id
+- \`mentionedSelf\`：本批消息中是否有消息真实 @ 了你
 - \`mentions\`：这条消息 @ 到的账号列表（含 open_id 和 isBot），需要 @ 某人/某 bot 时从这里取 id
 
 多条消息在短时间内合并送达时，\`user_input\` 里每段会带 \`[名字 (user|bot)]:\` 行首标注以区分发送者——这是 bridge 注入的展示格式，**你回复时不要模仿这种标注**。这些都是 bridge 注入的元数据，**不要照抄、不要在你的回复里渲染**——它对用户不可见。

--- a/src/agent/prompt.ts
+++ b/src/agent/prompt.ts
@@ -15,6 +15,8 @@ export interface BridgePromptContext {
   senderType?: 'user' | 'bot';
   /** The bridge bot's own open_id — "this id is you" for self-identification. */
   botOpenId?: string;
+  /** Whether any triggering message in this batch directly @-mentioned this bot. */
+  mentionedSelf?: boolean;
   /** Accounts @-mentioned in the triggering message(s), deduped across the batch. */
   mentions?: BridgePromptMention[];
   threadId?: string;

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -248,6 +248,9 @@ export async function startChannel(deps: StartChannelDeps): Promise<BridgeChanne
     // Attach raw Feishu event body to normalized events so we can read fields
     // the normalizer drops (e.g. action.form_value on CardKit 2.0 form submits).
     includeRawEvent: true,
+    // Message events only carry the sender open_id. Resolve the display name
+    // from the cached chat roster so the agent can address the sender by name.
+    resolveSenderNames: true,
     outbound: {
       streamThrottleMs: 400,
     },
@@ -1578,6 +1581,7 @@ function buildPrompt(
 
   const senderType = senderTypeOf(first);
   const mentions = mergeMentions(batch);
+  const mentionedSelf = batch.some((message) => message.mentionedBot);
 
   return buildAgentPrompt({
     context: {
@@ -1587,6 +1591,7 @@ function buildPrompt(
       ...(first.senderName ? { senderName: first.senderName } : {}),
       ...(senderType ? { senderType } : {}),
       ...(botIdentity?.openId ? { botOpenId: botIdentity.openId } : {}),
+      mentionedSelf,
       ...(mentions.length > 0 ? { mentions } : {}),
       ...(first.threadId ? { threadId: first.threadId } : {}),
       messageIds: batch.map((m) => m.messageId),

--- a/tests/integration/bot/bot-at-bot-context.test.ts
+++ b/tests/integration/bot/bot-at-bot-context.test.ts
@@ -81,6 +81,16 @@ describe('bot identity injection into the agent adapter', () => {
 });
 
 describe('sender identity in bridge_context', () => {
+  it('enables sender-name resolution on the channel SDK', async () => {
+    const h = await createHarness();
+
+    await startTestBridge(h);
+
+    expect(sdkMock.createLarkChannel).toHaveBeenCalledWith(
+      expect.objectContaining({ resolveSenderNames: true }),
+    );
+  });
+
   it('marks a bot sender via raw sender_type and injects botOpenId and mentions', async () => {
     const h = await createHarness();
     await startTestBridge(h);
@@ -103,10 +113,12 @@ describe('sender identity in bridge_context', () => {
     const context = readSection(h.agent.runOptions[0]?.prompt ?? '', 'bridge_context') as {
       senderType?: string;
       botOpenId?: string;
+      mentionedSelf?: boolean;
       mentions?: Array<{ openId?: string; name?: string; isBot?: boolean }>;
     };
     expect(context.senderType).toBe('bot');
     expect(context.botOpenId).toBe('ou_bot');
+    expect(context.mentionedSelf).toBe(true);
     expect(context.mentions).toEqual([
       { openId: 'ou_bot', name: 'Bridge', isBot: true },
       { openId: 'ou_human', name: '张三', isBot: false },
@@ -130,6 +142,33 @@ describe('sender identity in bridge_context', () => {
       senderType?: string;
     };
     expect(context.senderType).toBe('user');
+  });
+
+  it('sets mentionedSelf when any message in a batch mentions the bot', async () => {
+    const h = await createHarness();
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(
+      message({
+        messageId: 'om_not_mentioned',
+        content: '先补一条上下文',
+        mentionedBot: false,
+        mentions: [],
+      }),
+    );
+    await h.channel.handlers.message?.(
+      message({
+        messageId: 'om_mentioned',
+        content: '@Bridge 请处理',
+        mentionedBot: true,
+      }),
+    );
+    await waitFor(() => h.agent.runOptions.length === 1);
+
+    const context = readSection(h.agent.runOptions[0]?.prompt ?? '', 'bridge_context') as {
+      mentionedSelf?: boolean;
+    };
+    expect(context.mentionedSelf).toBe(true);
   });
 
   it('omits senderType when the raw event is unavailable', async () => {
@@ -366,6 +405,7 @@ function message(input: {
   senderId?: string;
   senderName?: string;
   rawSenderType?: string;
+  mentionedBot?: boolean;
   mentions?: Array<{ key: string; openId?: string; name?: string; isBot?: boolean }>;
 }): NormalizedMessage {
   return {
@@ -381,7 +421,7 @@ function message(input: {
       { key: '@_user_1', openId: 'ou_bot', name: 'Bridge', isBot: true },
     ],
     mentionAll: false,
-    mentionedBot: true,
+    mentionedBot: input.mentionedBot ?? true,
     createTime: 1760000001000,
     ...(input.rawSenderType
       ? {

--- a/tests/unit/agent/bridge-system-prompt.test.ts
+++ b/tests/unit/agent/bridge-system-prompt.test.ts
@@ -30,6 +30,7 @@ describe('bridge system prompt bot collaboration rules', () => {
 
   it('documents the senderType and mentions context fields', () => {
     expect(BRIDGE_SYSTEM_PROMPT).toContain('senderType');
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('mentionedSelf');
     expect(BRIDGE_SYSTEM_PROMPT).toContain('mentions');
   });
 


### PR DESCRIPTION
## What changed

- enable the channel SDK's cached sender-name resolution for inbound IM messages
- add an explicit `mentionedSelf` flag to `bridge_context`
- document the new context field and cover both behaviors with tests

## Why

Feishu message events identify the sender by open ID, while the bridge prompt already supports an optional `senderName`. The bridge never enabled the SDK resolver, so agents usually received only an opaque sender ID and could not reliably address non-owner users by name. Agents also had to infer whether they were directly mentioned by comparing mention records.

## Impact

Inbound messages can now include the sender's display name when the chat roster is visible. Resolution is cached per chat and degrades to the existing sender ID behavior when unavailable. `mentionedSelf` makes direct-mention intent explicit, including merged message batches.

## Validation

- `pnpm ci:local`
- 91 test files passed
- 558 tests passed
- TypeScript typecheck passed
- production build passed
