### PR TITLE
fix: filter Claude nested agent events

### DIFF
--- a/src/agent/claude/stream-json.ts
+++ b/src/agent/claude/stream-json.ts
@@ -15,6 +15,12 @@ interface ContentBlock {
 interface ClaudeRawEvent {
   type?: string;
   subtype?: string;
+  /**
+   * Claude sets this for messages emitted by a nested response, such as a
+   * subagent. Those messages are implementation details of the parent turn:
+   * the Agent tool returns their result to the main agent separately.
+   */
+  parent_tool_use_id?: string | null;
   session_id?: string;
   cwd?: string;
   model?: string;
@@ -30,6 +36,13 @@ interface ClaudeRawEvent {
 export function* translateEvent(raw: unknown): Generator<AgentEvent> {
   if (!raw || typeof raw !== 'object') return;
   const evt = raw as ClaudeRawEvent;
+
+  // `claude -p --output-format stream-json --verbose` includes nested
+  // assistant/user messages in the same stdout stream. Forwarding them would
+  // flatten subagent research, thinking, and tool calls into the user-visible
+  // Lark reply. Keep nested work private; the parent Agent tool result is a
+  // top-level event and remains available to the main agent for synthesis.
+  if (evt.parent_tool_use_id) return;
 
   if (evt.type === 'system' && evt.subtype === 'init') {
     yield {

--- a/tests/unit/agent/claude-stream-json.test.ts
+++ b/tests/unit/agent/claude-stream-json.test.ts
@@ -41,6 +41,39 @@ describe('Claude stream-json translator', () => {
     ]);
   });
 
+  it('filters nested subagent messages while preserving top-level events', () => {
+    const nestedAssistant = {
+      type: 'assistant',
+      parent_tool_use_id: 'tool-agent-1',
+      message: {
+        content: [
+          { type: 'text', text: 'private research report' },
+          { type: 'thinking', thinking: 'private reasoning' },
+          { type: 'tool_use', id: 'tool-child-1', name: 'WebSearch', input: { query: 'x' } },
+        ],
+      },
+    };
+    const nestedToolResult = {
+      type: 'user',
+      parent_tool_use_id: 'tool-agent-1',
+      message: {
+        content: [
+          { type: 'tool_result', tool_use_id: 'tool-child-1', content: 'private result' },
+        ],
+      },
+    };
+
+    expect([...translateEvent(nestedAssistant)]).toEqual([]);
+    expect([...translateEvent(nestedToolResult)]).toEqual([]);
+    expect([
+      ...translateEvent({
+        type: 'assistant',
+        parent_tool_use_id: null,
+        message: { content: [{ type: 'text', text: 'public synthesis' }] },
+      }),
+    ]).toEqual([{ type: 'text', delta: 'public synthesis' }]);
+  });
+
   it('translates user tool_result blocks including structured output and errors', () => {
     expect([
       ...translateEvent({


### PR DESCRIPTION
## What changed

- teach the Claude stream-json translator about `parent_tool_use_id`
- discard nested response events before they become bridge `AgentEvent`s
- add regression coverage for nested assistant text/thinking/tool calls, nested user tool results, and a top-level control case

## Why

Claude's verbose stream contains both the root conversation and nested subagent responses. The bridge previously ignored their hierarchy and flattened every content block into the public Lark run state. A research task with multiple subagents therefore exposed complete worker reports and tool activity in the group, followed by the main agent's synthesis.

Claude documents a non-null `AssistantMessage.parent_tool_use_id` as a nested response. Filtering at the adapter boundary keeps the worker transcript private while preserving the top-level Agent tool result that the main agent consumes.

Fixes #229.

This is intentionally separate from #228, which concerns the post-`result` process lifetime for background agents.

## User impact

Subagent research, reasoning, and tool traffic no longer flood user-visible Lark replies. The main agent can still receive the subagent result and produce its normal synthesized answer.

## Validation

- `pnpm exec vitest run tests/unit/agent/claude-stream-json.test.ts` — 7 passed
- `pnpm typecheck` — passed
- `pnpm build` — passed during dependency install
- `git diff --check` — passed
- `pnpm test:unit` — 352 passed, 1 unrelated environment-sensitive failure in `tests/unit/cli/preflight.test.ts`; the bridge runtime injects `LARKSUITE_CLI_CONFIG_DIR`, while that test expects it to be undefined
