### PR TITLE
feat: select runtime access by actor

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ If you'd rather not do it inside Feishu, `/invite` and `/config` write the match
         "allowedUsers": ["ou_xxxxxxxxxxxxx"],
         "allowedChats": ["oc_xxxxxxxxxxxxx"],
         "admins": ["ou_xxxxxxxxxxxxx"],
+        "agentUsers": ["ou_xxxxxxxxxxxxx"],
         "requireMentionInGroup": true
       }
     }
@@ -291,7 +292,7 @@ If you'd rather not do it inside Feishu, `/invite` and `/config` write the match
 }
 ```
 
-`allowedUsers` / `admins` take user `open_id`s; `allowedChats` takes group `chat_id`s. The easiest way to find an ID by hand: have the person message the bot (or `@` it in the group), then check the active profile's log:
+`allowedUsers` / `admins` / `agentUsers` take user `open_id`s; `allowedChats` takes group `chat_id`s. `agentUsers` is a runtime permission tier, not an admission list: actors in it use `permissions.maxAccess`, while every other actor that passed the normal access checks uses `permissions.defaultAccess`. Keep the default read-only and the maximum at the intended Agent access level when using this split. The easiest way to find an ID by hand: have the person message the bot (or `@` it in the group), then check the active profile's log:
 
 ```bash
 grep '"event":"enter"' ~/.lark-channel/profiles/<profile>/logs/bridge-$(date +%Y%m%d).jsonl | tail -5

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -43,7 +43,7 @@ import type {
 } from '../config/profile-schema';
 import { effectiveLarkCliIdentity } from '../config/profile-schema';
 import { resolveAppPaths } from '../config/app-paths';
-import { accessToClaudePermissionMode } from '../config/permissions';
+import { accessToClaudePermissionMode, accessToCodexSandbox } from '../config/permissions';
 import {
   canRunAdminCommand,
   canUseDm,
@@ -72,7 +72,7 @@ import { isAlive, readAndPrune, resolveTarget } from '../runtime/registry';
 import { readUiSidecar } from '../ui/sidecar';
 import type { SessionStore } from '../session/store';
 import { resolveWorkingDirectory } from '../policy/workspace';
-import { evaluateRunPolicy } from '../policy/run-policy';
+import { evaluateRunPolicy, requestedAccessForActor } from '../policy/run-policy';
 import type { ProcessPool } from '../bot/process-pool';
 import type { RunExecutor } from '../runtime/run-executor';
 import { RunRejected } from '../runtime/errors';
@@ -750,19 +750,21 @@ function selectedResumeCwd(ctx: CommandContext): string | undefined {
 
 function runtimeAccessStatus(
   profileConfig: ProfileConfig,
+  actorId: string,
 ): { label: string; value: string } {
+  const access = requestedAccessForActor(profileConfig, actorId);
   if (profileConfig.agentKind === 'claude') {
     return {
       label: 'permission',
       value: accessToClaudePermissionMode(
-        profileConfig.permissions.defaultAccess,
+        access,
         profileConfig.permissions,
       ),
     };
   }
   return {
     label: 'sandbox',
-    value: `${profileConfig.sandbox.defaultMode}/${profileConfig.sandbox.maxMode}`,
+    value: accessToCodexSandbox(access),
   };
 }
 
@@ -813,7 +815,7 @@ async function handleStatus(_args: string, ctx: CommandContext): Promise<void> {
     emptySessionText: isCodex ? '(未建立)' : undefined,
     sessionStale: !isCodex && Boolean(cwd && sess && sess.cwd !== cwd),
     agentName: ctx.agent.displayName,
-    runtimeAccess: runtimeAccessStatus(ctx.controls.profileConfig),
+    runtimeAccess: runtimeAccessStatus(ctx.controls.profileConfig, ctx.msg.senderId),
     larkCliStatus: await larkCliStatus(ctx),
     activeRun: Boolean(ctx.activeRuns.get(ctx.scope)),
     activeScopes: ctx.activeRuns.scopes().filter((scope) => !scope.startsWith('comment:')),
@@ -1147,7 +1149,7 @@ async function handleDoctor(args: string, ctx: CommandContext): Promise<void> {
     );
     return;
   }
-  const runtimeAccess = runtimeAccessStatus(ctx.controls.profileConfig);
+  const runtimeAccess = runtimeAccessStatus(ctx.controls.profileConfig, ctx.msg.senderId);
   const doctorReport = (echoCheck: string): string =>
     buildDoctorReport(ctx, {
       workspaceCheck: `ok (${workspace.cwdRealpath})`,
@@ -1278,7 +1280,7 @@ function buildDoctorReport(
     ? `${queue.active}/${queue.cap} active, ${queue.waiting} waiting`
     : 'unknown';
   const cwd = effectiveWorkspaceCwd(ctx);
-  const runtimeAccess = runtimeAccessStatus(ctx.controls.profileConfig);
+  const runtimeAccess = runtimeAccessStatus(ctx.controls.profileConfig, ctx.msg.senderId);
   const access =
     ctx.msg.chatType === 'p2p'
       ? canUseDm(ctx.controls.profileConfig, ctx.controls, ctx.msg.senderId)

--- a/src/config/config-ops.ts
+++ b/src/config/config-ops.ts
@@ -87,6 +87,7 @@ export async function saveAccessConfig(
             allowedUsers: access.allowedUsers,
             allowedChats: access.allowedChats,
             admins: access.admins,
+            agentUsers: access.agentUsers,
             ...(access.chatRequireMention && Object.keys(access.chatRequireMention).length > 0
               ? { chatRequireMention: access.chatRequireMention }
               : {}),
@@ -111,6 +112,7 @@ export async function saveAccessConfig(
         allowedUsers: access.allowedUsers.length,
         allowedChats: access.allowedChats.length,
         admins: access.admins.length,
+        agentUsers: access.agentUsers.length,
       });
       return access;
     });

--- a/src/config/profile-schema.ts
+++ b/src/config/profile-schema.ts
@@ -21,6 +21,11 @@ export interface ProfileAccess {
   allowedUsers: string[];
   allowedChats: string[];
   admins: string[];
+  /**
+   * open_id allowlist for actors that receive the profile's maximum runtime
+   * access. Other allowed actors receive permissions.defaultAccess.
+   */
+  agentUsers: string[];
   requireMentionInGroup: boolean;
   /**
    * Per-chat override of {@link requireMentionInGroup}, keyed by chat_id.
@@ -295,6 +300,7 @@ function normalizeAccess(
     allowedUsers: stringArray(access?.allowedUsers),
     allowedChats: stringArray(access?.allowedChats),
     admins: stringArray(access?.admins),
+    agentUsers: stringArray(access?.agentUsers),
     requireMentionInGroup: access?.requireMentionInGroup ?? legacyRequireMentionInGroup ?? true,
     // Omit when empty so configs without per-chat overrides stay clean.
     ...(Object.keys(chatRequireMention).length > 0 ? { chatRequireMention } : {}),

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -84,6 +84,11 @@ export interface AppAccess {
    * (/account, /config, /exit, /reconnect, /doctor, /cd, /ws, /doc,
    * /invite, /remove). */
   admins?: string[];
+  /**
+   * open_id list whose runs use permissions.maxAccess. Allowed actors not in
+   * this list use permissions.defaultAccess.
+   */
+  agentUsers?: string[];
   /** Per-chat @-mention override (chat_id → bool); overrides the global
    * requireMentionInGroup for the listed chats. */
   chatRequireMention?: Record<string, boolean>;

--- a/src/policy/fingerprint.ts
+++ b/src/policy/fingerprint.ts
@@ -49,6 +49,7 @@ export function accessPolicyDigest(access: ProfileConfig['access']): string {
     admins: [...access.admins].sort(),
     allowedChats: [...access.allowedChats].sort(),
     allowedUsers: [...access.allowedUsers].sort(),
+    agentUsers: [...access.agentUsers].sort(),
     requireMentionInGroup: access.requireMentionInGroup,
   });
 }

--- a/src/policy/run-policy.ts
+++ b/src/policy/run-policy.ts
@@ -86,6 +86,15 @@ export type RunPolicyResult = RunPolicyAllow | RunPolicyReject;
 
 const DEFAULT_TTL_MS = 5 * 60 * 1000;
 
+export function requestedAccessForActor(
+  profileConfig: Pick<ProfileConfig, 'access' | 'permissions'>,
+  actorId: string,
+): AccessMode {
+  return profileConfig.access.agentUsers.includes(actorId)
+    ? profileConfig.permissions.maxAccess
+    : profileConfig.permissions.defaultAccess;
+}
+
 export function evaluateRunPolicy(input: RunPolicyInput): RunPolicyResult {
   if (!input.access.ok) {
     return reject('access-denied', '当前用户无权发起运行。');
@@ -105,7 +114,7 @@ export function evaluateRunPolicy(input: RunPolicyInput): RunPolicyResult {
   }
 
   const accessMode = clampAccess(
-    input.profileConfig.permissions.defaultAccess,
+    requestedAccessForActor(input.profileConfig, input.scope.actorId),
     input.profileConfig.permissions.maxAccess,
     input.capability.permissions.maxAccess,
   );

--- a/tests/integration/commands/doctor-status.test.ts
+++ b/tests/integration/commands/doctor-status.test.ts
@@ -56,6 +56,18 @@ describe('/status and /doctor diagnostics', () => {
     expect(status).not.toContain('bypassPermissions');
   });
 
+  it('shows and uses maximum runtime access for an allowlisted agent user', async () => {
+    const h = await createHarness({ configuredWorkspace: true });
+    h.controls.profileConfig.permissions.maxAccess = 'full';
+    h.controls.profileConfig.access.agentUsers = ['ou-admin'];
+
+    await expect(h.run('/status')).resolves.toBe(true);
+    expect(JSON.stringify(lastContent(h.channel))).toContain('bypassPermissions');
+
+    await expect(h.run('/doctor')).resolves.toBe(true);
+    expect(h.agent.runOptions.at(-1)?.permissionMode).toBe('bypassPermissions');
+  });
+
   it('runs only self-checks when no cwd is selected', async () => {
     const h = await createHarness({ configuredWorkspace: false, bindWorkspace: false });
 

--- a/tests/integration/config/profile-migration.test.ts
+++ b/tests/integration/config/profile-migration.test.ts
@@ -86,6 +86,7 @@ describe('profile v2 migration', () => {
       allowedUsers: ['ou_allowed'],
       allowedChats: ['oc_allowed'],
       admins: ['ou_admin'],
+      agentUsers: [],
       requireMentionInGroup: false,
     });
     expect(next.profiles.claude?.preferences).toEqual({ messageReply: 'card' });

--- a/tests/unit/config/profile-schema.test.ts
+++ b/tests/unit/config/profile-schema.test.ts
@@ -131,6 +131,7 @@ describe('profile schema', () => {
       allowedUsers: [],
       allowedChats: [],
       admins: [],
+      agentUsers: [],
       requireMentionInGroup: true,
     });
   });

--- a/tests/unit/policy/fingerprint.test.ts
+++ b/tests/unit/policy/fingerprint.test.ts
@@ -103,6 +103,7 @@ describe('policy fingerprint', () => {
         allowedUsers: ['ou_b', 'ou_a'],
         allowedChats: ['oc_b', 'oc_a'],
         admins: ['ou_admin_b', 'ou_admin_a'],
+        agentUsers: ['ou_agent_b', 'ou_agent_a'],
       },
     });
 
@@ -112,6 +113,7 @@ describe('policy fingerprint', () => {
         allowedUsers: ['ou_a', 'ou_b'],
         allowedChats: ['oc_a', 'oc_b'],
         admins: ['ou_admin_a', 'ou_admin_b'],
+        agentUsers: ['ou_agent_a', 'ou_agent_b'],
       }),
     );
     expect(

--- a/tests/unit/policy/run-policy.test.ts
+++ b/tests/unit/policy/run-policy.test.ts
@@ -85,6 +85,38 @@ describe('run policy', () => {
     expect(result.permissionMode).toBe('plan');
   });
 
+  it('uses maxAccess for allowlisted agent users and defaultAccess for other actors', () => {
+    const profileConfig = profile({
+      permissions: { defaultAccess: 'read-only', maxAccess: 'full' },
+      agentUsers: ['ou_agent'],
+    });
+    const agentResult = evaluateRunPolicy(
+      baseInput({
+        profileConfig,
+        scope: scope({ actorId: 'ou_agent' }),
+      }),
+    );
+    const readerResult = evaluateRunPolicy(
+      baseInput({
+        profileConfig,
+        scope: scope({ actorId: 'ou_reader' }),
+      }),
+    );
+
+    expect(agentResult).toMatchObject({
+      ok: true,
+      accessMode: 'full',
+      sandbox: 'danger-full-access',
+      permissionMode: 'bypassPermissions',
+    });
+    expect(readerResult).toMatchObject({
+      ok: true,
+      accessMode: 'read-only',
+      sandbox: 'read-only',
+      permissionMode: 'plan',
+    });
+  });
+
   it('returns an expiry and a stable policy fingerprint for accepted runs', () => {
     const input = baseInput({ now: 1000 });
     const result = evaluateRunPolicy(input);
@@ -181,6 +213,7 @@ function profile(options: {
     maxAccess: AccessMode;
   };
   attachments?: Partial<ProfileConfig['attachments']>;
+  agentUsers?: string[];
 } = {}) {
   const cfg = createDefaultProfileConfig({
     agentKind: options.agentKind ?? 'claude',
@@ -195,6 +228,9 @@ function profile(options: {
       ? { codex: { binaryPath: '/usr/local/bin/codex' } }
       : {}),
     permissions: options.permissions,
+    access: {
+      agentUsers: options.agentUsers,
+    },
   });
   return {
     ...cfg,

--- a/tests/unit/runtime/profile-runtime.test.ts
+++ b/tests/unit/runtime/profile-runtime.test.ts
@@ -413,6 +413,7 @@ describe('profile runtime resolver', () => {
       allowedUsers: ['ou_allowed'],
       allowedChats: ['oc_allowed'],
       admins: ['ou_admin'],
+      agentUsers: [],
       requireMentionInGroup: false,
     });
     expect(runtime.profileConfig.preferences).toMatchObject({
@@ -429,6 +430,7 @@ describe('profile runtime resolver', () => {
       allowedUsers: ['ou_allowed'],
       allowedChats: ['oc_allowed'],
       admins: ['ou_admin'],
+      agentUsers: [],
       requireMentionInGroup: false,
     });
     expect(saved.profiles.claude?.preferences).toMatchObject({


### PR DESCRIPTION
## Summary
- add an optional `access.agentUsers` open_id allowlist
- run allowlisted actors at `permissions.maxAccess` while other admitted actors use `permissions.defaultAccess`
- report the actor-specific mode in /status and include the tier list in policy fingerprints

## Validation
- `pnpm ci:local`
- 620 tests passed
- typecheck and build passed