### PR TITLE
feat: configurable description for groups created via /new chat

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -341,6 +341,7 @@ async function handleNewChat(rawName: string, ctx: CommandContext): Promise<void
       channel: ctx.channel,
       name,
       inviteOpenId: ctx.msg.senderId,
+      description: ctx.controls.cfg.preferences?.newChatDescription,
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -144,6 +144,13 @@ export interface AppPreferences {
    * Cloud-doc comments still require @-mention unconditionally.
    */
   requireMentionInGroup?: boolean;
+  /**
+   * Description applied to group chats created via `/new chat`. Useful as a
+   * stable marker so bridge-created groups stay identifiable (searchable in
+   * Lark, visible in chat settings) even after the group is renamed.
+   * Undefined = no description (the previous behavior).
+   */
+  newChatDescription?: string;
   /** Access control — user/chat allowlists + admin gating. See AppAccess. */
   access?: AppAccess;
   /**

--- a/tests/unit/bot/group.test.ts
+++ b/tests/unit/bot/group.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { defaultChatName } from '../../../src/bot/group.js';
+import type { LarkChannel } from '@larksuite/channel';
+import { createBoundChat, defaultChatName } from '../../../src/bot/group.js';
 
 describe('group chat helpers', () => {
   afterEach(() => {
@@ -11,5 +12,36 @@ describe('group chat helpers', () => {
     vi.setSystemTime(new Date(2026, 4, 25, 16, 52, 0));
 
     expect(defaultChatName('Codex')).toBe('Codex · 5-25 16:52');
+  });
+
+  it('passes the description through to channel.createChat', async () => {
+    const createChat = vi.fn().mockResolvedValue({ chatId: 'oc_test' });
+    const channel = { createChat } as unknown as LarkChannel;
+
+    await createBoundChat({
+      channel,
+      name: 'Claude Code · 5-25 16:52',
+      inviteOpenId: 'ou_user',
+      description: 'Claude Code session group',
+    });
+
+    expect(createChat).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'Claude Code session group' }),
+    );
+  });
+
+  it('omits the description when not configured', async () => {
+    const createChat = vi.fn().mockResolvedValue({ chatId: 'oc_test' });
+    const channel = { createChat } as unknown as LarkChannel;
+
+    await createBoundChat({
+      channel,
+      name: 'Claude Code · 5-25 16:52',
+      inviteOpenId: 'ou_user',
+    });
+
+    expect(createChat).toHaveBeenCalledWith(
+      expect.objectContaining({ description: undefined }),
+    );
   });
 });


### PR DESCRIPTION
## Motivation

Groups created with `/new chat` currently have an empty description. In practice it's useful to stamp bridge-created groups with a stable marker (e.g. `Claude Code session group`) so they stay identifiable — searchable in Lark, visible in chat settings — even after the group gets renamed to a topic-specific name later.

The plumbing already exists: `createBoundChat()` accepts a `description` and forwards it to `channel.createChat()`, but `handleNewChat()` never passes one.

## Changes

- Add optional `preferences.newChatDescription` config key (documented via schema JSDoc, consistent with the other preference keys).
- `handleNewChat()` threads it into `createBoundChat()`.
- Unit tests: description is passed through to `channel.createChat`, and omitted when unset.

Default behavior is unchanged when the key is not configured.

## Testing

- `pnpm typecheck` passes
- `pnpm vitest run tests/unit/bot/group.test.ts` — 3/3 pass
- Full `pnpm test`: 618 passed; the 2 failures (`tests/unit/cli/preflight.test.ts`, `tests/integration/cli/secrets-profile.test.ts`) also fail on unmodified `main` in my environment — they read the developer's real `~/.lark-channel` profile, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)