### PR TITLE
MB-191: attach log snapshots to Bug issue creation

### DIFF
--- a/src/agent/bridge-system-prompt.ts
+++ b/src/agent/bridge-system-prompt.ts
@@ -106,6 +106,10 @@ bridge 会给你的子进程注入当前运行 profile 的环境变量:
 
 配置文件可能是多 profile 结构,不要假设根层一定有旧版单 profile 的 \`accounts.app\`;确实需要读取配置时按当前 profile 取值,且不要输出密钥。
 
+## Multica Bug Issue 建票
+
+创建 Multica Bug Issue 时，不要直接运行 \`multica issue create\`。必须改用 \`lark-channel-bridge multica-issue-create <原 multica issue create 参数>\`，让 bridge 在建票时自动附带最近运行日志快照。非 Bug Issue 仍可直接使用普通 \`multica issue create\`。
+
 ## 飞书 OAuth 授权（\`lark-cli auth login\`）
 
 授权流程要让 \`lark-cli\` 进程一直活到用户在浏览器里点完为止。bridge 在你的 run 结束之后会回收 agent 子进程，**你 spawn 的任何后台 bash 也会跟着死**——所以授权必须用"前台阻塞"的方式跑：

--- a/src/cli/commands/multica-issue.ts
+++ b/src/cli/commands/multica-issue.ts
@@ -38,7 +38,7 @@ export async function runMulticaIssueCreate(
     }
 
     const createArgs = ['issue', 'create', ...args];
-    if (snapshot) createArgs.push('--attachment', snapshot.path);
+    if (snapshot) createArgs.push('--attachment', snapshot.path, '--allow-external-file');
 
     const result = (deps.spawnSync ?? spawnProcessSync)('multica', createArgs, { stdio: 'inherit' });
     return typeof result.status === 'number' ? result.status : 1;

--- a/src/cli/commands/multica-issue.ts
+++ b/src/cli/commands/multica-issue.ts
@@ -1,0 +1,137 @@
+import type { SpawnSyncOptions, SpawnSyncReturns } from 'node:child_process';
+import { mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join } from 'node:path';
+import { spawnProcessSync } from '../../platform/spawn';
+
+const DEFAULT_RESULTS_DIR = '/Users/YUYSONG/Agents/AIOS Framework/results';
+const BUG_ISSUE_PATTERN = /\bbug\b|\bfix\b|修复|排查|卡死|失败|不工作/i;
+const SNAPSHOT_LINE_LIMIT = 500;
+
+type SpawnSync = (
+  command: string,
+  args: readonly string[],
+  options: SpawnSyncOptions,
+) => SpawnSyncReturns<Buffer>;
+
+interface LogSnapshot {
+  path: string;
+  dir: string;
+}
+
+interface MulticaIssueCreateDeps {
+  resultsDir?: string;
+  spawnSync?: SpawnSync;
+  warn?: (message: string) => void;
+}
+
+export async function runMulticaIssueCreate(
+  args: readonly string[],
+  deps: MulticaIssueCreateDeps = {},
+): Promise<number> {
+  const warn = deps.warn ?? ((message: string) => console.warn(message));
+  let snapshot: LogSnapshot | undefined;
+
+  try {
+    if (await isBugIssueCreate(args)) {
+      snapshot = await createLatestLogSnapshot(deps.resultsDir ?? DEFAULT_RESULTS_DIR, warn);
+    }
+
+    const createArgs = ['issue', 'create', ...args];
+    if (snapshot) createArgs.push('--attachment', snapshot.path);
+
+    const result = (deps.spawnSync ?? spawnProcessSync)('multica', createArgs, { stdio: 'inherit' });
+    return typeof result.status === 'number' ? result.status : 1;
+  } finally {
+    if (snapshot) {
+      await rm(snapshot.dir, { recursive: true, force: true });
+    }
+  }
+}
+
+export async function isBugIssueCreate(args: readonly string[]): Promise<boolean> {
+  const title = getOptionValue(args, '--title');
+  if (title && BUG_ISSUE_PATTERN.test(title)) return true;
+
+  const descriptionFile = getOptionValue(args, '--description-file');
+  if (!descriptionFile) return false;
+
+  try {
+    const description = await readFile(descriptionFile, 'utf8');
+    return BUG_ISSUE_PATTERN.test(description);
+  } catch {
+    return false;
+  }
+}
+
+async function createLatestLogSnapshot(
+  resultsDir: string,
+  warn: (message: string) => void,
+): Promise<LogSnapshot | undefined> {
+  const latestLog = await findLatestLogFile(resultsDir);
+  if (!latestLog) {
+    warn(`Warning: no log file found under ${resultsDir}; creating Bug issue without a log snapshot.`);
+    return undefined;
+  }
+
+  const content = await readFile(latestLog, 'utf8');
+  const lines = content.split(/\r?\n/);
+  const tail = lines.slice(-SNAPSHOT_LINE_LIMIT).join('\n');
+  if (!tail.trim()) {
+    warn(`Warning: latest log file ${latestLog} is empty; creating Bug issue without a log snapshot.`);
+    return undefined;
+  }
+
+  const dir = await mkdtemp(join(tmpdir(), 'lark-channel-multica-bug-log-'));
+  const stamp = new Date().toISOString().replace(/[-:.TZ]/g, '');
+  const path = join(dir, `bug-log-snapshot-${stamp}-${process.pid}.log`);
+  await writeFile(path, tail, 'utf8');
+  return { path, dir };
+}
+
+async function findLatestLogFile(resultsDir: string): Promise<string | undefined> {
+  let names: string[];
+  try {
+    names = await readdir(resultsDir);
+  } catch {
+    return undefined;
+  }
+
+  let latest: { path: string; mtimeMs: number } | undefined;
+  for (const name of names) {
+    if (!name.endsWith('.log')) continue;
+    const path = join(resultsDir, name);
+    let fileStat;
+    try {
+      fileStat = await stat(path);
+    } catch {
+      continue;
+    }
+    if (!fileStat.isFile()) continue;
+    if (!latest || fileStat.mtimeMs > latest.mtimeMs) latest = { path, mtimeMs: fileStat.mtimeMs };
+  }
+
+  return latest?.path;
+}
+
+function getOptionValue(args: readonly string[], option: string): string | undefined {
+  const prefix = `${option}=`;
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (!arg) continue;
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length);
+    if (arg === option) {
+      const value = args[i + 1];
+      if (value && !value.startsWith('--')) return value;
+    }
+  }
+  return undefined;
+}
+
+export function multicaIssueCreateArgsFromProcessArgv(argv: readonly string[]): string[] {
+  const commandIndex = argv.findIndex((arg) => basename(arg) === 'multica-issue-create' || arg === 'multica-issue-create');
+  if (commandIndex >= 0) return argv.slice(commandIndex + 1);
+
+  const subcommandIndex = argv.indexOf('multica-issue-create');
+  return subcommandIndex >= 0 ? argv.slice(subcommandIndex + 1) : [];
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import pkg from '../../package.json';
 import { formatAgentPreflightDiagnostic, getAgentPreflightDiagnostic } from '../agent/preflight';
 import { runMigrate } from './commands/migrate';
+import { multicaIssueCreateArgsFromProcessArgv, runMulticaIssueCreate } from './commands/multica-issue';
 import { runKillCli, runPs } from './commands/ps';
 import {
   runSecretsGet,
@@ -66,6 +67,16 @@ program
   .option('--agent <kind>', 'agent kind for legacy v1 profile migration (claude or codex)')
   .action(async (opts: { config?: string; profile?: string; agent?: string }) => {
     await runMigrate(opts);
+  });
+
+program
+  .command('multica-issue-create')
+  .description('Create a Multica issue, automatically attaching a recent log snapshot for Bug issues')
+  .allowUnknownOption(true)
+  .allowExcessArguments(true)
+  .argument('[args...]', 'arguments passed to `multica issue create`')
+  .action(async () => {
+    process.exitCode = await runMulticaIssueCreate(multicaIssueCreateArgsFromProcessArgv(process.argv));
   });
 
 const profile = program

--- a/tests/unit/agent/bridge-system-prompt.test.ts
+++ b/tests/unit/agent/bridge-system-prompt.test.ts
@@ -37,6 +37,11 @@ describe('bridge system prompt bot collaboration rules', () => {
     expect(BRIDGE_SYSTEM_PROMPT).toContain('[名字 (user|bot)]');
     expect(BRIDGE_SYSTEM_PROMPT).toContain('不要模仿');
   });
+
+  it('requires the bridge Multica wrapper for Bug Issue creation', () => {
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('lark-channel-bridge multica-issue-create');
+    expect(BRIDGE_SYSTEM_PROMPT).toContain('自动附带最近运行日志快照');
+  });
 });
 
 describe('buildBridgeSystemPrompt', () => {

--- a/tests/unit/cli/index-registration.test.ts
+++ b/tests/unit/cli/index-registration.test.ts
@@ -16,4 +16,11 @@ describe('CLI command registration', () => {
     const appSecretOptions = source.match(/--app-secret <secret>/g) ?? [];
     expect(appSecretOptions.length).toBeGreaterThanOrEqual(3);
   });
+
+  it('registers the Multica issue create wrapper command', async () => {
+    const source = await readFile(join(process.cwd(), 'src', 'cli', 'index.ts'), 'utf8');
+
+    expect(source).toMatch(/\.command\(['"]multica-issue-create['"]\)/);
+    expect(source).toContain('runMulticaIssueCreate');
+  });
 });

--- a/tests/unit/cli/multica-issue.test.ts
+++ b/tests/unit/cli/multica-issue.test.ts
@@ -58,6 +58,7 @@ describe('runMulticaIssueCreate', () => {
     expect(status).toBe(0);
     const args = captured.mock.calls[0]![1] as string[];
     expect(args.slice(0, 4)).toEqual(['issue', 'create', '--title', 'Bug: tool call failed']);
+    expect(args).toContain('--allow-external-file');
     expect(attachmentPath).toMatch(/bug-log-snapshot-\d+-\d+\.log$/);
     expect(snapshot.startsWith('line 11\n')).toBe(true);
     expect(snapshot).toContain('line 510');

--- a/tests/unit/cli/multica-issue.test.ts
+++ b/tests/unit/cli/multica-issue.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { SpawnSyncOptions, SpawnSyncReturns } from 'node:child_process';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runMulticaIssueCreate } from '../../../src/cli/commands/multica-issue';
+
+type SpawnSyncMock = (
+  command: string,
+  args: readonly string[],
+  options: SpawnSyncOptions,
+) => SpawnSyncReturns<Buffer>;
+
+function spawnResult(status: number): SpawnSyncReturns<Buffer> {
+  return {
+    pid: 123,
+    output: [],
+    stdout: Buffer.alloc(0),
+    stderr: Buffer.alloc(0),
+    status,
+    signal: null,
+  };
+}
+
+describe('runMulticaIssueCreate', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'bridge-multica-issue-test-'));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('attaches a unique tail snapshot for Bug issues', async () => {
+    const resultsDir = join(tempDir, 'results');
+    await mkdir(resultsDir);
+    await writeFile(join(resultsDir, 'old.log'), 'old log\n', 'utf8');
+    const latest = join(resultsDir, 'latest.log');
+    await writeFile(latest, Array.from({ length: 510 }, (_, index) => `line ${index + 1}`).join('\n'), 'utf8');
+    await writeFile(join(resultsDir, 'newer.json'), '{"not":"a log"}\n', 'utf8');
+
+    let snapshot = '';
+    let attachmentPath = '';
+    const captured = vi.fn<SpawnSyncMock>((command, args) => {
+      const cliArgs = args as string[];
+      attachmentPath = cliArgs[cliArgs.indexOf('--attachment') + 1] ?? '';
+      snapshot = readFileSync(attachmentPath, 'utf8');
+      return spawnResult(0);
+    });
+    const status = await runMulticaIssueCreate(['--title', 'Bug: tool call failed'], {
+      resultsDir,
+      spawnSync: captured,
+    });
+
+    expect(status).toBe(0);
+    const args = captured.mock.calls[0]![1] as string[];
+    expect(args.slice(0, 4)).toEqual(['issue', 'create', '--title', 'Bug: tool call failed']);
+    expect(attachmentPath).toMatch(/bug-log-snapshot-\d+-\d+\.log$/);
+    expect(snapshot.startsWith('line 11\n')).toBe(true);
+    expect(snapshot).toContain('line 510');
+    await expect(stat(attachmentPath)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+
+  it('does not attach logs for non-Bug issues', async () => {
+    const resultsDir = join(tempDir, 'results');
+    await mkdir(resultsDir);
+    await writeFile(join(resultsDir, 'latest.log'), 'TOOL_CALL\n', 'utf8');
+    const captured = vi.fn<SpawnSyncMock>(() => spawnResult(0));
+
+    await runMulticaIssueCreate(['--title', 'Add a settings page'], {
+      resultsDir,
+      spawnSync: captured,
+    });
+
+    const args = captured.mock.calls[0]![1] as string[];
+    expect(args).not.toContain('--attachment');
+  });
+
+  it('warns and continues without an attachment when no logs exist', async () => {
+    const resultsDir = join(tempDir, 'missing-results');
+    const captured = vi.fn<SpawnSyncMock>(() => spawnResult(0));
+    const warn = vi.fn();
+
+    const status = await runMulticaIssueCreate(['--title=Bug: broken'], {
+      resultsDir,
+      spawnSync: captured,
+      warn,
+    });
+
+    expect(status).toBe(0);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no log file found'));
+    const args = captured.mock.calls[0]![1] as string[];
+    expect(args).not.toContain('--attachment');
+  });
+});


### PR DESCRIPTION
## Summary\n- Add a bridge CLI wrapper for `multica issue create` that attaches the latest AIOS `.log` tail snapshot for Bug issues.\n- Keep non-Bug issue creation unchanged and warn/continue when no log is available.\n- Update bridge prompt guidance so agents use the wrapper for Bug issue creation.\n\n## Tests\n- `npm run typecheck`\n- `npm run test:unit -- tests/unit/cli/multica-issue.test.ts tests/unit/cli/index-registration.test.ts tests/unit/agent/bridge-system-prompt.test.ts`\n- `npm run build`\n\nNote: local working tree already had unrelated unstaged changes; this PR contains only commit `037cd3a`.