### PR TITLE
fix(windows): schtasks codepage garbling and visible console window

### DIFF
--- a/src/daemon/paths.ts
+++ b/src/daemon/paths.ts
@@ -95,6 +95,14 @@ export function windowsLauncherCmdPath(profile: string = paths.profile): string 
   return join(paths.appDir, 'daemon', serviceProfileId(profile), 'launcher.cmd');
 }
 
+/**
+ * The VBS wrapper that launches launcher.cmd with a hidden console window.
+ * Task Scheduler runs this instead of the .cmd directly so the daemon
+ * doesn't pop a visible console on the user's desktop.
+ */
+export function windowsLauncherVbsPath(profile: string = paths.profile): string {
+  return join(paths.appDir, 'daemon', serviceProfileId(profile), 'launcher.vbs');
+}
 // === Daemon log paths (platform-agnostic) ===
 
 /**

--- a/src/daemon/schtasks.ts
+++ b/src/daemon/schtasks.ts
@@ -8,6 +8,7 @@ import {
   daemonStdoutPath,
   windowsTaskName,
   windowsLauncherCmdPath,
+  windowsLauncherVbsPath,
 } from './paths';
 import { paths } from '../config/paths';
 
@@ -71,6 +72,29 @@ async function writeLauncherCmd(profile: string, runArgs: string[] = ['run']): P
   await writeFile(cmdPath, content, 'utf8');
 }
 
+/**
+ * Generate a VBS wrapper that runs the launcher .cmd with a hidden
+ * console window (intWindowStyle = 0). bWaitOnReturn = True so the
+ * wscript process stays alive until the daemon exits, letting Task
+ * Scheduler track the task as Running and kill the full process tree
+ * on /End.
+ */
+export function buildLauncherVbs(cmdPath: string): string {
+  // VBS string escaping: double every embedded double-quote.
+  const escaped = cmdPath.replace(/"/g, '""');
+  return [
+    `CreateObject("WScript.Shell").Run "cmd /c ""${escaped}""", 0, True`,
+    '',
+  ].join('\r\n');
+}
+
+async function writeLauncherVbs(profile: string): Promise<void> {
+  const content = buildLauncherVbs(windowsLauncherCmdPath(profile));
+  const vbsPath = windowsLauncherVbsPath(profile);
+  await mkdir(dirname(vbsPath), { recursive: true });
+  await writeFile(vbsPath, content, 'utf8');
+}
+
 interface SchtasksResult {
   ok: boolean;
   stderr: string;
@@ -78,7 +102,17 @@ interface SchtasksResult {
 }
 
 function runSchtasks(args: string[]): SchtasksResult {
-  const r = spawnSync('schtasks', args, { encoding: 'utf8' });
+  // Force UTF-8 codepage so schtasks emits English field names regardless
+  // of the system's OEM codepage. On CJK Windows (e.g. cp936/GBK) the
+  // default output is localized, and Node decoding it as UTF-8 produces
+  // garbage that breaks regexes like /Status:\s+Running/.
+  // Using shell:'cmd.exe' lets Node handle the /d /s /c quoting so the
+  // && chain and >nul redirection work correctly even when args contain
+  // embedded double-quotes (e.g. the /TR path in installTask).
+  const r = spawnSync(`chcp 65001 >nul && schtasks ${args.join(' ')}`, {
+    encoding: 'utf8',
+    shell: 'cmd.exe',
+  });
   return {
     ok: r.status === 0,
     stderr: r.stderr ?? '',
@@ -99,6 +133,7 @@ export async function installTask(
   runArgs: string[] = ['run'],
 ): Promise<SchtasksResult> {
   await writeLauncherCmd(profile, runArgs);
+  await writeLauncherVbs(profile);
   return runSchtasks([
     '/Create',
     '/F',
@@ -109,7 +144,7 @@ export async function installTask(
     '/TN',
     windowsTaskName(profile),
     '/TR',
-    `"${windowsLauncherCmdPath(profile)}"`,
+    `"${windowsLauncherVbsPath(profile)}"`,
   ]);
 }
 
@@ -189,9 +224,12 @@ export async function waitUntilStopped(profile: string, timeoutMs = 5000): Promi
 
 export async function deleteTask(profile: string): Promise<SchtasksResult> {
   const r = runSchtasks(['/Delete', '/F', '/TN', windowsTaskName(profile)]);
-  // Remove the launcher script too; best-effort.
+  // Remove the launcher scripts too; best-effort.
   if (existsSync(windowsLauncherCmdPath(profile))) {
     await rm(windowsLauncherCmdPath(profile), { force: true });
+  }
+  if (existsSync(windowsLauncherVbsPath(profile))) {
+    await rm(windowsLauncherVbsPath(profile), { force: true });
   }
   return r;
 }


### PR DESCRIPTION
## Problem

Two Windows-specific bugs in the Task Scheduler daemon adapter:

### 1. `status` always reports "not running" on CJK Windows

`runSchtasks()` spawned `schtasks` directly and decoded stdout as UTF-8. On Chinese Windows the OEM codepage is 936 (GBK), so `schtasks` emits localized field names in GBK. Node's UTF-8 decoder produces garbage, breaking regexes like `/Status:\s+Running/`.

**Repro:** On a Chinese Windows machine, run `lark-channel-bridge start`, then `lark-channel-bridge status` — it always says "bot 当前没在后台运行" even though the bot is alive.

**Root cause verified:** `spawnSync('schtasks', ['/Query', '/V', '/FO', 'LIST', ...], { encoding: 'utf8' })` returns GBK bytes decoded as UTF-8 → garbled text → regex miss.

### 2. Daemon pops a visible CMD console window

`schtasks /TR` pointed at `launcher.cmd` directly, so Task Scheduler opened an interactive console on the user's desktop. Closing the window killed the bot.

## Fix

### Codepage fix

Wrap every `schtasks` invocation in `chcp 65001 >nul && schtasks ...` via `shell: 'cmd.exe'`, forcing UTF-8 output with stable English field names regardless of the system locale.

### Hidden window fix

Generate a `launcher.vbs` wrapper (`WScript.Shell.Run` with `intWindowStyle=0`, `bWaitOnReturn=True`) and point `/TR` at it. The daemon now runs fully hidden; wscript stays alive so Task Scheduler correctly tracks the Running state and kills the full process tree on `/End`.

## Changes

- `src/daemon/paths.ts`: add `windowsLauncherVbsPath()`
- `src/daemon/schtasks.ts`:
  - `runSchtasks()`: force codepage 65001 via `shell: 'cmd.exe'`
  - `buildLauncherVbs()` + `writeLauncherVbs()`: generate VBS hidden-window wrapper
  - `installTask()`: write VBS + point `/TR` at `.vbs` instead of `.cmd`
  - `deleteTask()`: clean up both `.cmd` and `.vbs`

## Testing

- `pnpm typecheck` passes
- `pnpm test`: 610/618 pass; the 8 failures are pre-existing (macOS launchd tests on Windows, missing codex binary) — unrelated to this change
- Service-related tests (`service-profile.test.ts`, `kill-os-managed.test.ts`): 14/14 pass
- Manually verified `chcp 65001 && schtasks /Query /V /FO LIST` returns English output on cp936 system
- Manually verified VBS wrapper hides the console window