### PR TITLE
Emit one-way callback identity fingerprints

### DIFF
--- a/src/card/dispatcher.ts
+++ b/src/card/dispatcher.ts
@@ -6,6 +6,7 @@ import type { PendingQueue } from '../bot/pending-queue';
 import type { ProcessPool } from '../bot/process-pool';
 import type { CallbackAuth } from './callback-auth';
 import { runCommandHandler, type CommandContext, type Controls } from '../commands';
+import { authorizedIdentityFingerprint } from '../core/identity-fingerprint';
 import { log } from '../core/logger';
 import { canUseDm, canUseGroup } from '../policy/access';
 import type { RunExecutor } from '../runtime/run-executor';
@@ -87,7 +88,17 @@ export async function handleCardAction(deps: CardDispatchDeps): Promise<void> {
     if (isSignedBridgeCallback(payload) && !verifyBridgeToken(deps, payload, scope, cmd)) {
       return;
     }
-    log.info('cardAction', 'cmd', { cmd, scope });
+    // Emit one-way identities only after the normal bridge access policy has
+    // approved the click. Optional local telemetry can authorize a target-
+    // specific callback without receiving raw provider identifiers.
+    log.info('cardAction', 'cmd', {
+      cmd,
+      scope,
+      identityFingerprintVersion: 'v1',
+      chatFingerprint: authorizedIdentityFingerprint('chat', chatId),
+      operatorFingerprint: authorizedIdentityFingerprint('operator', operatorId),
+      messageFingerprint: authorizedIdentityFingerprint('message', deps.evt.messageId),
+    });
     const msg = makeFakeMsg(deps.evt, threadId);
 
     const ctx: CommandContext = {

--- a/src/core/identity-fingerprint.ts
+++ b/src/core/identity-fingerprint.ts
@@ -1,0 +1,19 @@
+import { createHash } from 'node:crypto';
+
+export type IdentityFingerprintKind = 'chat' | 'operator' | 'message';
+
+const DOMAIN = 'lark-channel-bridge:authorized-identity:v1';
+
+/**
+ * Stable, one-way identity for access-checked telemetry consumers.
+ *
+ * The kind is part of the preimage so the same raw value cannot be correlated
+ * across identity classes. Raw provider identifiers remain inside the bridge.
+ */
+export function authorizedIdentityFingerprint(
+  kind: IdentityFingerprintKind,
+  value: string,
+): string {
+  if (!value) throw new Error(`missing ${kind} identity`);
+  return `sha256:${createHash('sha256').update(`${DOMAIN}\0${kind}\0${value}`, 'utf8').digest('hex')}`;
+}

--- a/tests/integration/card/callback-dispatch.test.ts
+++ b/tests/integration/card/callback-dispatch.test.ts
@@ -1,5 +1,5 @@
 import type { CardActionEvent } from '@larksuite/channel';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ActiveRuns } from '../../../src/bot/active-runs.js';
 import type { ChatModeCache } from '../../../src/bot/chat-mode-cache.js';
 import { PendingQueue } from '../../../src/bot/pending-queue.js';
@@ -8,6 +8,7 @@ import { CallbackNonceStore } from '../../../src/card/callback-store.js';
 import { handleCardAction } from '../../../src/card/dispatcher.js';
 import type { Controls } from '../../../src/commands/index.js';
 import { createDefaultProfileConfig } from '../../../src/config/profile-schema.js';
+import { log } from '../../../src/core/logger.js';
 import { SessionStore } from '../../../src/session/store.js';
 import { WorkspaceStore } from '../../../src/workspace/store.js';
 import { FakeAgentAdapter, type FakeAgentRun } from '../../helpers/fake-agent.js';
@@ -18,6 +19,7 @@ const cleanups: Array<() => Promise<void>> = [];
 
 describe('signed card callback dispatch', () => {
   afterEach(async () => {
+    vi.restoreAllMocks();
     await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
   });
 
@@ -43,6 +45,28 @@ describe('signed card callback dispatch', () => {
     });
 
     expect(deniedRun.stopped).toBe(false);
+  });
+
+  it('emits one-way identities after an authorized command callback', async () => {
+    const h = await createHarness();
+    const activeRun = h.agent.run({ runId: 'run-active', prompt: 'running' }) as FakeAgentRun;
+    h.activeRuns.register('oc_group', activeRun);
+    const info = vi.spyOn(log, 'info');
+
+    await h.dispatch({
+      cmd: 'stop',
+      __bridge_cb: true,
+      bridge_token: h.token('stop'),
+    });
+
+    expect(info).toHaveBeenCalledWith('cardAction', 'cmd', {
+      cmd: 'stop',
+      scope: 'oc_group',
+      identityFingerprintVersion: 'v1',
+      chatFingerprint: 'sha256:c0d49291450e14813b509a81e8fb672ce0794a2c7991e345170b05af4cba4ee7',
+      operatorFingerprint: 'sha256:1fd2465f8c78bd60e46eff793ca548fdfc49cbda13c849f1212cfafaa256fdfc',
+      messageFingerprint: 'sha256:92622a77472b21a43a4358ff0a12cb80e00631044d3d73d58f3c5b75c11c9bdf',
+    });
   });
 
   it('forwards signed bridge callbacks without leaking auth fields into the agent payload', async () => {

--- a/tests/unit/core/identity-fingerprint.test.ts
+++ b/tests/unit/core/identity-fingerprint.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { authorizedIdentityFingerprint } from '../../../src/core/identity-fingerprint.js';
+
+describe('authorized identity fingerprint', () => {
+  it('produces stable domain-separated SHA-256 values', () => {
+    expect(authorizedIdentityFingerprint('chat', 'oc_group')).toBe(
+      'sha256:c0d49291450e14813b509a81e8fb672ce0794a2c7991e345170b05af4cba4ee7',
+    );
+    expect(authorizedIdentityFingerprint('operator', 'ou_operator')).toBe(
+      'sha256:1fd2465f8c78bd60e46eff793ca548fdfc49cbda13c849f1212cfafaa256fdfc',
+    );
+    expect(authorizedIdentityFingerprint('message', 'om_card')).toBe(
+      'sha256:92622a77472b21a43a4358ff0a12cb80e00631044d3d73d58f3c5b75c11c9bdf',
+    );
+  });
+
+  it('rejects missing identities', () => {
+    expect(() => authorizedIdentityFingerprint('chat', '')).toThrow('missing chat identity');
+  });
+});


### PR DESCRIPTION
## What changed

- Add domain-separated SHA-256 fingerprints for access-approved callback chat, operator, and message identities.
- Include the one-way values in structured command callback telemetry without exposing raw provider identifiers.
- Add unit vectors and an integration assertion at the authorized callback boundary.

## Why

Optional local telemetry consumers need stable one-way identifiers to authorize downstream callback processing. Keeping this contract upstream prevents package upgrades from silently removing a local-only patch.

## Security

- Fingerprints are emitted only after the normal bridge access policy approves the callback.
- Identity kind and versioned domain are included in each hash preimage to prevent cross-class correlation.
- Raw provider identifiers are not passed to telemetry consumers.

## Validation

- `pnpm ci:local`
- 96 test files / 598 tests passed
- Typecheck and production build passed
