### PR TITLE
feat(codex): 完善 App Server 传输与可恢复的持久任务控制器

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ overwriting existing files. Only an explicit `--force` replaces them. Runtime
 task state stays outside the workspace in
 `~/.lark-channel/profiles/<profile>/codex-tasks.json`.
 
+When the Bridge was started with a custom `run -c/--config` path, each
+`codex-task` subcommand accepts the same `-c/--config` option. Controller runs
+also expose that exact path as `LARK_CHANNEL_BRIDGE_CONFIG`;
+`LARK_CHANNEL_CONFIG` remains reserved for the lark-cli source projection.
+
 ```bash
 lark-channel-bridge codex-task list --profile codex --json
 lark-channel-bridge codex-task create --profile codex --title "CI check" --cwd /absolute/project --json
@@ -230,7 +235,7 @@ If a profile was created with the wrong agent kind, stop or unregister any match
 | `/doctor [description]` | Run low-sensitive diagnostics |
 | `/help` | Help card |
 
-DMs do not require an @ mention. Groups and topic groups require `@bot` by default; `@all` is ignored. Cloud-doc comments in supported document types run when the bot is mentioned. Messages beginning with `/` are always handled as Bridge commands; unknown commands return a help hint instead of being sent to the agent.
+DMs do not require an @ mention. Groups and topic groups require `@bot` by default; `@all` is ignored. Cloud-doc comments in supported document types run when the bot is mentioned. Known `/...` commands are handled by the Bridge; unrecognized slash-prefixed input continues to the agent as a normal prompt.
 
 ## Reply Display and COT
 

--- a/README.md
+++ b/README.md
@@ -104,13 +104,81 @@ lark-channel-bridge restart --profile codex
 lark-channel-bridge status --profile codex
 ```
 
+### Codex transport
+
+Codex profiles use `codex exec --json` by default. To opt a new profile into the
+Codex app-server transport, set it during bootstrap:
+
+```bash
+lark-channel-bridge profile create codex-app --agent codex --codex-transport app-server
+# The same option is available when `run`, `start`, or `migrate` creates a Codex profile.
+```
+
+The selection is persisted as `profiles.<name>.codex.transport`; the background
+service later starts from that persisted profile rather than retaining bootstrap
+flags. To switch an existing profile, stop it, edit that field to `exec` or
+`app-server`, then run `lark-channel-bridge restart --profile <name>`. Omitting the
+field keeps the backward-compatible `exec` behavior.
+
+The app-server transport keeps the same effective `CODEX_HOME`, so it reuses the
+Codex account, provider/model routing, and durable thread store. New Bridge
+threads are persistent, use readable `Feishu · ...` names, and can be discovered
+and resumed from the Codex Desktop sidebar. Codex App runs in a separate
+app-server process, so an inventory refresh, window refocus, or restart may be
+needed before a newly-created thread appears; there is no cross-process live
+`thread/started` broadcast. Hand off a thread sequentially between the Bridge and
+Codex App—do not let both processes write the same thread at the same time.
+
+Each Bridge app-server child uses process-local lean overrides: user MCP servers,
+MCP Apps, plugins, Browser/Computer Use, permission prompts, hooks, and desktop
+`notify` commands are disabled for that child. The Bridge does not rewrite the
+user's global Codex config. `codex.ignoreUserConfig` and `codex.ignoreRules`
+remain exec-only flags; app-server runs continue to use the normal account,
+provider, instructions, and rules from the shared Codex home.
+
+### Fixed controller workspace and worker tasks (MVP)
+
+An App Server profile can keep `workspaces.default` fixed to a dedicated
+controller directory and install a workspace-scoped `codex-task-controller`
+Skill. Initialization only writes the profile's configured default workspace;
+when `--workspace` is supplied it must resolve to that same directory:
+
+```bash
+lark-channel-bridge codex-task init --profile codex
+```
+
+Initialization creates `<default-workspace>/AGENTS.md` and
+`<default-workspace>/.agents/skills/codex-task-controller/SKILL.md` without
+overwriting existing files. Only an explicit `--force` replaces them. Runtime
+task state stays outside the workspace in
+`~/.lark-channel/profiles/<profile>/codex-tasks.json`.
+
+```bash
+lark-channel-bridge codex-task list --profile codex --json
+lark-channel-bridge codex-task create --profile codex --title "CI check" --cwd /absolute/project --json
+lark-channel-bridge codex-task create --profile codex --title "CI check" --cwd /absolute/project --message "Run the tests" --json
+lark-channel-bridge codex-task read T-A1B2C3 --profile codex --json
+lark-channel-bridge codex-task send T-A1B2C3 --profile codex --message "Continue with CI" --json
+```
+
+`list` returns only workers registered by that profile. `read` uses
+`thread/read` without resuming the task and returns filtered task metadata,
+status, and user/agent text rather than raw thread/tool payloads. `create` uses
+persistent `thread/start` plus `thread/name/set`; `send` performs
+`thread/resume` plus `turn/start` in a short-lived app-server and waits for a
+terminal event. A profile-local lock prevents two `codex-task send` commands
+from writing the same worker concurrently, but it cannot detect or block a
+separate Codex App process. App and Bridge must still hand off sequentially.
+This MVP intentionally omits delete/archive, background fire-and-forget,
+cross-process stop, and App-to-Lark live mirroring.
+
 ## Commands
 
 ### Host CLI
 
 ```text
-lark-channel-bridge run [--profile <name>] [--agent claude|codex] [--workspace <path>] [-c <config>]
-lark-channel-bridge migrate [--profile <name>] [--agent claude|codex]
+lark-channel-bridge run [--profile <name>] [--agent claude|codex] [--codex-transport exec|app-server] [--workspace <path>] [-c <config>]
+lark-channel-bridge migrate [--profile <name>] [--agent claude|codex] [--codex-transport exec|app-server]
 lark-channel-bridge ps
 lark-channel-bridge kill <id|#>
 lark-channel-bridge --help
@@ -121,12 +189,14 @@ lark-channel-bridge --help
 ```bash
 lark-channel-bridge profile create claude --agent claude
 lark-channel-bridge profile create codex --agent codex
+lark-channel-bridge profile create codex-app --agent codex --codex-transport app-server
 lark-channel-bridge profile list
 lark-channel-bridge profile use <name>
 lark-channel-bridge profile remove <name>
 lark-channel-bridge profile remove <name> --purge --yes
 lark-channel-bridge profile export <name> [--output ./profile.json] [--force]
 lark-channel-bridge profile export <name> --include-secrets --yes
+lark-channel-bridge codex-task init|list|create|read|send
 ```
 
 `profile remove` archives local state by default, including the active profile. If other profiles remain, the bridge switches to the next one; if it was the last profile, the root config is cleared so the same name can be created again. `--purge --yes` permanently deletes local state. `profile export` redacts app secrets by default; `--include-secrets --yes` includes sensitive config.
@@ -145,6 +215,7 @@ If a profile was created with the wrong agent kind, stop or unregister any match
 | `/ws remove <name>` | Delete a named workspace |
 | `/resume` | Resume compatible history for the same agent, working directory, and permission mode |
 | `/status` | Show profile, agent, working directory, session, lark-cli identity, and run state |
+| `/model` | Show the configured model and the latest actual model recorded for this session |
 | `/config` | Adjust presentation preferences, access settings, and lark-cli identity policy |
 | `/invite user @name` | Allow a user to use the bot in DMs |
 | `/invite admin @name` | Add an access-control admin |
@@ -159,7 +230,7 @@ If a profile was created with the wrong agent kind, stop or unregister any match
 | `/doctor [description]` | Run low-sensitive diagnostics |
 | `/help` | Help card |
 
-DMs do not require an @ mention. Groups and topic groups require `@bot` by default; `@all` is ignored. Cloud-doc comments in supported document types run when the bot is mentioned.
+DMs do not require an @ mention. Groups and topic groups require `@bot` by default; `@all` is ignored. Cloud-doc comments in supported document types run when the bot is mentioned. Messages beginning with `/` are always handled as Bridge commands; unknown commands return a help hint instead of being sent to the agent.
 
 ## Reply Display and COT
 

--- a/README.md
+++ b/README.md
@@ -168,14 +168,27 @@ lark-channel-bridge codex-task send T-A1B2C3 --profile codex --message "Continue
 
 `list` returns only workers registered by that profile. `read` uses
 `thread/read` without resuming the task and returns filtered task metadata,
-status, and user/agent text rather than raw thread/tool payloads. `create` uses
-persistent `thread/start` plus `thread/name/set`; `send` performs
-`thread/resume` plus `turn/start` in a short-lived app-server and waits for a
-terminal event. A profile-local lock prevents two `codex-task send` commands
-from writing the same worker concurrently, but it cannot detect or block a
-separate Codex App process. App and Bridge must still hand off sequentially.
-This MVP intentionally omits delete/archive, background fire-and-forget,
-cross-process stop, and App-to-Lark live mirroring.
+status, and user/agent text rather than raw thread/tool payloads. An empty
+`create` reserves a pending handle but does not claim that an unstarted thread
+is durable. The first `send` (or `create --message`) performs `thread/start` and
+`turn/start` in the same App Server process. The fresh thread ID is first stored
+as a private candidate, then promoted to the durable thread only after
+`turn/start` succeeds. If that response is lost, the next `send` verifies the
+candidate with `thread/read`: a durable candidate is imported but the new
+message is not sent, and the command fails closed with an ambiguous-outcome
+warning; only an explicit `thread not loaded` response permits a fresh retry.
+Candidate IDs are never included in normal CLI output. Thread naming remains
+best-effort. Later sends use `thread/resume` with historical turn replay
+disabled. A dedicated profile-local execution lock rejects concurrent sends to
+the same worker. A five-minute idle watchdog is refreshed by recognized App
+Server activity, including command, file-change, and MCP progress that is not
+rendered as chat output; a truly silent worker is marked `timeout`. `SIGINT` and
+`SIGTERM` interrupt the active turn and persist `interrupted` before releasing
+the lock. `timeout` and `interrupted` results remain available as structured
+output but use a non-zero CLI exit status. The lock cannot detect or block a
+separate Codex App process, so App and Bridge must still hand off sequentially. This MVP
+intentionally omits delete/archive, background fire-and-forget, cross-process
+stop, and App-to-Lark live mirroring.
 
 ## Commands
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -147,6 +147,10 @@ lark-channel-bridge codex-task init --profile codex
 `--force` 才覆盖。运行时 registry 保存在
 `~/.lark-channel/profiles/<profile>/codex-tasks.json`，不会写进工作区或 Skill。
 
+如果 Bridge 使用自定义 `run -c/--config` 路径启动，每个 `codex-task` 子命令都接受
+同一个 `-c/--config` 选项。主控进程会通过 `LARK_CHANNEL_BRIDGE_CONFIG` 传递该精确
+路径；`LARK_CHANNEL_CONFIG` 仍只用于 lark-cli source projection。
+
 ```bash
 lark-channel-bridge codex-task list --profile codex --json
 lark-channel-bridge codex-task create --profile codex --title "CI 检查" --cwd /absolute/project --json
@@ -221,7 +225,7 @@ lark-channel-bridge codex-task init|list|create|read|send
 | `/doctor [描述]` | 执行低敏诊断 |
 | `/help` | 帮助卡片 |
 
-私聊不需要 @。群和话题群默认必须 `@bot`；`@all` 会被忽略。支持的云文档评论里 @bot 就会触发回复。以 `/` 开头的消息始终由 Bridge 命令层处理；未知命令只返回帮助提示，不会再交给 agent。
+私聊不需要 @。群和话题群默认必须 `@bot`；`@all` 会被忽略。支持的云文档评论里 @bot 就会触发回复。Bridge 只处理已注册的 `/...` 命令；无法识别的 slash-prefixed 内容仍会作为普通 prompt 交给 agent。
 
 ## 回复展示与 COT
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -104,13 +104,72 @@ lark-channel-bridge restart --profile codex
 lark-channel-bridge status --profile codex
 ```
 
+### Codex transport
+
+Codex profile 默认使用 `codex exec --json`。新建 profile 时可显式选择 Codex
+app-server transport：
+
+```bash
+lark-channel-bridge profile create codex-app --agent codex --codex-transport app-server
+# `run`、`start` 或 `migrate` 创建 Codex profile 时也支持同一选项。
+```
+
+该选择会持久化到 `profiles.<name>.codex.transport`；后台服务后续只依赖已保存的
+profile，不会保留首次启动参数。切换已有 profile 时，先停止它，把该字段改为
+`exec` 或 `app-server`，再运行 `lark-channel-bridge restart --profile <name>`。
+字段缺省时继续使用向后兼容的 `exec` 行为。
+
+app-server transport 保持同一个有效 `CODEX_HOME`，因此会复用 Codex 账号、
+provider/model routing 和持久化 thread store。Bridge 新建的 thread 会持久化，并使用
+可读的 `飞书 · ...` 名称；Codex Desktop sidebar 可以发现并恢复这些 thread。Codex App
+运行在另一个 app-server 进程中，新 thread 可能要等 inventory 刷新、窗口重新聚焦或
+App 重启后才出现，协议没有跨进程实时广播 `thread/started`。Bridge 和 Codex App 可以
+顺序交接同一个 thread，但不要让两个进程同时写它。
+
+Bridge 的每个 app-server 子进程都会应用局部 lean override：该子进程不会启动用户
+MCP、MCP Apps、plugins、Browser/Computer Use、permission prompt、hooks 或桌面
+`notify` 命令，也不会改写用户的全局 Codex 配置。`codex.ignoreUserConfig` 和
+`codex.ignoreRules` 仍然只是 exec transport 的 flag；app-server 继续使用共享 Codex
+home 中的正常账号、provider、指令和 rules。
+
+### 固定主控工作区与 worker tasks（MVP）
+
+App Server profile 可以把 `workspaces.default` 固定为专用主控目录，再安装一个
+工作区级 `codex-task-controller` Skill。初始化命令只写当前 profile 已配置的默认目录；
+如果传 `--workspace`，它也必须解析到同一个目录：
+
+```bash
+lark-channel-bridge codex-task init --profile codex
+```
+
+初始化会以 no-clobber 方式创建 `<default-workspace>/AGENTS.md` 和
+`<default-workspace>/.agents/skills/codex-task-controller/SKILL.md`；只有显式
+`--force` 才覆盖。运行时 registry 保存在
+`~/.lark-channel/profiles/<profile>/codex-tasks.json`，不会写进工作区或 Skill。
+
+```bash
+lark-channel-bridge codex-task list --profile codex --json
+lark-channel-bridge codex-task create --profile codex --title "CI 检查" --cwd /absolute/project --json
+lark-channel-bridge codex-task create --profile codex --title "CI 检查" --cwd /absolute/project --message "检查测试" --json
+lark-channel-bridge codex-task read T-A1B2C3 --profile codex --json
+lark-channel-bridge codex-task send T-A1B2C3 --profile codex --message "继续检查 CI" --json
+```
+
+`list` 只列出该 profile 注册的 worker；`read` 使用 `thread/read`，不会 resume task，
+并只返回筛选后的 task 元数据、状态和用户/agent 文本，不返回原始 thread/工具载荷。
+`create` 使用持久化 `thread/start` + `thread/name/set`；`send` 会在短生命周期
+app-server 中完成 `thread/resume` + `turn/start` 并等待终态。profile-local lock 可以
+防止两个 `codex-task send` 同时写一个 worker，但无法检测或阻止 Codex App 另一个
+进程正在写；App 与 Bridge 仍必须顺序交接。本 MVP 没有 delete/archive、后台
+fire-and-forget、跨进程 stop 或 App→飞书实时镜像。
+
 ## 命令速查
 
 ### 宿主 CLI
 
 ```text
-lark-channel-bridge run [--profile <name>] [--agent claude|codex] [--workspace <path>] [-c <config>]
-lark-channel-bridge migrate [--profile <name>] [--agent claude|codex]
+lark-channel-bridge run [--profile <name>] [--agent claude|codex] [--codex-transport exec|app-server] [--workspace <path>] [-c <config>]
+lark-channel-bridge migrate [--profile <name>] [--agent claude|codex] [--codex-transport exec|app-server]
 lark-channel-bridge ps
 lark-channel-bridge kill <id|#>
 lark-channel-bridge --help
@@ -121,12 +180,14 @@ lark-channel-bridge --help
 ```bash
 lark-channel-bridge profile create claude --agent claude
 lark-channel-bridge profile create codex --agent codex
+lark-channel-bridge profile create codex-app --agent codex --codex-transport app-server
 lark-channel-bridge profile list
 lark-channel-bridge profile use <name>
 lark-channel-bridge profile remove <name>
 lark-channel-bridge profile remove <name> --purge --yes
 lark-channel-bridge profile export <name> [--output ./profile.json] [--force]
 lark-channel-bridge profile export <name> --include-secrets --yes
+lark-channel-bridge codex-task init|list|create|read|send
 ```
 
 `profile remove` 默认归档本地状态，也可以删除当前激活的 profile。若还剩其他 profile，会自动切到下一个；若这是最后一个 profile，会清空 root config，之后可以用同名重新创建。只有加 `--purge --yes` 才会永久删除。`profile export` 默认脱敏 app secret；只有加 `--include-secrets --yes` 才会导出敏感配置。
@@ -145,6 +206,7 @@ lark-channel-bridge profile export <name> --include-secrets --yes
 | `/ws remove <name>` | 删除命名工作空间 |
 | `/resume` | 恢复同 agent、工作目录、权限模式兼容的历史会话 |
 | `/status` | 查看 profile、agent、工作目录、会话、lark-cli 身份和运行状态 |
+| `/model` | 查看配置模型和当前 session 最近记录的实际模型 |
 | `/config` | 调整展示偏好、访问控制和 lark-cli 身份策略 |
 | `/invite user @某人` | 允许用户私聊使用 bot |
 | `/invite admin @某人` | 添加访问控制管理员 |
@@ -159,7 +221,7 @@ lark-channel-bridge profile export <name> --include-secrets --yes
 | `/doctor [描述]` | 执行低敏诊断 |
 | `/help` | 帮助卡片 |
 
-私聊不需要 @。群和话题群默认必须 `@bot`；`@all` 会被忽略。支持的云文档评论里 @bot 就会触发回复。
+私聊不需要 @。群和话题群默认必须 `@bot`；`@all` 会被忽略。支持的云文档评论里 @bot 就会触发回复。以 `/` 开头的消息始终由 Bridge 命令层处理；未知命令只返回帮助提示，不会再交给 agent。
 
 ## 回复展示与 COT
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -161,11 +161,21 @@ lark-channel-bridge codex-task send T-A1B2C3 --profile codex --message "继续�
 
 `list` 只列出该 profile 注册的 worker；`read` 使用 `thread/read`，不会 resume task，
 并只返回筛选后的 task 元数据、状态和用户/agent 文本，不返回原始 thread/工具载荷。
-`create` 使用持久化 `thread/start` + `thread/name/set`；`send` 会在短生命周期
-app-server 中完成 `thread/resume` + `turn/start` 并等待终态。profile-local lock 可以
-防止两个 `codex-task send` 同时写一个 worker，但无法检测或阻止 Codex App 另一个
-进程正在写；App 与 Bridge 仍必须顺序交接。本 MVP 没有 delete/archive、后台
-fire-and-forget、跨进程 stop 或 App→飞书实时镜像。
+不带消息的 `create` 只预留一个 `pending` handle，不会把尚未启动 turn 的内存 thread
+标记成可恢复。首次 `send`（或 `create --message`）会在同一个 App Server 进程内依次
+执行 `thread/start` 与 `turn/start`。fresh thread ID 会先作为私有 candidate 落盘，
+`turn/start` 成功后才提升为 durable thread。如果响应丢失，下一次 `send` 会先用
+`thread/read` 验证：candidate 已 durable 时只导入并 fail closed，提示前一 turn 结果
+不确定，不会发送本次消息；只有明确返回 `thread not loaded` 才允许重新物化。普通 CLI
+输出不会暴露 candidate ID，显示名称仍按 best-effort 设置。后续发送使用
+`thread/resume`，并关闭历史 turns 重放。专用的 profile-local 执行锁会直接拒绝同一
+worker 的并发发送。默认 5 分钟的空闲 watchdog 会被已识别的 App Server 活动刷新，
+包括不会渲染成聊天文本的 command、file-change 和 MCP progress；只有真正静默的
+worker 才会标记为 `timeout`。`SIGINT`/`SIGTERM` 会先 interrupt 当前 turn、落盘
+`interrupted` 并释放锁；`timeout` 与 `interrupted` 仍会输出结构化结果，但 CLI 使用
+非零退出码。该锁仍无法检测或阻止 Codex App 的另一个进程写入，因此 App 与 Bridge
+必须顺序交接。本 MVP 没有
+delete/archive、后台 fire-and-forget、跨进程 stop 或 App→飞书实时镜像。
 
 ## 命令速查
 

--- a/src/agent/codex/app-server-adapter.ts
+++ b/src/agent/codex/app-server-adapter.ts
@@ -1,0 +1,607 @@
+import { createInterface, type Interface as ReadLineInterface } from 'node:readline';
+import type { Readable, Writable } from 'node:stream';
+import pkg from '../../../package.json';
+import type { SandboxMode } from '../../config/profile-schema';
+import { log } from '../../core/logger';
+import { spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
+import { SpawnFailed } from '../../runtime/errors';
+import { buildBridgeSystemPrompt } from '../bridge-system-prompt';
+import { checkAgentAvailability, type AgentAvailability } from '../preflight';
+import type {
+  AgentAdapter,
+  AgentBotIdentity,
+  AgentEvent,
+  AgentRun,
+  AgentRunOptions,
+} from '../types';
+import {
+  CodexAppServerEventTranslator,
+  CodexAppServerJsonRpc,
+  type CodexAppServerIncoming,
+} from './app-server-jsonrpc';
+import {
+  buildLeanAppServerArgs,
+} from './app-server-lean';
+import {
+  buildAppServerProcessEnv,
+  readAppServerConfigInventory,
+  type CodexAppServerProcessOptions,
+} from './app-server-process';
+
+export interface CodexAppServerAdapterOptions extends CodexAppServerProcessOptions {
+  ignoreUserConfig?: boolean;
+  ignoreRules?: boolean;
+  sandbox?: SandboxMode;
+  stopGraceMs?: number;
+  developerInstructions?: string;
+}
+
+type CodexAppServerChild = SpawnedProcessByStdio<Writable, Readable, Readable>;
+
+const RPC_TIMEOUT_MS = 15_000;
+const NORMAL_SHUTDOWN_GRACE_MS = 250;
+const MAX_PROTOCOL_LINE_CHARS = 4 * 1024 * 1024;
+const MAX_BUFFERED_NOTIFICATIONS = 2_000;
+
+export class CodexAppServerAdapter implements AgentAdapter {
+  readonly id = 'codex';
+  readonly displayName = 'Codex App Server';
+
+  private readonly options: CodexAppServerAdapterOptions;
+  private botIdentity: AgentBotIdentity | undefined;
+  private warnedExecOnlyConfig = false;
+  private readonly preparedArgs = new Map<string, string[]>();
+
+  constructor(options: CodexAppServerAdapterOptions) {
+    this.options = options;
+  }
+
+  setBotIdentity(identity: AgentBotIdentity): void {
+    this.botIdentity = identity;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return (await this.checkAvailability()).ok;
+  }
+
+  async checkAvailability(): Promise<AgentAvailability> {
+    return checkAgentAvailability({
+      agentId: 'codex',
+      agentName: 'Codex App Server',
+      command: this.options.binary,
+      binaryPath: this.options.binary,
+      args: ['app-server', '--help'],
+    });
+  }
+
+  async prepareRun(options: AgentRunOptions): Promise<void> {
+    if (!options.cwd) throw new Error('cwd is required for CodexAppServerAdapter.prepareRun');
+    this.preparedArgs.delete(options.runId);
+    try {
+      const inventory = await readAppServerConfigInventory({
+        binary: this.options.binary,
+        cwd: options.cwd,
+        env: buildAppServerProcessEnv(this.options),
+      });
+      this.preparedArgs.set(options.runId, buildLeanAppServerArgs(inventory));
+    } catch (err) {
+      throw new SpawnFailed(
+        'codex app-server lean configuration probe failed',
+        err,
+        'agent-prepare-failed',
+      );
+    }
+  }
+
+  discardPreparedRun(options: AgentRunOptions): void {
+    this.preparedArgs.delete(options.runId);
+  }
+
+  run(options: AgentRunOptions): AgentRun {
+    const cwd = options.cwd;
+    if (!cwd) throw new Error('cwd is required for CodexAppServerAdapter.run');
+    const argv = this.preparedArgs.get(options.runId);
+    if (!argv) {
+      throw new Error('CodexAppServerAdapter.run requires prepareRun for the same runId');
+    }
+    this.preparedArgs.delete(options.runId);
+    if (
+      !this.warnedExecOnlyConfig &&
+      (this.options.ignoreUserConfig || this.options.ignoreRules !== false)
+    ) {
+      this.warnedExecOnlyConfig = true;
+      log.warn('app-server', 'exec-only-config-ignored', {
+        ignoreUserConfig: this.options.ignoreUserConfig === true,
+        ignoreRules: this.options.ignoreRules !== false,
+      });
+    }
+    return new CodexAppServerRun({
+      adapter: this.options,
+      run: { ...options, cwd },
+      botIdentity: this.botIdentity,
+      argv,
+    });
+  }
+}
+
+interface CodexAppServerRunInput {
+  adapter: CodexAppServerAdapterOptions;
+  run: AgentRunOptions & { cwd: string };
+  botIdentity?: AgentBotIdentity;
+  argv: string[];
+}
+
+class CodexAppServerRun implements AgentRun {
+  readonly runId: string;
+  readonly events: AsyncIterable<AgentEvent>;
+
+  private readonly input: CodexAppServerRunInput;
+  private readonly child: CodexAppServerChild;
+  private readonly rpc: CodexAppServerJsonRpc;
+  private readonly translator = new CodexAppServerEventTranslator();
+  private readonly queue = new AsyncEventQueue();
+  private readonly stderrChunks: Buffer[] = [];
+  private stderrBytes = 0;
+  private readonly readline: ReadLineInterface;
+  private readonly exitPromise: Promise<void>;
+  private readonly terminalPromise: Promise<void>;
+  private resolveTerminal!: () => void;
+  private writeTail = Promise.resolve();
+  private runtimeError: Error | undefined;
+  private threadId: string | undefined;
+  private turnId: string | undefined;
+  private stopRequested = false;
+  private terminal = false;
+  private exited = false;
+  private normalShutdownTimer: ReturnType<typeof setTimeout> | undefined;
+  private readonly pendingNotifications: Array<{ method: string; params: unknown }> = [];
+
+  constructor(input: CodexAppServerRunInput) {
+    this.input = input;
+    this.runId = input.run.runId;
+    this.events = this.queue;
+
+    this.child = spawnProcess(
+      input.adapter.binary,
+      input.argv,
+      {
+        cwd: input.run.cwd,
+        env: buildAppServerProcessEnv(input.adapter),
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    ) as CodexAppServerChild;
+
+    this.rpc = new CodexAppServerJsonRpc((message) => this.writeMessage(message));
+    this.terminalPromise = new Promise<void>((resolve) => {
+      this.resolveTerminal = resolve;
+    });
+    this.exitPromise = new Promise<void>((resolve) => {
+      this.child.once('close', (code, signal) => {
+        this.exited = true;
+        if (this.normalShutdownTimer) clearTimeout(this.normalShutdownTimer);
+        log.info('app-server', 'exit', { pid: this.child.pid ?? null, code, signal });
+        const stderr = Buffer.concat(this.stderrChunks).toString('utf8').trim();
+        const detail = this.runtimeError?.message ?? (stderr ? stderr.slice(0, 500) : undefined);
+        this.rpc.fail(new Error(detail ?? `codex app-server exited: ${code ?? signal ?? 'unknown'}`));
+        if (!this.terminal) {
+          this.publish(
+            this.translator.finish(
+              this.stopRequested ? 'interrupted' : 'failed',
+              this.stopRequested ? undefined : detail,
+            ),
+          );
+        }
+        this.readline.close();
+        this.queue.close();
+        resolve();
+      });
+    });
+
+    this.readline = createInterface({ input: this.child.stdout, crlfDelay: Infinity });
+    this.installProcessHandlers();
+
+    log.info('app-server', 'spawn', {
+      pid: this.child.pid ?? null,
+      cwd: input.run.cwd,
+      hasThread: Boolean(input.run.threadId),
+      lean: true,
+      promptChars: input.run.prompt.length,
+      images: input.run.images?.length ?? 0,
+      model: input.run.model,
+    });
+    void this.start().catch((err) => this.failTransport(err));
+  }
+
+  async stop(): Promise<void> {
+    if (this.exited) return;
+    this.stopRequested = true;
+    const graceMs = this.input.run.stopGraceMs ?? this.input.adapter.stopGraceMs ?? 5000;
+
+    if (!this.terminal && this.threadId && this.turnId) {
+      try {
+        await withTimeout(
+          this.rpc.request('turn/interrupt', {
+            threadId: this.threadId,
+            turnId: this.turnId,
+          }),
+          Math.min(graceMs, 1000),
+          'turn/interrupt',
+        );
+        await waitForPromise(this.terminalPromise, graceMs);
+      } catch (err) {
+        log.warn('app-server', 'interrupt-failed', {
+          message: errorMessage(err),
+          threadId: this.threadId,
+          turnId: this.turnId,
+        });
+      }
+    }
+
+    if (!this.terminal) this.publish(this.translator.finish('interrupted'));
+    this.terminate('SIGTERM');
+    if (!(await waitForPromise(this.exitPromise, graceMs))) {
+      log.warn('app-server', 'stop-sigkill', {
+        pid: this.child.pid ?? null,
+        graceMs,
+        reason: 'grace-period-expired',
+      });
+      this.terminate('SIGKILL');
+      await waitForPromise(this.exitPromise, 1000);
+    }
+  }
+
+  waitForExit(timeoutMs: number): Promise<boolean> {
+    if (this.exited) return Promise.resolve(true);
+    return waitForPromise(this.exitPromise, timeoutMs);
+  }
+
+  private installProcessHandlers(): void {
+    this.child.once('error', (err) => {
+      this.failTransport(err);
+    });
+    this.child.stdin.on('error', (err) => {
+      if (this.exited || this.terminal) return;
+      this.failTransport(err);
+    });
+    this.child.stderr.on('data', (chunk: Buffer) => {
+      if (this.stderrBytes < 64 * 1024) {
+        this.stderrChunks.push(chunk);
+        this.stderrBytes += chunk.byteLength;
+      }
+      for (const line of chunk.toString('utf8').split(/\r?\n/)) {
+        if (line.trim()) log.warn('app-server', 'stderr', { line });
+      }
+    });
+    this.readline.on('line', (line) => this.receiveLine(line));
+    this.readline.on('close', () => {
+      if (!this.terminal && !this.exited) {
+        this.failTransport(new Error('codex app-server stdout closed before a terminal event'));
+      }
+    });
+  }
+
+  private async start(): Promise<void> {
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    if (!this.child.pid) {
+      throw new Error(
+        this.runtimeError
+          ? `failed to spawn codex app-server: ${this.runtimeError.message}`
+          : 'failed to spawn codex app-server: spawn returned no pid',
+      );
+    }
+
+    await withTimeout(
+      this.rpc.request('initialize', {
+        clientInfo: {
+          name: 'lark-channel-bridge',
+          title: 'Lark Channel Bridge',
+          version: pkg.version,
+        },
+        capabilities: null,
+      }),
+      RPC_TIMEOUT_MS,
+      'initialize',
+    );
+    await this.rpc.notify('initialized');
+    if (this.stopRequested) throw new Error('codex app-server run stopped during initialization');
+
+    const threadResult = await withTimeout(
+      this.rpc.request(
+        this.input.run.threadId ? 'thread/resume' : 'thread/start',
+        this.threadParams(),
+      ),
+      RPC_TIMEOUT_MS,
+      this.input.run.threadId ? 'thread/resume' : 'thread/start',
+    );
+    const threadResponse = recordValue(threadResult);
+    const thread = recordValue(threadResponse?.thread);
+    const threadId = stringValue(thread?.id);
+    if (!threadId) throw new Error('codex app-server returned no thread id');
+    if (this.input.run.threadId && threadId !== this.input.run.threadId) {
+      throw new Error(`codex app-server resumed an unexpected thread: ${threadId}`);
+    }
+    this.threadId = threadId;
+    if (!this.input.run.threadId) {
+      await withTimeout(
+        this.rpc.request('thread/name/set', {
+          threadId,
+          name: this.input.run.threadName?.trim() || '飞书 · 新会话',
+        }),
+        RPC_TIMEOUT_MS,
+        'thread/name/set',
+      );
+    }
+    this.publish([
+      {
+        type: 'system',
+        threadId,
+        cwd: stringValue(threadResponse?.cwd) ?? this.input.run.cwd,
+        ...(stringValue(threadResponse?.model) ?? this.input.run.model
+          ? { model: stringValue(threadResponse?.model) ?? this.input.run.model }
+          : {}),
+      },
+    ]);
+
+    const turnResult = await withTimeout(
+      this.rpc.request('turn/start', {
+        threadId,
+        input: [
+          { type: 'text', text: this.input.run.prompt },
+          ...(this.input.run.images ?? []).map((path) => ({ type: 'localImage', path })),
+        ],
+        approvalPolicy: 'never',
+        cwd: this.input.run.cwd,
+        ...(this.input.run.model ? { model: this.input.run.model } : {}),
+      }),
+      RPC_TIMEOUT_MS,
+      'turn/start',
+    );
+    const turnResponse = recordValue(turnResult);
+    const turn = recordValue(turnResponse?.turn);
+    const turnId = stringValue(turn?.id);
+    if (!turnId) throw new Error('codex app-server returned no turn id');
+    this.turnId = turnId;
+    this.translator.setContext(threadId, turnId);
+    this.flushPendingNotifications();
+  }
+
+  private threadParams(): Record<string, unknown> {
+    const common = {
+      cwd: this.input.run.cwd,
+      approvalPolicy: 'never',
+      sandbox: this.input.run.sandbox ?? this.input.adapter.sandbox ?? 'danger-full-access',
+      developerInstructions:
+        this.input.adapter.developerInstructions ?? buildBridgeSystemPrompt(this.input.botIdentity),
+      ...(this.input.run.model ? { model: this.input.run.model } : {}),
+    };
+    return this.input.run.threadId
+      ? { threadId: this.input.run.threadId, ...common }
+      : {
+          serviceName: 'lark-channel-bridge',
+          threadSource: 'user',
+          ephemeral: false,
+          ...common,
+        };
+  }
+
+  private receiveLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    if (trimmed.length > MAX_PROTOCOL_LINE_CHARS) {
+      this.failTransport(new Error('codex app-server emitted an oversized protocol line'));
+      return;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      this.failTransport(new Error('codex app-server emitted malformed JSON'));
+      return;
+    }
+    let incoming: CodexAppServerIncoming | undefined;
+    try {
+      incoming = this.rpc.receive(parsed);
+    } catch (err) {
+      this.failTransport(err);
+      return;
+    }
+    if (!incoming) return;
+    if (incoming.kind === 'request') {
+      void this.handleServerRequest(incoming).catch((err) => this.failTransport(err));
+      return;
+    }
+    this.handleNotification(incoming.method, incoming.params);
+  }
+
+  private handleNotification(method: string, params: unknown): void {
+    if (!this.turnId && isRunNotification(method)) {
+      if (this.pendingNotifications.length >= MAX_BUFFERED_NOTIFICATIONS) {
+        this.failTransport(new Error('codex app-server notification buffer overflow'));
+        return;
+      }
+      this.pendingNotifications.push({ method, params });
+      return;
+    }
+    const events = this.translator.translate(method, params);
+    this.publish(events);
+    if (this.translator.terminalEmitted()) this.beginNormalShutdown();
+  }
+
+  private flushPendingNotifications(): void {
+    for (const notification of this.pendingNotifications.splice(0)) {
+      this.handleNotification(notification.method, notification.params);
+      if (this.terminal) break;
+    }
+  }
+
+  private async handleServerRequest(request: Extract<CodexAppServerIncoming, { kind: 'request' }>): Promise<void> {
+    const decision = this.stopRequested ? 'cancel' : 'decline';
+    switch (request.method) {
+      case 'item/commandExecution/requestApproval':
+      case 'item/fileChange/requestApproval':
+        await this.rpc.respond(request.id, { decision });
+        return;
+      case 'item/tool/requestUserInput':
+        await this.rpc.respond(request.id, { answers: {} });
+        return;
+      case 'mcpServer/elicitation/request':
+        await this.rpc.respond(request.id, { action: decision });
+        return;
+      case 'item/permissions/requestApproval':
+        await this.rpc.respond(request.id, { permissions: {}, scope: 'turn' });
+        return;
+      case 'applyPatchApproval':
+      case 'execCommandApproval':
+        await this.rpc.respond(
+          request.id,
+          this.stopRequested
+            ? { decision: 'abort' }
+            : { decision: { denied: { rejection: 'lark-channel-bridge approval policy is never' } } },
+        );
+        return;
+      default:
+        log.warn('app-server', 'unsupported-server-request', { method: request.method });
+        await this.rpc.respondError(request.id, -32601, `unsupported server request: ${request.method}`);
+    }
+  }
+
+  private publish(events: readonly AgentEvent[]): void {
+    for (const event of events) {
+      this.queue.push(event);
+      if (event.type === 'done' || event.type === 'error') {
+        if (!this.terminal) {
+          this.terminal = true;
+          this.resolveTerminal();
+          this.queue.close();
+        }
+      }
+    }
+  }
+
+  private failTransport(error: unknown): void {
+    const err = error instanceof Error ? error : new Error(String(error));
+    this.runtimeError = err;
+    this.rpc.fail(err);
+    this.publish(this.translator.fail(`codex app-server protocol error: ${err.message}`));
+    this.terminate('SIGTERM');
+  }
+
+  private beginNormalShutdown(): void {
+    if (!this.terminal || this.exited) return;
+    if (!this.child.stdin.destroyed && !this.child.stdin.writableEnded) this.child.stdin.end();
+    if (this.normalShutdownTimer) return;
+    this.normalShutdownTimer = setTimeout(() => this.terminate('SIGTERM'), NORMAL_SHUTDOWN_GRACE_MS);
+  }
+
+  private terminate(signal: NodeJS.Signals): void {
+    if (this.exited || this.child.exitCode !== null || this.child.signalCode !== null) return;
+    this.child.kill(signal);
+  }
+
+  private writeMessage(message: unknown): Promise<void> {
+    const line = `${JSON.stringify(message)}\n`;
+    const operation = this.writeTail.then(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          if (this.child.stdin.destroyed || this.child.stdin.writableEnded) {
+            reject(new Error('codex app-server stdin is closed'));
+            return;
+          }
+          try {
+            this.child.stdin.write(line, 'utf8', (err?: Error | null) => {
+              if (err) reject(err);
+              else resolve();
+            });
+          } catch (err) {
+            reject(err instanceof Error ? err : new Error(String(err)));
+          }
+        }),
+    );
+    this.writeTail = operation.catch(() => undefined);
+    return operation;
+  }
+}
+
+class AsyncEventQueue implements AsyncIterable<AgentEvent> {
+  private readonly values: AgentEvent[] = [];
+  private readonly waiters: Array<(result: IteratorResult<AgentEvent>) => void> = [];
+  private closed = false;
+
+  push(event: AgentEvent): void {
+    if (this.closed) return;
+    const waiter = this.waiters.shift();
+    if (waiter) waiter({ done: false, value: event });
+    else this.values.push(event);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) waiter({ done: true, value: undefined });
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<AgentEvent> {
+    return {
+      next: (): Promise<IteratorResult<AgentEvent>> => {
+        const value = this.values.shift();
+        if (value) return Promise.resolve({ done: false, value });
+        if (this.closed) return Promise.resolve({ done: true, value: undefined });
+        return new Promise<IteratorResult<AgentEvent>>((resolve) => this.waiters.push(resolve));
+      },
+    };
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, operation: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`codex app-server ${operation} timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function waitForPromise(promise: Promise<void>, timeoutMs: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => true),
+      new Promise<false>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function isRunNotification(method: string): boolean {
+  return (
+    method === 'error' ||
+    method === 'thread/tokenUsage/updated' ||
+    method.startsWith('turn/') ||
+    method.startsWith('item/')
+  );
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/agent/codex/app-server-adapter.ts
+++ b/src/agent/codex/app-server-adapter.ts
@@ -29,9 +29,12 @@ import {
   buildLeanAppServerArgs,
 } from './app-server-lean';
 import {
+  APP_SERVER_PROCESS_GROUP_ENABLED,
   buildAppServerProcessEnv,
   readAppServerConfigInventory,
   readAppServerFeatureInventory,
+  signalAppServerProcess,
+  terminateAppServerProcessGroup,
   type CodexAppServerProcessOptions,
 } from './app-server-process';
 
@@ -41,11 +44,16 @@ export interface CodexAppServerAdapterOptions extends CodexAppServerProcessOptio
   sandbox?: SandboxMode;
   stopGraceMs?: number;
   developerInstructions?: string;
+  /** Observe matching raw run notifications, including notifications with no display event. */
+  onActivity?: () => void;
+  /** Persist/reconcile a fresh in-memory thread id before its first turn is submitted. */
+  onThreadCandidate?: (threadId: string) => Promise<void>;
 }
 
 type CodexAppServerChild = SpawnedProcessByStdio<Writable, Readable, Readable>;
 
 const RPC_TIMEOUT_MS = 15_000;
+const THREAD_NAME_TIMEOUT_MS = 2_000;
 const NORMAL_SHUTDOWN_GRACE_MS = 250;
 const MAX_PROTOCOL_LINE_CHARS = 4 * 1024 * 1024;
 const MAX_BUFFERED_NOTIFICATIONS = 2_000;
@@ -212,6 +220,7 @@ class CodexAppServerRun implements AgentRun {
         cwd: input.run.cwd,
         env: buildAppServerProcessEnv(input.adapter),
         stdio: ['pipe', 'pipe', 'pipe'],
+        detached: APP_SERVER_PROCESS_GROUP_ENABLED,
       },
     ) as CodexAppServerChild;
 
@@ -237,7 +246,16 @@ class CodexAppServerRun implements AgentRun {
         }
         this.readline.close();
         this.queue.close();
-        resolve();
+        void terminateAppServerProcessGroup(this.child).then(
+          () => resolve(),
+          (err) => {
+            log.warn('app-server', 'process-group-cleanup-failed', {
+              pid: this.child.pid ?? null,
+              message: errorMessage(err),
+            });
+            resolve();
+          },
+        );
       });
     });
 
@@ -257,7 +275,10 @@ class CodexAppServerRun implements AgentRun {
   }
 
   async stop(): Promise<void> {
-    if (this.exited) return;
+    if (this.exited) {
+      await this.exitPromise;
+      return;
+    }
     this.stopRequested = true;
     const graceMs = this.input.run.stopGraceMs ?? this.input.adapter.stopGraceMs ?? 5000;
 
@@ -295,7 +316,6 @@ class CodexAppServerRun implements AgentRun {
   }
 
   waitForExit(timeoutMs: number): Promise<boolean> {
-    if (this.exited) return Promise.resolve(true);
     return waitForPromise(this.exitPromise, timeoutMs);
   }
 
@@ -341,7 +361,7 @@ class CodexAppServerRun implements AgentRun {
           title: 'Lark Channel Bridge',
           version: pkg.version,
         },
-        capabilities: null,
+        capabilities: { experimentalApi: true },
       }),
       RPC_TIMEOUT_MS,
       'initialize',
@@ -367,25 +387,9 @@ class CodexAppServerRun implements AgentRun {
     }
     this.threadId = threadId;
     if (!this.input.run.threadId) {
-      await withTimeout(
-        this.rpc.request('thread/name/set', {
-          threadId,
-          name: this.input.run.threadName?.trim() || '飞书 · 新会话',
-        }),
-        RPC_TIMEOUT_MS,
-        'thread/name/set',
-      );
+      await this.input.adapter.onThreadCandidate?.(threadId);
+      if (this.stopRequested) throw new Error('codex app-server run stopped before turn start');
     }
-    this.publish([
-      {
-        type: 'system',
-        threadId,
-        cwd: stringValue(threadResponse?.cwd) ?? this.input.run.cwd,
-        ...(stringValue(threadResponse?.model) ?? this.input.run.model
-          ? { model: stringValue(threadResponse?.model) ?? this.input.run.model }
-          : {}),
-      },
-    ]);
 
     const turnResult = await withTimeout(
       this.rpc.request('turn/start', {
@@ -407,7 +411,45 @@ class CodexAppServerRun implements AgentRun {
     if (!turnId) throw new Error('codex app-server returned no turn id');
     this.turnId = turnId;
     this.translator.setContext(threadId, turnId);
+    // A fresh thread becomes resumable only once its first turn has started.
+    // Publish it now so task controllers never persist an in-memory-only id.
+    this.publish([
+      {
+        type: 'system',
+        threadId,
+        cwd: stringValue(threadResponse?.cwd) ?? this.input.run.cwd,
+        ...(stringValue(threadResponse?.model) ?? this.input.run.model
+          ? { model: stringValue(threadResponse?.model) ?? this.input.run.model }
+          : {}),
+      },
+    ]);
+    if (!this.input.run.threadId) {
+      void this.setFreshThreadName(threadId);
+      // Let the queued name request reach stdin before a synchronously buffered
+      // terminal notification closes the normal-shutdown side of the pipe.
+      await Promise.resolve();
+    }
     this.flushPendingNotifications();
+  }
+
+  private async setFreshThreadName(threadId: string): Promise<void> {
+    try {
+      await withTimeout(
+        this.rpc.request('thread/name/set', {
+          threadId,
+          name: this.input.run.threadName?.trim() || '飞书 · 新会话',
+        }),
+        THREAD_NAME_TIMEOUT_MS,
+        'thread/name/set',
+      );
+    } catch (err) {
+      // Naming is cosmetic. A rejected or unsupported name must not discard a
+      // turn that has already started successfully.
+      log.warn('app-server', 'thread-name-failed', {
+        threadId,
+        message: errorMessage(err),
+      });
+    }
   }
 
   private threadParams(): Record<string, unknown> {
@@ -420,7 +462,7 @@ class CodexAppServerRun implements AgentRun {
       ...(this.input.run.model ? { model: this.input.run.model } : {}),
     };
     return this.input.run.threadId
-      ? { threadId: this.input.run.threadId, ...common }
+      ? { threadId: this.input.run.threadId, excludeTurns: true, ...common }
       : {
           serviceName: 'lark-channel-bridge',
           threadSource: 'user',
@@ -470,6 +512,18 @@ class CodexAppServerRun implements AgentRun {
   }
 
   private handleNotification(method: string, params: unknown): void {
+    const notification = recordValue(params);
+    if (
+      !this.turnId &&
+      this.input.run.threadId &&
+      method === 'thread/tokenUsage/updated' &&
+      notification &&
+      !stringValue(notification.turnId)
+    ) {
+      // Legacy servers may replay cumulative usage without a turn id after
+      // resume. Such a snapshot cannot be attributed safely to the new turn.
+      return;
+    }
     if (!this.turnId && isRunNotification(method)) {
       if (this.pendingNotifications.length >= MAX_BUFFERED_NOTIFICATIONS) {
         this.failTransport(new Error('codex app-server notification buffer overflow'));
@@ -477,6 +531,14 @@ class CodexAppServerRun implements AgentRun {
       }
       this.pendingNotifications.push({ method, params });
       return;
+    }
+    if (
+      !this.terminal &&
+      isRunNotification(method) &&
+      notification &&
+      this.matchesCurrentRunNotification(notification)
+    ) {
+      this.notifyActivity();
     }
     const events = this.translator.translate(method, params);
     this.publish(events);
@@ -501,7 +563,7 @@ class CodexAppServerRun implements AgentRun {
         await this.rpc.respond(request.id, { answers: {} });
         return;
       case 'mcpServer/elicitation/request':
-        await this.rpc.respond(request.id, { action: decision });
+        await this.rpc.respond(request.id, { action: decision, content: null });
         return;
       case 'item/permissions/requestApproval':
         await this.rpc.respond(request.id, { permissions: {}, scope: 'turn' });
@@ -551,8 +613,25 @@ class CodexAppServerRun implements AgentRun {
   }
 
   private terminate(signal: NodeJS.Signals): void {
-    if (this.exited || this.child.exitCode !== null || this.child.signalCode !== null) return;
-    this.child.kill(signal);
+    if (this.exited) return;
+    signalAppServerProcess(this.child, signal);
+  }
+
+  private matchesCurrentRunNotification(params: Record<string, unknown>): boolean {
+    if (!this.threadId || !this.turnId) return false;
+    const eventThreadId = stringValue(params.threadId);
+    const eventTurnId = stringValue(params.turnId ?? recordValue(params.turn)?.id);
+    if (eventThreadId && eventThreadId !== this.threadId) return false;
+    if (eventTurnId && eventTurnId !== this.turnId) return false;
+    return true;
+  }
+
+  private notifyActivity(): void {
+    try {
+      this.input.adapter.onActivity?.();
+    } catch (err) {
+      log.warn('app-server', 'activity-hook-failed', { message: errorMessage(err) });
+    }
   }
 
   private writeMessage(message: unknown): Promise<void> {

--- a/src/agent/codex/app-server-adapter.ts
+++ b/src/agent/codex/app-server-adapter.ts
@@ -6,7 +6,12 @@ import { log } from '../../core/logger';
 import { spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
 import { SpawnFailed } from '../../runtime/errors';
 import { buildBridgeSystemPrompt } from '../bridge-system-prompt';
-import { checkAgentAvailability, type AgentAvailability } from '../preflight';
+import {
+  AgentPreflightError,
+  checkAgentAvailability,
+  type AgentAvailability,
+  type AgentPreflightDiagnostic,
+} from '../preflight';
 import type {
   AgentAdapter,
   AgentBotIdentity,
@@ -20,11 +25,13 @@ import {
   type CodexAppServerIncoming,
 } from './app-server-jsonrpc';
 import {
+  assertMcpServersDisabled,
   buildLeanAppServerArgs,
 } from './app-server-lean';
 import {
   buildAppServerProcessEnv,
   readAppServerConfigInventory,
+  readAppServerFeatureInventory,
   type CodexAppServerProcessOptions,
 } from './app-server-process';
 
@@ -65,13 +72,24 @@ export class CodexAppServerAdapter implements AgentAdapter {
   }
 
   async checkAvailability(): Promise<AgentAvailability> {
-    return checkAgentAvailability({
+    const appServer = await checkAgentAvailability({
       agentId: 'codex',
       agentName: 'Codex App Server',
       command: this.options.binary,
       binaryPath: this.options.binary,
       args: ['app-server', '--help'],
     });
+    if (!appServer.ok) return appServer;
+    try {
+      await readAppServerFeatureInventory({
+        binary: this.options.binary,
+        cwd: process.cwd(),
+        env: buildAppServerProcessEnv(this.options),
+      });
+      return appServer;
+    } catch (err) {
+      return featureInventoryAvailabilityFailure(this.options.binary, err);
+    }
   }
 
   async prepareRun(options: AgentRunOptions): Promise<void> {
@@ -122,6 +140,32 @@ export class CodexAppServerAdapter implements AgentAdapter {
       argv,
     });
   }
+}
+
+function featureInventoryAvailabilityFailure(binary: string, error: unknown): AgentAvailability {
+  const message = error instanceof Error ? error.message : String(error);
+  const diagnostic: AgentPreflightDiagnostic = {
+    code: message.includes('timed out')
+      ? 'agent-version-check-timeout'
+      : message.includes('no parseable feature inventory')
+        ? 'agent-version-check-empty-output'
+        : 'agent-version-check-nonzero-exit',
+    agentId: 'codex',
+    agentName: 'Codex App Server',
+    command: binary,
+    binaryPath: binary,
+    args: ['features', 'list'],
+    ...(message.includes('timed out') ? { timeoutMs: 5_000 } : {}),
+    stderrExcerpt: message.slice(0, 500),
+  };
+  return {
+    ok: false,
+    diagnostic,
+    error: new AgentPreflightError(
+      diagnostic,
+      `Codex App Server feature inventory is unavailable: ${message}`,
+    ),
+  };
 }
 
 interface CodexAppServerRunInput {
@@ -304,6 +348,7 @@ class CodexAppServerRun implements AgentRun {
     );
     await this.rpc.notify('initialized');
     if (this.stopRequested) throw new Error('codex app-server run stopped during initialization');
+    await this.verifyLoadedMcpServers();
 
     const threadResult = await withTimeout(
       this.rpc.request(
@@ -384,6 +429,17 @@ class CodexAppServerRun implements AgentRun {
         };
   }
 
+  private async verifyLoadedMcpServers(): Promise<void> {
+    const response = recordValue(await withTimeout(
+      this.rpc.request('config/read', { includeLayers: false, cwd: this.input.run.cwd }),
+      RPC_TIMEOUT_MS,
+      'config/read',
+    ));
+    const config = recordValue(response?.config);
+    if (!config) throw new Error('codex app-server config/read returned no config');
+    assertMcpServersDisabled(config.mcp_servers ?? config.mcpServers);
+  }
+
   private receiveLine(line: string): void {
     const trimmed = line.trim();
     if (!trimmed) return;
@@ -450,13 +506,14 @@ class CodexAppServerRun implements AgentRun {
       case 'item/permissions/requestApproval':
         await this.rpc.respond(request.id, { permissions: {}, scope: 'turn' });
         return;
+      case 'currentTime/read':
+        await this.rpc.respond(request.id, { currentTimeAt: Math.floor(Date.now() / 1000) });
+        return;
       case 'applyPatchApproval':
       case 'execCommandApproval':
         await this.rpc.respond(
           request.id,
-          this.stopRequested
-            ? { decision: 'abort' }
-            : { decision: { denied: { rejection: 'lark-channel-bridge approval policy is never' } } },
+          { decision: this.stopRequested ? 'abort' : 'denied' },
         );
         return;
       default:

--- a/src/agent/codex/app-server-client.ts
+++ b/src/agent/codex/app-server-client.ts
@@ -8,7 +8,7 @@ import {
   type CodexAppServerProcessOptions,
 } from './app-server-process';
 import { CodexAppServerJsonRpc, type CodexAppServerIncoming } from './app-server-jsonrpc';
-import { buildLeanAppServerArgs } from './app-server-lean';
+import { assertMcpServersDisabled, buildLeanAppServerArgs } from './app-server-lean';
 
 type CodexAppServerChild = SpawnedProcessByStdio<Writable, Readable, Readable>;
 
@@ -104,6 +104,13 @@ export async function withCodexAppServerConnection<T>(
       capabilities: null,
     });
     await connection.notify('initialized');
+    const response = recordValue(await connection.request('config/read', {
+      includeLayers: false,
+      cwd: options.cwd,
+    }));
+    const config = recordValue(response?.config);
+    if (!config) throw new Error('codex app-server config/read returned no config');
+    assertMcpServersDisabled(config.mcp_servers ?? config.mcpServers);
     return await operation(connection);
   } finally {
     if (!child.stdin.destroyed && !child.stdin.writableEnded) child.stdin.end();
@@ -134,6 +141,10 @@ function receiveLine(line: string, rpc: CodexAppServerJsonRpc): void {
 
 function rejectServerRequest(rpc: CodexAppServerJsonRpc, request: CodexAppServerIncoming): void {
   if (request.kind !== 'request') return;
+  if (request.method === 'currentTime/read') {
+    void rpc.respond(request.id, { currentTimeAt: Math.floor(Date.now() / 1000) });
+    return;
+  }
   void rpc.respondError(request.id, -32601, `unsupported task-controller request: ${request.method}`);
 }
 
@@ -163,4 +174,10 @@ async function waitForPromise(promise: Promise<unknown>, timeoutMs: number): Pro
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
 }

--- a/src/agent/codex/app-server-client.ts
+++ b/src/agent/codex/app-server-client.ts
@@ -3,12 +3,16 @@ import type { Readable, Writable } from 'node:stream';
 import pkg from '../../../package.json';
 import { spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
 import {
+  APP_SERVER_PROCESS_GROUP_ENABLED,
   buildAppServerProcessEnv,
   readAppServerConfigInventory,
+  terminateAndReapChild,
   type CodexAppServerProcessOptions,
 } from './app-server-process';
 import { CodexAppServerJsonRpc, type CodexAppServerIncoming } from './app-server-jsonrpc';
 import { assertMcpServersDisabled, buildLeanAppServerArgs } from './app-server-lean';
+
+export { CodexAppServerRpcError } from './app-server-jsonrpc';
 
 type CodexAppServerChild = SpawnedProcessByStdio<Writable, Readable, Readable>;
 
@@ -45,6 +49,7 @@ export async function withCodexAppServerConnection<T>(
     cwd: options.cwd,
     env,
     stdio: ['pipe', 'pipe', 'pipe'],
+    detached: APP_SERVER_PROCESS_GROUP_ENABLED,
   }) as CodexAppServerChild;
   const stderrChunks: Buffer[] = [];
   let stderrBytes = 0;
@@ -113,14 +118,7 @@ export async function withCodexAppServerConnection<T>(
     assertMcpServersDisabled(config.mcp_servers ?? config.mcpServers);
     return await operation(connection);
   } finally {
-    if (!child.stdin.destroyed && !child.stdin.writableEnded) child.stdin.end();
-    if (!(await waitForPromise(closed, 500))) {
-      if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
-      if (!(await waitForPromise(closed, 500)) && child.exitCode === null && child.signalCode === null) {
-        child.kill('SIGKILL');
-        await waitForPromise(closed, 500);
-      }
-    }
+    await terminateAndReapChild(child, closed);
   }
 }
 
@@ -155,20 +153,6 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: str
       promise,
       new Promise<never>((_, reject) => {
         timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
-      }),
-    ]);
-  } finally {
-    if (timer) clearTimeout(timer);
-  }
-}
-
-async function waitForPromise(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  try {
-    return await Promise.race([
-      promise.then(() => true, () => true),
-      new Promise<boolean>((resolve) => {
-        timer = setTimeout(() => resolve(false), timeoutMs);
       }),
     ]);
   } finally {

--- a/src/agent/codex/app-server-client.ts
+++ b/src/agent/codex/app-server-client.ts
@@ -1,0 +1,166 @@
+import { createInterface } from 'node:readline';
+import type { Readable, Writable } from 'node:stream';
+import pkg from '../../../package.json';
+import { spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
+import {
+  buildAppServerProcessEnv,
+  readAppServerConfigInventory,
+  type CodexAppServerProcessOptions,
+} from './app-server-process';
+import { CodexAppServerJsonRpc, type CodexAppServerIncoming } from './app-server-jsonrpc';
+import { buildLeanAppServerArgs } from './app-server-lean';
+
+type CodexAppServerChild = SpawnedProcessByStdio<Writable, Readable, Readable>;
+
+export interface CodexAppServerClientOptions extends CodexAppServerProcessOptions {
+  cwd: string;
+  clientName?: string;
+  clientTitle?: string;
+  timeoutMs?: number;
+}
+
+export interface CodexAppServerConnection {
+  request(method: string, params: unknown): Promise<unknown>;
+  notify(method: string, params?: unknown): Promise<void>;
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000;
+const MAX_PROTOCOL_LINE_CHARS = 4 * 1024 * 1024;
+
+/**
+ * Open a short-lived, lean app-server connection for deterministic control-plane
+ * RPCs. The connection is initialized before `operation` runs and always reaped.
+ */
+export async function withCodexAppServerConnection<T>(
+  options: CodexAppServerClientOptions,
+  operation: (connection: CodexAppServerConnection) => Promise<T>,
+): Promise<T> {
+  const env = buildAppServerProcessEnv(options);
+  const inventory = await readAppServerConfigInventory({
+    binary: options.binary,
+    cwd: options.cwd,
+    env,
+  });
+  const child = spawnProcess(options.binary, buildLeanAppServerArgs(inventory), {
+    cwd: options.cwd,
+    env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) as CodexAppServerChild;
+  const stderrChunks: Buffer[] = [];
+  let stderrBytes = 0;
+  let writeTail = Promise.resolve();
+  const writeMessage = (message: unknown): Promise<void> => {
+    const line = `${JSON.stringify(message)}\n`;
+    const write = writeTail.then(
+      () => new Promise<void>((resolve, reject) => {
+        if (child.stdin.destroyed || child.stdin.writableEnded) {
+          reject(new Error('codex app-server control connection stdin is closed'));
+          return;
+        }
+        child.stdin.write(line, 'utf8', (err?: Error | null) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      }),
+    );
+    writeTail = write.catch(() => undefined);
+    return write;
+  };
+  const rpc = new CodexAppServerJsonRpc(writeMessage);
+  const readline = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  const closed = new Promise<void>((resolve) => {
+    child.once('close', (code, signal) => {
+      const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+      rpc.fail(new Error(
+        stderr.slice(0, 500) || `codex app-server control connection exited: ${code ?? signal ?? 'unknown'}`,
+      ));
+      readline.close();
+      resolve();
+    });
+  });
+  child.once('error', (err) => rpc.fail(err));
+  child.stdin.on('error', (err) => rpc.fail(err));
+  child.stderr.on('data', (chunk: Buffer) => {
+    if (stderrBytes >= 64 * 1024) return;
+    stderrChunks.push(chunk);
+    stderrBytes += chunk.byteLength;
+  });
+  readline.on('line', (line) => receiveLine(line, rpc));
+
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const connection: CodexAppServerConnection = {
+    request: (method, params) => withTimeout(rpc.request(method, params), timeoutMs, method),
+    notify: (method, params) => rpc.notify(method, params),
+  };
+
+  try {
+    if (!child.pid) throw new Error('failed to spawn codex app-server control connection');
+    await connection.request('initialize', {
+      clientInfo: {
+        name: options.clientName ?? 'lark-channel-bridge-task-controller',
+        title: options.clientTitle ?? 'Lark Channel Bridge Task Controller',
+        version: pkg.version,
+      },
+      capabilities: null,
+    });
+    await connection.notify('initialized');
+    return await operation(connection);
+  } finally {
+    if (!child.stdin.destroyed && !child.stdin.writableEnded) child.stdin.end();
+    if (!(await waitForPromise(closed, 500))) {
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+      if (!(await waitForPromise(closed, 500)) && child.exitCode === null && child.signalCode === null) {
+        child.kill('SIGKILL');
+        await waitForPromise(closed, 500);
+      }
+    }
+  }
+}
+
+function receiveLine(line: string, rpc: CodexAppServerJsonRpc): void {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  if (trimmed.length > MAX_PROTOCOL_LINE_CHARS) {
+    rpc.fail(new Error('codex app-server control connection emitted an oversized protocol line'));
+    return;
+  }
+  try {
+    const incoming = rpc.receive(JSON.parse(trimmed));
+    if (incoming?.kind === 'request') rejectServerRequest(rpc, incoming);
+  } catch (err) {
+    rpc.fail(err);
+  }
+}
+
+function rejectServerRequest(rpc: CodexAppServerJsonRpc, request: CodexAppServerIncoming): void {
+  if (request.kind !== 'request') return;
+  void rpc.respondError(request.id, -32601, `unsupported task-controller request: ${request.method}`);
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out after ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function waitForPromise(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => true, () => true),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/src/agent/codex/app-server-jsonrpc.ts
+++ b/src/agent/codex/app-server-jsonrpc.ts
@@ -1,0 +1,563 @@
+import { log } from '../../core/logger';
+import type { AgentEvent } from '../types';
+import type { CodexFinishReason, ProtocolDriftState } from './jsonl';
+
+export type JsonRpcId = number | string;
+
+export type CodexAppServerIncoming =
+  | { kind: 'notification'; method: string; params: unknown }
+  | { kind: 'request'; id: JsonRpcId; method: string; params: unknown };
+
+export class CodexAppServerRpcError extends Error {
+  readonly code: number | string | undefined;
+  readonly data: unknown;
+
+  constructor(message: string, code?: number | string, data?: unknown) {
+    super(message);
+    this.name = 'CodexAppServerRpcError';
+    this.code = code;
+    this.data = data;
+  }
+}
+
+interface PendingRequest {
+  method: string;
+  resolve(value: unknown): void;
+  reject(error: Error): void;
+}
+
+/**
+ * Minimal JSONL request/response multiplexer for `codex app-server` stdio.
+ * The protocol deliberately omits the JSON-RPC `jsonrpc` field.
+ */
+export class CodexAppServerJsonRpc {
+  private readonly writeMessage: (message: unknown) => Promise<void>;
+  private readonly pending = new Map<JsonRpcId, PendingRequest>();
+  private nextId = 1;
+  private closedError: Error | undefined;
+
+  constructor(writeMessage: (message: unknown) => Promise<void>) {
+    this.writeMessage = writeMessage;
+  }
+
+  request(method: string, params: unknown): Promise<unknown> {
+    if (this.closedError) return Promise.reject(this.closedError);
+    const id = this.nextId++;
+    const response = new Promise<unknown>((resolve, reject) => {
+      this.pending.set(id, { method, resolve, reject });
+    });
+    void this.writeMessage({ method, id, params }).catch((err) => {
+      const pending = this.pending.get(id);
+      if (!pending) return;
+      this.pending.delete(id);
+      pending.reject(asError(err, `failed to write ${method} request`));
+    });
+    return response;
+  }
+
+  notify(method: string, params?: unknown): Promise<void> {
+    if (this.closedError) return Promise.reject(this.closedError);
+    return this.writeMessage(params === undefined ? { method } : { method, params });
+  }
+
+  respond(id: JsonRpcId, result: unknown): Promise<void> {
+    if (this.closedError) return Promise.reject(this.closedError);
+    return this.writeMessage({ id, result });
+  }
+
+  respondError(id: JsonRpcId, code: number, message: string): Promise<void> {
+    if (this.closedError) return Promise.reject(this.closedError);
+    return this.writeMessage({ id, error: { code, message } });
+  }
+
+  receive(input: unknown): CodexAppServerIncoming | undefined {
+    const message = recordValue(input);
+    if (!message) throw new Error('codex app-server emitted a non-object message');
+
+    if (typeof message.method === 'string') {
+      if (isJsonRpcId(message.id)) {
+        return {
+          kind: 'request',
+          id: message.id,
+          method: message.method,
+          params: message.params,
+        };
+      }
+      return { kind: 'notification', method: message.method, params: message.params };
+    }
+
+    if (!isJsonRpcId(message.id)) {
+      throw new Error('codex app-server message has neither method nor request id');
+    }
+    const pending = this.pending.get(message.id);
+    if (!pending) {
+      throw new Error(`codex app-server returned an unknown response id: ${String(message.id)}`);
+    }
+    this.pending.delete(message.id);
+    if (Object.prototype.hasOwnProperty.call(message, 'error')) {
+      const error = recordValue(message.error);
+      pending.reject(
+        new CodexAppServerRpcError(
+          stringValue(error?.message) ?? `codex app-server rejected ${pending.method}`,
+          numberOrStringValue(error?.code),
+          error?.data,
+        ),
+      );
+    } else if (Object.prototype.hasOwnProperty.call(message, 'result')) {
+      pending.resolve(message.result);
+    } else {
+      pending.reject(new Error(`codex app-server returned a malformed ${pending.method} response`));
+    }
+    return undefined;
+  }
+
+  fail(error: unknown): void {
+    if (this.closedError) return;
+    this.closedError = asError(error, 'codex app-server connection closed');
+    for (const pending of this.pending.values()) pending.reject(this.closedError);
+    this.pending.clear();
+  }
+}
+
+interface AgentMessageState {
+  text: string;
+  emittedText: string;
+  phase?: string;
+}
+
+interface UsageState {
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedInputTokens?: number;
+  reasoningOutputTokens?: number;
+}
+
+/** Translates app-server notifications into the bridge's stable AgentEvent contract. */
+export class CodexAppServerEventTranslator {
+  private threadId: string | undefined;
+  private turnId: string | undefined;
+  private terminal = false;
+  private lastNonTerminalError: string | undefined;
+  private finalText: string | undefined;
+  private finalMessageId: string | undefined;
+  private finalMessagePhase: string | undefined;
+  private latestUsage: UsageState | undefined;
+  private readonly messages = new Map<string, AgentMessageState>();
+  private readonly startedTools = new Set<string>();
+  private drift: ProtocolDriftState = { unknownEvents: 0, anomalies: 0 };
+
+  setContext(threadId: string, turnId: string): void {
+    this.threadId = threadId;
+    this.turnId = turnId;
+  }
+
+  translate(method: string, input: unknown): AgentEvent[] {
+    if (this.terminal) return [];
+    const params = recordValue(input);
+    if (!params) {
+      this.drift.anomalies++;
+      return [];
+    }
+    if (!this.matchesContext(params)) return [];
+
+    switch (method) {
+      case 'turn/started':
+      case 'thread/started':
+        return [];
+      case 'item/started':
+        return this.translateItemStarted(params);
+      case 'item/completed':
+        return this.translateItemCompleted(params);
+      case 'item/agentMessage/delta':
+        return this.translateAgentMessageDelta(params);
+      case 'item/reasoning/summaryTextDelta': {
+        const delta = stringValue(params.delta);
+        return delta ? [{ type: 'thinking', delta }] : [];
+      }
+      case 'thread/tokenUsage/updated':
+        this.captureUsage(params);
+        return [];
+      case 'error': {
+        const error = recordValue(params.error);
+        const message = stringValue(error?.message);
+        if (message && params.willRetry !== true) this.lastNonTerminalError = message;
+        return [];
+      }
+      case 'turn/completed':
+        return this.translateTurnCompleted(params);
+      case 'item/commandExecution/outputDelta':
+      case 'item/fileChange/outputDelta':
+      case 'item/fileChange/patchUpdated':
+      case 'item/mcpToolCall/progress':
+      case 'item/reasoning/summaryPartAdded':
+      case 'item/reasoning/textDelta':
+        return [];
+      default:
+        this.drift.unknownEvents++;
+        log.warn('app-server', 'unknown-notification', { method });
+        return [];
+    }
+  }
+
+  finish(reason: CodexFinishReason = 'failed', detail?: string): AgentEvent[] {
+    if (this.terminal) return [];
+    this.terminal = true;
+    const events = this.incompleteEvents();
+    if (reason === 'failed') {
+      const suffix = detail ?? this.lastNonTerminalError;
+      events.push({
+        type: 'error',
+        message: truncate(
+          suffix
+            ? `codex app-server stream ended before a terminal event: ${suffix}`
+            : 'codex app-server stream ended before a terminal event',
+          4096,
+        ),
+        terminationReason: 'failed',
+      });
+    } else {
+      events.push({ type: 'done', threadId: this.threadId, terminationReason: reason });
+    }
+    return events;
+  }
+
+  fail(message: string): AgentEvent[] {
+    if (this.terminal) return [];
+    this.terminal = true;
+    return [
+      ...this.incompleteEvents(),
+      { type: 'error', message: truncate(message, 4096), terminationReason: 'failed' },
+    ];
+  }
+
+  terminalEmitted(): boolean {
+    return this.terminal;
+  }
+
+  protocolDrift(): ProtocolDriftState {
+    return { ...this.drift };
+  }
+
+  private matchesContext(params: Record<string, unknown>): boolean {
+    const eventThreadId = stringValue(params.threadId);
+    const eventTurnId = stringValue(params.turnId ?? recordValue(params.turn)?.id);
+    if (eventThreadId && this.threadId && eventThreadId !== this.threadId) {
+      this.drift.anomalies++;
+      return false;
+    }
+    if (eventTurnId && this.turnId && eventTurnId !== this.turnId) {
+      this.drift.anomalies++;
+      return false;
+    }
+    return true;
+  }
+
+  private translateAgentMessageDelta(params: Record<string, unknown>): AgentEvent[] {
+    const itemId = stringValue(params.itemId);
+    const delta = stringValue(params.delta);
+    if (!itemId || delta === undefined) {
+      this.drift.anomalies++;
+      return [];
+    }
+    const events = this.flushUnphasedFinal(itemId);
+    const message = this.messages.get(itemId) ?? { text: '', emittedText: '' };
+    message.text += delta;
+    this.messages.set(itemId, message);
+    if (delta && message.phase === 'commentary') {
+      message.emittedText += delta;
+      events.push({ type: 'text', delta });
+    } else if (message.phase === 'final_answer' || message.phase === undefined) {
+      this.setFinalCandidate(itemId, message.phase, message.text);
+    }
+    return events;
+  }
+
+  private translateItemStarted(params: Record<string, unknown>): AgentEvent[] {
+    const item = recordValue(params.item);
+    const id = stringValue(item?.id);
+    const type = stringValue(item?.type);
+    if (!item || !id || !type) {
+      this.drift.anomalies++;
+      return [];
+    }
+    if (type === 'agentMessage') {
+      const events = this.flushUnphasedFinal(id);
+      const prior = this.messages.get(id) ?? { text: '', emittedText: '' };
+      const phase = stringValue(item.phase) ?? prior.phase;
+      const text = prior.text || stringValue(item.text) || '';
+      const next = { ...prior, text, ...(phase ? { phase } : {}) };
+      this.messages.set(id, next);
+      if (phase === 'commentary') {
+        events.push(...this.emitCommentarySuffix(next));
+        if (this.finalMessageId === id) this.clearFinalCandidate();
+      } else if (phase === 'final_answer' || phase === undefined) {
+        this.setFinalCandidate(id, phase, text);
+      }
+      return events;
+    }
+    const events = this.flushUnphasedFinal();
+    const tool = toolFromItem(item);
+    if (!tool) return events;
+    this.startedTools.add(id);
+    events.push({ type: 'tool_use', id, name: tool.name, input: tool.input });
+    return events;
+  }
+
+  private translateItemCompleted(params: Record<string, unknown>): AgentEvent[] {
+    const item = recordValue(params.item);
+    const id = stringValue(item?.id);
+    const type = stringValue(item?.type);
+    if (!item || !id || !type) {
+      this.drift.anomalies++;
+      return [];
+    }
+    if (type === 'agentMessage') return this.completeAgentMessage(id, item);
+
+    const events = this.flushUnphasedFinal();
+    const tool = toolFromItem(item);
+    if (!tool) return events;
+    if (!this.startedTools.has(id)) {
+      this.drift.anomalies++;
+      events.push({ type: 'tool_use', id, name: tool.name, input: tool.input });
+    }
+    this.startedTools.delete(id);
+    events.push({
+      type: 'tool_result',
+      id,
+      output: toolOutput(item),
+      isError: toolFailed(item),
+    });
+    return events;
+  }
+
+  private completeAgentMessage(id: string, item: Record<string, unknown>): AgentEvent[] {
+    const completedText = stringValue(item.text) ?? '';
+    const events = this.flushUnphasedFinal(id);
+    const state = this.messages.get(id) ?? { text: '', emittedText: '' };
+    const phase = stringValue(item.phase) ?? state.phase;
+    const authoritativeText = completedText || state.text;
+    state.text = authoritativeText;
+    if (phase) state.phase = phase;
+    this.messages.set(id, state);
+    if (phase === 'commentary') {
+      events.push(...this.emitCommentarySuffix(state));
+      if (this.finalMessageId === id) this.clearFinalCandidate();
+    } else if (authoritativeText) {
+      this.setFinalCandidate(id, phase, authoritativeText);
+    }
+    return events;
+  }
+
+  private emitCommentarySuffix(state: AgentMessageState): AgentEvent[] {
+    if (!state.text || state.text === state.emittedText) return [];
+    if (!state.text.startsWith(state.emittedText)) {
+      this.drift.anomalies++;
+      return [];
+    }
+    const suffix = state.text.slice(state.emittedText.length);
+    state.emittedText = state.text;
+    return suffix ? [{ type: 'text', delta: suffix }] : [];
+  }
+
+  private flushUnphasedFinal(exceptId?: string): AgentEvent[] {
+    if (
+      !this.finalMessageId ||
+      this.finalMessagePhase !== undefined ||
+      this.finalMessageId === exceptId
+    ) {
+      return [];
+    }
+    const state = this.messages.get(this.finalMessageId);
+    const events = state ? this.emitCommentarySuffix(state) : [];
+    this.clearFinalCandidate();
+    return events;
+  }
+
+  private setFinalCandidate(id: string, phase: string | undefined, text: string): void {
+    this.finalMessageId = id;
+    this.finalMessagePhase = phase;
+    this.finalText = text || undefined;
+  }
+
+  private clearFinalCandidate(): void {
+    this.finalText = undefined;
+    this.finalMessageId = undefined;
+    this.finalMessagePhase = undefined;
+  }
+
+  private captureUsage(params: Record<string, unknown>): void {
+    const tokenUsage = recordValue(params.tokenUsage);
+    const last = recordValue(tokenUsage?.last);
+    if (!last) {
+      this.drift.anomalies++;
+      return;
+    }
+    this.latestUsage = {
+      inputTokens: numberValue(last.inputTokens),
+      outputTokens: numberValue(last.outputTokens),
+      cachedInputTokens: numberValue(last.cachedInputTokens),
+      reasoningOutputTokens: numberValue(last.reasoningOutputTokens),
+    };
+  }
+
+  private translateTurnCompleted(params: Record<string, unknown>): AgentEvent[] {
+    const turn = recordValue(params.turn);
+    const status = stringValue(turn?.status);
+    if (!turn || !status || status === 'inProgress') {
+      this.drift.anomalies++;
+      return [];
+    }
+    this.terminal = true;
+    if (status === 'completed') {
+      const events = this.finalEvents();
+      events.push({ type: 'done', threadId: this.threadId, terminationReason: 'normal' });
+      return events;
+    }
+    const events = this.incompleteEvents();
+    if (status === 'interrupted') {
+      events.push({ type: 'done', threadId: this.threadId, terminationReason: 'interrupted' });
+      return events;
+    }
+    const error = recordValue(turn.error);
+    events.push({
+      type: 'error',
+      message: truncate(
+        stringValue(error?.message) ?? this.lastNonTerminalError ?? 'codex turn failed',
+        4096,
+      ),
+      terminationReason: 'failed',
+    });
+    return events;
+  }
+
+  private finalEvents(): AgentEvent[] {
+    const events: AgentEvent[] = [];
+    if (this.finalText) events.push({ type: 'final_text', content: this.finalText });
+    if (this.latestUsage) events.push({ type: 'usage', ...this.latestUsage });
+    return events;
+  }
+
+  private incompleteEvents(): AgentEvent[] {
+    const events: AgentEvent[] = [];
+    if (this.finalText) events.push({ type: 'text', delta: this.finalText });
+    if (this.latestUsage) events.push({ type: 'usage', ...this.latestUsage });
+    return events;
+  }
+}
+
+function toolFromItem(item: Record<string, unknown>): { name: string; input: unknown } | undefined {
+  switch (item.type) {
+    case 'commandExecution':
+      return {
+        name: 'Bash',
+        input: {
+          command: stringValue(item.command) ?? '',
+          cwd: stringValue(item.cwd) ?? '',
+          ...(Array.isArray(item.commandActions) ? { commandActions: item.commandActions } : {}),
+        },
+      };
+    case 'fileChange':
+      return { name: 'FileChange', input: { changes: item.changes ?? [] } };
+    case 'mcpToolCall':
+      return {
+        name: [stringValue(item.server), stringValue(item.tool)].filter(Boolean).join('/') || 'MCP',
+        input: item.arguments,
+      };
+    case 'dynamicToolCall':
+      return {
+        name: [stringValue(item.namespace), stringValue(item.tool)].filter(Boolean).join('/') || 'Tool',
+        input: item.arguments,
+      };
+    case 'collabAgentToolCall':
+      return {
+        name: stringValue(item.tool) ?? 'Agent',
+        input: {
+          prompt: item.prompt,
+          receiverThreadIds: item.receiverThreadIds,
+          model: item.model,
+        },
+      };
+    case 'webSearch':
+      return { name: 'WebSearch', input: { query: stringValue(item.query) ?? '' } };
+    case 'imageView':
+      return { name: 'ViewImage', input: { path: stringValue(item.path) ?? '' } };
+    case 'imageGeneration':
+      return { name: 'ImageGeneration', input: { revisedPrompt: item.revisedPrompt } };
+    default:
+      return undefined;
+  }
+}
+
+function toolOutput(item: Record<string, unknown>): string {
+  switch (item.type) {
+    case 'commandExecution':
+      return stringValue(item.aggregatedOutput) ?? '';
+    case 'fileChange':
+      return stringifyValue({ status: item.status, changes: item.changes });
+    case 'mcpToolCall':
+      return stringifyValue(item.error ?? item.result ?? '');
+    case 'dynamicToolCall':
+      return stringifyValue(item.contentItems ?? { success: item.success });
+    case 'collabAgentToolCall':
+      return stringifyValue({ status: item.status, agentsStates: item.agentsStates });
+    case 'webSearch':
+      return stringifyValue(item.results ?? '');
+    case 'imageView':
+      return stringValue(item.path) ?? '';
+    case 'imageGeneration':
+      return stringValue(item.result) ?? stringValue(item.savedPath) ?? '';
+    default:
+      return '';
+  }
+}
+
+function toolFailed(item: Record<string, unknown>): boolean {
+  const status = stringValue(item.status);
+  if (status === 'failed' || status === 'declined') return true;
+  const exitCode = numberValue(item.exitCode);
+  if (exitCode !== undefined && exitCode !== 0) return true;
+  if (item.type === 'mcpToolCall' && item.error != null) return true;
+  if (item.type === 'dynamicToolCall' && item.success === false) return true;
+  return false;
+}
+
+function stringifyValue(value: unknown): string {
+  if (typeof value === 'string') return value;
+  if (value === undefined || value === null) return '';
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function asError(error: unknown, fallback: string): Error {
+  if (error instanceof Error) return error;
+  return new Error(error === undefined ? fallback : String(error));
+}
+
+function isJsonRpcId(value: unknown): value is JsonRpcId {
+  return typeof value === 'string' || (typeof value === 'number' && Number.isFinite(value));
+}
+
+function numberOrStringValue(value: unknown): number | string | undefined {
+  return typeof value === 'string' || typeof value === 'number' ? value : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function numberValue(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}

--- a/src/agent/codex/app-server-jsonrpc.ts
+++ b/src/agent/codex/app-server-jsonrpc.ts
@@ -9,12 +9,14 @@ export type CodexAppServerIncoming =
   | { kind: 'request'; id: JsonRpcId; method: string; params: unknown };
 
 export class CodexAppServerRpcError extends Error {
+  readonly method: string;
   readonly code: number | string | undefined;
   readonly data: unknown;
 
-  constructor(message: string, code?: number | string, data?: unknown) {
+  constructor(method: string, message: string, code?: number | string, data?: unknown) {
     super(message);
     this.name = 'CodexAppServerRpcError';
+    this.method = method;
     this.code = code;
     this.data = data;
   }
@@ -98,6 +100,7 @@ export class CodexAppServerJsonRpc {
       const error = recordValue(message.error);
       pending.reject(
         new CodexAppServerRpcError(
+          pending.method,
           stringValue(error?.message) ?? `codex app-server rejected ${pending.method}`,
           numberOrStringValue(error?.code),
           error?.data,

--- a/src/agent/codex/app-server-lean.ts
+++ b/src/agent/codex/app-server-lean.ts
@@ -1,4 +1,5 @@
 export interface CodexAppServerConfigInventory {
+  features?: readonly string[];
   mcp_servers?: unknown;
 }
 
@@ -37,11 +38,36 @@ export function buildLeanAppServerArgs(inventory?: CodexAppServerConfigInventory
     '-c',
     'include_apps_instructions=false',
   ];
-  for (const feature of DISABLED_FEATURES) args.push('--disable', feature);
+  const supportedFeatures = new Set(inventory?.features ?? []);
+  for (const feature of DISABLED_FEATURES) {
+    if (supportedFeatures.has(feature)) args.push('--disable', feature);
+  }
 
   const mcpOverride = disabledMcpServersOverride(inventory?.mcp_servers);
   if (mcpOverride) args.push('-c', mcpOverride);
   return args;
+}
+
+export function parseCodexFeatureList(output: string): string[] {
+  const features = new Set<string>();
+  for (const line of output.split(/\r?\n/)) {
+    const match = line.trim().match(/^([a-z][a-z0-9_]*)\s+.+\s+(?:true|false)$/);
+    if (match?.[1]) features.add(match[1]);
+  }
+  return [...features];
+}
+
+export function assertMcpServersDisabled(input: unknown): void {
+  if (input === undefined || input === null) return;
+  const servers = recordValue(input);
+  if (!servers) throw new Error('codex app-server returned a malformed mcp_servers inventory');
+  const enabled = Object.entries(servers)
+    .filter(([, value]) => recordValue(value)?.enabled !== false)
+    .map(([name]) => name)
+    .sort((left, right) => left.localeCompare(right));
+  if (enabled.length > 0) {
+    throw new Error(`codex app-server loaded MCP servers that are not disabled: ${enabled.join(', ')}`);
+  }
 }
 
 function disabledMcpServersOverride(input: unknown): string | undefined {

--- a/src/agent/codex/app-server-lean.ts
+++ b/src/agent/codex/app-server-lean.ts
@@ -1,0 +1,71 @@
+export interface CodexAppServerConfigInventory {
+  mcp_servers?: unknown;
+}
+
+const DISABLED_FEATURES = [
+  'apps',
+  'enable_mcp_apps',
+  'plugins',
+  'remote_plugin',
+  'plugin_sharing',
+  'skill_mcp_dependency_install',
+  'tool_call_mcp_elicitation',
+  'tool_suggest',
+  'browser_use',
+  'browser_use_external',
+  'browser_use_full_cdp_access',
+  'in_app_browser',
+  'computer_use',
+  'request_permissions_tool',
+  'hooks',
+] as const;
+
+/**
+ * App-server shares the user's CODEX_HOME so its durable threads remain
+ * discoverable by Codex App. These process-local overrides remove desktop-only
+ * hooks and tool surfaces without rewriting the user's config.toml.
+ */
+export function buildLeanAppServerArgs(inventory?: CodexAppServerConfigInventory): string[] {
+  const args = [
+    'app-server',
+    '--listen',
+    'stdio://',
+    '-c',
+    'shell_environment_policy.inherit="all"',
+    '-c',
+    'notify=[]',
+    '-c',
+    'include_apps_instructions=false',
+  ];
+  for (const feature of DISABLED_FEATURES) args.push('--disable', feature);
+
+  const mcpOverride = disabledMcpServersOverride(inventory?.mcp_servers);
+  if (mcpOverride) args.push('-c', mcpOverride);
+  return args;
+}
+
+function disabledMcpServersOverride(input: unknown): string | undefined {
+  const servers = recordValue(input);
+  if (!servers) return undefined;
+  const entries = Object.entries(servers)
+    .filter(([, value]) => recordValue(value))
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([name, value]) => {
+      const config = recordValue(value);
+      const dummyTransport = typeof config?.url === 'string'
+        ? 'url="http://127.0.0.1"'
+        : 'command="disabled-by-lark-channel-bridge"';
+      return `${tomlString(name)}={enabled=false,${dummyTransport}}`;
+    });
+  return entries.length > 0 ? `mcp_servers={${entries.join(',')}}` : undefined;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value);
+}

--- a/src/agent/codex/app-server-process.ts
+++ b/src/agent/codex/app-server-process.ts
@@ -1,7 +1,9 @@
+import type { ChildProcess } from 'node:child_process';
 import { createInterface } from 'node:readline';
 import type { Readable, Writable } from 'node:stream';
 import { join } from 'node:path';
 import pkg from '../../../package.json';
+import { log } from '../../core/logger';
 import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
 import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel-env';
 import { CodexAppServerJsonRpc } from './app-server-jsonrpc';
@@ -25,12 +27,23 @@ export interface AppServerConfigProbeInput {
   binary: string;
   cwd: string;
   env: NodeJS.ProcessEnv;
+  featureListTimeoutMs?: number;
+  shutdownGraceMs?: number;
+}
+
+export interface TerminateChildOptions {
+  eofGraceMs?: number;
+  terminateGraceMs?: number;
+  killGraceMs?: number;
 }
 
 const RPC_TIMEOUT_MS = 15_000;
 const FEATURE_LIST_TIMEOUT_MS = 5_000;
 const MAX_PROTOCOL_LINE_CHARS = 4 * 1024 * 1024;
 const MAX_FEATURE_LIST_CHARS = 1024 * 1024;
+
+/** POSIX children get their own process group so wrapper descendants can be terminated together. */
+export const APP_SERVER_PROCESS_GROUP_ENABLED = process.platform !== 'win32';
 
 export async function readAppServerConfigInventory(
   input: AppServerConfigProbeInput,
@@ -40,6 +53,7 @@ export async function readAppServerConfigInventory(
     cwd: input.cwd,
     env: input.env,
     stdio: ['pipe', 'pipe', 'pipe'],
+    detached: APP_SERVER_PROCESS_GROUP_ENABLED,
   }) as CodexAppServerChild;
   const stderrChunks: Buffer[] = [];
   let stderrBytes = 0;
@@ -121,64 +135,138 @@ export async function readAppServerConfigInventory(
     if (!config) throw new Error('codex app-server config/read returned no config');
     return { features, mcp_servers: config.mcp_servers ?? config.mcpServers };
   } finally {
-    if (!child.stdin.destroyed && !child.stdin.writableEnded) child.stdin.end();
-    if (!(await waitForPromise(closed, 500))) {
-      if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
-      if (!(await waitForPromise(closed, 500)) && child.exitCode === null && child.signalCode === null) {
-        child.kill('SIGKILL');
-        await waitForPromise(closed, 500);
-      }
-    }
+    const graceMs = input.shutdownGraceMs ?? 500;
+    await terminateAndReapChild(child, closed, {
+      eofGraceMs: graceMs,
+      terminateGraceMs: graceMs,
+      killGraceMs: graceMs,
+    });
   }
 }
 
 export async function readAppServerFeatureInventory(
   input: AppServerConfigProbeInput,
 ): Promise<string[]> {
-  return new Promise<string[]>((resolve, reject) => {
-    const child = spawnProcess(input.binary, ['features', 'list'], {
-      cwd: input.cwd,
-      env: input.env,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-    let stdout = '';
-    let stderr = '';
-    let settled = false;
-    const timer = setTimeout(() => {
-      if (settled) return;
-      child.kill('SIGTERM');
-      settled = true;
-      reject(new Error(`codex features list timed out after ${FEATURE_LIST_TIMEOUT_MS}ms`));
-    }, FEATURE_LIST_TIMEOUT_MS);
-    const finish = (operation: () => void): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timer);
-      operation();
-    };
-    child.stdout?.on('data', (chunk: Buffer) => {
-      if (stdout.length < MAX_FEATURE_LIST_CHARS) stdout += chunk.toString('utf8');
-    });
-    child.stderr?.on('data', (chunk: Buffer) => {
-      if (stderr.length < 16 * 1024) stderr += chunk.toString('utf8');
-    });
-    child.once('error', (err) => finish(() => reject(err)));
-    child.once('close', (code, signal) => finish(() => {
-      if (code !== 0) {
-        reject(new Error(
-          stderr.trim().slice(0, 500)
-            || `codex features list exited: ${code ?? signal ?? 'unknown'}`,
-        ));
-        return;
-      }
-      const features = parseCodexFeatureList(stdout);
-      if (features.length === 0) {
-        reject(new Error('codex features list returned no parseable feature inventory'));
-        return;
-      }
-      resolve(features);
-    }));
+  const child = spawnProcess(input.binary, ['features', 'list'], {
+    cwd: input.cwd,
+    env: input.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    detached: APP_SERVER_PROCESS_GROUP_ENABLED,
   });
+  let stdout = '';
+  let stderr = '';
+  const closed = new Promise<void>((resolve) => child.once('close', () => resolve()));
+  const result = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
+    child.once('error', reject);
+    child.once('close', (code, signal) => resolve({ code, signal }));
+  });
+  child.stdout?.on('data', (chunk: Buffer) => {
+    if (stdout.length < MAX_FEATURE_LIST_CHARS) stdout += chunk.toString('utf8');
+  });
+  child.stderr?.on('data', (chunk: Buffer) => {
+    if (stderr.length < 16 * 1024) stderr += chunk.toString('utf8');
+  });
+
+  const timeoutMs = input.featureListTimeoutMs ?? FEATURE_LIST_TIMEOUT_MS;
+  try {
+    const { code, signal } = await withTimeout(result, timeoutMs, 'codex features list');
+    if (code !== 0) {
+      throw new Error(
+        stderr.trim().slice(0, 500)
+          || `codex features list exited: ${code ?? signal ?? 'unknown'}`,
+      );
+    }
+    const features = parseCodexFeatureList(stdout);
+    if (features.length === 0) {
+      throw new Error('codex features list returned no parseable feature inventory');
+    }
+    return features;
+  } finally {
+    const graceMs = input.shutdownGraceMs ?? 500;
+    await terminateAndReapChild(child, closed, {
+      eofGraceMs: 0,
+      terminateGraceMs: graceMs,
+      killGraceMs: graceMs,
+    });
+  }
+}
+
+export async function terminateAndReapChild(
+  child: ChildProcess,
+  closed: Promise<unknown>,
+  options: TerminateChildOptions = {},
+): Promise<boolean> {
+  const eofGraceMs = options.eofGraceMs ?? 500;
+  const terminateGraceMs = options.terminateGraceMs ?? 500;
+  const killGraceMs = options.killGraceMs ?? 500;
+  if (child.stdin && !child.stdin.destroyed && !child.stdin.writableEnded) child.stdin.end();
+  if (await waitForPromise(closed, eofGraceMs)) {
+    return terminateAppServerProcessGroup(child, { terminateGraceMs, killGraceMs });
+  }
+
+  signalAppServerProcess(child, 'SIGTERM');
+  if (await waitForPromise(closed, terminateGraceMs)) {
+    return terminateAppServerProcessGroup(child, {
+      terminateGraceMs: 0,
+      killGraceMs,
+    });
+  }
+
+  signalAppServerProcess(child, 'SIGKILL');
+  const childReaped = await waitForPromise(closed, killGraceMs);
+  if (!childReaped) {
+    log.warn('app-server', 'child-reap-timeout', {
+      pid: child.pid ?? null,
+      killGraceMs,
+    });
+  }
+  const groupReaped = await terminateAppServerProcessGroup(child, {
+    terminateGraceMs: 0,
+    killGraceMs,
+  });
+  return childReaped && groupReaped;
+}
+
+export function signalAppServerProcess(
+  child: ChildProcess,
+  signal: NodeJS.Signals,
+): boolean {
+  const pid = child.pid;
+  if (APP_SERVER_PROCESS_GROUP_ENABLED && pid && signalProcessGroup(pid, signal)) return true;
+
+  if (child.exitCode !== null || child.signalCode !== null) return false;
+  try {
+    return child.kill(signal);
+  } catch (err) {
+    log.warn('app-server', 'child-signal-failed', {
+      pid: pid ?? null,
+      signal,
+      code: (err as NodeJS.ErrnoException).code ?? null,
+    });
+    return false;
+  }
+}
+
+export async function terminateAppServerProcessGroup(
+  child: ChildProcess,
+  options: Pick<TerminateChildOptions, 'terminateGraceMs' | 'killGraceMs'> = {},
+): Promise<boolean> {
+  if (!APP_SERVER_PROCESS_GROUP_ENABLED || !child.pid) return true;
+  const pid = child.pid;
+  if (!isProcessGroupAlive(pid)) return true;
+
+  signalProcessGroup(pid, 'SIGTERM');
+  if (await waitForProcessGroupExit(pid, options.terminateGraceMs ?? 500)) return true;
+
+  signalProcessGroup(pid, 'SIGKILL');
+  const reaped = await waitForProcessGroupExit(pid, options.killGraceMs ?? 500);
+  if (!reaped) {
+    log.warn('app-server', 'process-group-reap-timeout', {
+      pid,
+      killGraceMs: options.killGraceMs ?? 500,
+    });
+  }
+  return reaped;
 }
 
 export function buildAppServerProcessEnv(options: CodexAppServerProcessOptions): NodeJS.ProcessEnv {
@@ -205,7 +293,7 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, operation:
   }
 }
 
-async function waitForPromise(promise: Promise<void>, timeoutMs: number): Promise<boolean> {
+async function waitForPromise(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   try {
     return await Promise.race([
@@ -217,6 +305,42 @@ async function waitForPromise(promise: Promise<void>, timeoutMs: number): Promis
   } finally {
     if (timer) clearTimeout(timer);
   }
+}
+
+function signalProcessGroup(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(-pid, signal);
+    return true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ESRCH') {
+      log.warn('app-server', 'process-group-signal-failed', {
+        pid,
+        signal,
+        code: code ?? null,
+      });
+    }
+    return false;
+  }
+}
+
+function isProcessGroupAlive(pid: number): boolean {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+async function waitForProcessGroupExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + Math.max(0, timeoutMs);
+  while (isProcessGroupAlive(pid)) {
+    const remainingMs = deadline - Date.now();
+    if (remainingMs <= 0) return false;
+    await new Promise((resolve) => setTimeout(resolve, Math.min(10, remainingMs)));
+  }
+  return true;
 }
 
 function recordValue(value: unknown): Record<string, unknown> | undefined {

--- a/src/agent/codex/app-server-process.ts
+++ b/src/agent/codex/app-server-process.ts
@@ -7,6 +7,7 @@ import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel
 import { CodexAppServerJsonRpc } from './app-server-jsonrpc';
 import {
   buildLeanAppServerArgs,
+  parseCodexFeatureList,
   type CodexAppServerConfigInventory,
 } from './app-server-lean';
 
@@ -27,12 +28,15 @@ export interface AppServerConfigProbeInput {
 }
 
 const RPC_TIMEOUT_MS = 15_000;
+const FEATURE_LIST_TIMEOUT_MS = 5_000;
 const MAX_PROTOCOL_LINE_CHARS = 4 * 1024 * 1024;
+const MAX_FEATURE_LIST_CHARS = 1024 * 1024;
 
 export async function readAppServerConfigInventory(
   input: AppServerConfigProbeInput,
 ): Promise<CodexAppServerConfigInventory> {
-  const child = spawnProcess(input.binary, buildLeanAppServerArgs(), {
+  const features = await readAppServerFeatureInventory(input);
+  const child = spawnProcess(input.binary, buildLeanAppServerArgs({ features }), {
     cwd: input.cwd,
     env: input.env,
     stdio: ['pipe', 'pipe', 'pipe'],
@@ -115,7 +119,7 @@ export async function readAppServerConfigInventory(
     ));
     const config = recordValue(response?.config);
     if (!config) throw new Error('codex app-server config/read returned no config');
-    return { mcp_servers: config.mcp_servers ?? config.mcpServers };
+    return { features, mcp_servers: config.mcp_servers ?? config.mcpServers };
   } finally {
     if (!child.stdin.destroyed && !child.stdin.writableEnded) child.stdin.end();
     if (!(await waitForPromise(closed, 500))) {
@@ -126,6 +130,55 @@ export async function readAppServerConfigInventory(
       }
     }
   }
+}
+
+export async function readAppServerFeatureInventory(
+  input: AppServerConfigProbeInput,
+): Promise<string[]> {
+  return new Promise<string[]>((resolve, reject) => {
+    const child = spawnProcess(input.binary, ['features', 'list'], {
+      cwd: input.cwd,
+      env: input.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      child.kill('SIGTERM');
+      settled = true;
+      reject(new Error(`codex features list timed out after ${FEATURE_LIST_TIMEOUT_MS}ms`));
+    }, FEATURE_LIST_TIMEOUT_MS);
+    const finish = (operation: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      operation();
+    };
+    child.stdout?.on('data', (chunk: Buffer) => {
+      if (stdout.length < MAX_FEATURE_LIST_CHARS) stdout += chunk.toString('utf8');
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      if (stderr.length < 16 * 1024) stderr += chunk.toString('utf8');
+    });
+    child.once('error', (err) => finish(() => reject(err)));
+    child.once('close', (code, signal) => finish(() => {
+      if (code !== 0) {
+        reject(new Error(
+          stderr.trim().slice(0, 500)
+            || `codex features list exited: ${code ?? signal ?? 'unknown'}`,
+        ));
+        return;
+      }
+      const features = parseCodexFeatureList(stdout);
+      if (features.length === 0) {
+        reject(new Error('codex features list returned no parseable feature inventory'));
+        return;
+      }
+      resolve(features);
+    }));
+  });
 }
 
 export function buildAppServerProcessEnv(options: CodexAppServerProcessOptions): NodeJS.ProcessEnv {

--- a/src/agent/codex/app-server-process.ts
+++ b/src/agent/codex/app-server-process.ts
@@ -1,0 +1,173 @@
+import { createInterface } from 'node:readline';
+import type { Readable, Writable } from 'node:stream';
+import { join } from 'node:path';
+import pkg from '../../../package.json';
+import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
+import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel-env';
+import { CodexAppServerJsonRpc } from './app-server-jsonrpc';
+import {
+  buildLeanAppServerArgs,
+  type CodexAppServerConfigInventory,
+} from './app-server-lean';
+
+type CodexAppServerChild = SpawnedProcessByStdio<Writable, Readable, Readable>;
+
+export interface CodexAppServerProcessOptions {
+  binary: string;
+  profileStateDir: string;
+  codexHome?: string;
+  inheritCodexHome?: boolean;
+  larkChannel?: LarkChannelEnvContext;
+}
+
+export interface AppServerConfigProbeInput {
+  binary: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+}
+
+const RPC_TIMEOUT_MS = 15_000;
+const MAX_PROTOCOL_LINE_CHARS = 4 * 1024 * 1024;
+
+export async function readAppServerConfigInventory(
+  input: AppServerConfigProbeInput,
+): Promise<CodexAppServerConfigInventory> {
+  const child = spawnProcess(input.binary, buildLeanAppServerArgs(), {
+    cwd: input.cwd,
+    env: input.env,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }) as CodexAppServerChild;
+  const stderrChunks: Buffer[] = [];
+  let stderrBytes = 0;
+  let writeTail = Promise.resolve();
+  const writeMessage = (message: unknown): Promise<void> => {
+    const line = `${JSON.stringify(message)}\n`;
+    const operation = writeTail.then(
+      () => new Promise<void>((resolve, reject) => {
+        if (child.stdin.destroyed || child.stdin.writableEnded) {
+          reject(new Error('codex app-server config probe stdin is closed'));
+          return;
+        }
+        child.stdin.write(line, 'utf8', (err?: Error | null) => {
+          if (err) reject(err);
+          else resolve();
+        });
+      }),
+    );
+    writeTail = operation.catch(() => undefined);
+    return operation;
+  };
+  const rpc = new CodexAppServerJsonRpc(writeMessage);
+  const readline = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  const closed = new Promise<void>((resolve) => {
+    child.once('close', (code, signal) => {
+      const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+      rpc.fail(new Error(
+        stderr.slice(0, 500) || `codex app-server config probe exited: ${code ?? signal ?? 'unknown'}`,
+      ));
+      readline.close();
+      resolve();
+    });
+  });
+  child.once('error', (err) => rpc.fail(err));
+  child.stdin.on('error', (err) => rpc.fail(err));
+  child.stderr.on('data', (chunk: Buffer) => {
+    if (stderrBytes >= 16 * 1024) return;
+    stderrChunks.push(chunk);
+    stderrBytes += chunk.byteLength;
+  });
+  readline.on('line', (line) => {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    if (trimmed.length > MAX_PROTOCOL_LINE_CHARS) {
+      rpc.fail(new Error('codex app-server config probe emitted an oversized protocol line'));
+      return;
+    }
+    try {
+      const incoming = rpc.receive(JSON.parse(trimmed));
+      if (incoming?.kind === 'request') {
+        void rpc.respondError(incoming.id, -32601, `unsupported config probe request: ${incoming.method}`);
+      }
+    } catch (err) {
+      rpc.fail(err);
+    }
+  });
+
+  try {
+    if (!child.pid) throw new Error('failed to spawn codex app-server config probe');
+    await withTimeout(
+      rpc.request('initialize', {
+        clientInfo: {
+          name: 'lark-channel-bridge-config-probe',
+          title: 'Lark Channel Bridge Config Probe',
+          version: pkg.version,
+        },
+        capabilities: null,
+      }),
+      RPC_TIMEOUT_MS,
+      'config probe initialize',
+    );
+    await rpc.notify('initialized');
+    const response = recordValue(await withTimeout(
+      rpc.request('config/read', { includeLayers: false, cwd: input.cwd }),
+      RPC_TIMEOUT_MS,
+      'config/read',
+    ));
+    const config = recordValue(response?.config);
+    if (!config) throw new Error('codex app-server config/read returned no config');
+    return { mcp_servers: config.mcp_servers ?? config.mcpServers };
+  } finally {
+    if (!child.stdin.destroyed && !child.stdin.writableEnded) child.stdin.end();
+    if (!(await waitForPromise(closed, 500))) {
+      if (child.exitCode === null && child.signalCode === null) child.kill('SIGTERM');
+      if (!(await waitForPromise(closed, 500)) && child.exitCode === null && child.signalCode === null) {
+        child.kill('SIGKILL');
+        await waitForPromise(closed, 500);
+      }
+    }
+  }
+}
+
+export function buildAppServerProcessEnv(options: CodexAppServerProcessOptions): NodeJS.ProcessEnv {
+  const envOverrides = buildLarkChannelEnv(options.larkChannel);
+  if (options.codexHome) {
+    envOverrides.CODEX_HOME = options.codexHome;
+  } else if (options.inheritCodexHome === false) {
+    envOverrides.CODEX_HOME = join(options.profileStateDir, 'codex-home');
+  }
+  return mergeProcessEnv(process.env, envOverrides);
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, operation: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`${operation} timed out after ${timeoutMs}ms`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function waitForPromise(promise: Promise<void>, timeoutMs: number): Promise<boolean> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise.then(() => true, () => true),
+      new Promise<boolean>((resolve) => {
+        timer = setTimeout(() => resolve(false), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}

--- a/src/agent/lark-channel-env.ts
+++ b/src/agent/lark-channel-env.ts
@@ -24,6 +24,10 @@ export function buildLarkChannelEnv(context?: LarkChannelEnvContext): NodeJS.Pro
     (rootDir ? join(rootDir, 'config.json') : undefined);
   if (configPath) env.LARK_CHANNEL_CONFIG = configPath;
 
+  const bridgeConfigPath = nonEmpty(context?.configPath)
+    ?? (rootDir ? join(rootDir, 'config.json') : undefined);
+  if (bridgeConfigPath) env.LARK_CHANNEL_BRIDGE_CONFIG = bridgeConfigPath;
+
   const larkCliConfigDir = nonEmpty(context?.larkCliConfigDir);
   if (larkCliConfigDir) env.LARKSUITE_CLI_CONFIG_DIR = larkCliConfigDir;
 

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -31,6 +31,8 @@ export const CLAUDE_DEFAULT_PERMISSION_MODE: ClaudePermissionMode = 'bypassPermi
 export interface AgentRunOptions {
   runId: string;
   prompt: string;
+  /** User-facing title for a newly-created persistent thread. */
+  threadName?: string;
   cwd?: string;
   sessionId?: string;
   threadId?: string;
@@ -82,6 +84,8 @@ export interface AgentAdapter {
   isAvailable(): Promise<boolean>;
   checkAvailability?(): Promise<AgentAvailability>;
   prepareRun?(opts: AgentRunOptions): Promise<void>;
+  /** Release process-local preparation state when a prepared run is cancelled before spawn. */
+  discardPreparedRun?(opts: AgentRunOptions): void;
   run(opts: AgentRunOptions): AgentRun;
   /**
    * Late-bound identity injection: the adapter is constructed before the

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -62,6 +62,7 @@ import { PendingQueue } from './pending-queue';
 import { ProcessPool } from './process-pool';
 import { fetchQuotedContext, fetchTopicContext, type QuotedContext } from './quote';
 import { lookupMessageThreadId } from './thread-id';
+import { buildBridgeThreadName } from './thread-name';
 import { addWorkingReaction, removeReaction } from './reaction';
 import { fetchKnownChats } from './lark-info';
 import type { AppPaths } from '../config/app-paths';
@@ -866,9 +867,11 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
       ]
     : undefined;
 
+  const userPart = buildUserPart(batch, attachments);
   const prompt = buildPrompt(
     batch,
     attachments,
+    userPart,
     quotes,
     topicContext,
     channel.botIdentity,
@@ -915,6 +918,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     scopeId: scope,
     scope: scopeContext,
     prompt,
+    threadName: buildBridgeThreadName('飞书', userPart),
     attachments: attachments.map(toPolicyAttachment),
     access: accessDecision,
     capability,
@@ -1755,6 +1759,7 @@ function delay(ms: number): Promise<void> {
 function buildPrompt(
   batch: NormalizedMessage[],
   attachments: LocalAttachment[],
+  userPart: string,
   quotes: QuotedContext[] = [],
   topicContext: QuotedContext[] = [],
   botIdentity?: { openId: string; name?: string },
@@ -1762,25 +1767,6 @@ function buildPrompt(
 ): string {
   const first = batch[0];
   if (!first) return '';
-
-  const fileKeys = batch.flatMap((m) => m.resources.map((r) => r.fileKey));
-  // When the debounce window merged messages (possibly from several senders —
-  // common in bot-at-bot group chats), annotate each segment with its sender
-  // so the agent can tell who said what. Single-message batches stay verbatim.
-  const annotate = batch.length > 1;
-  const texts = batch
-    .map((m) => {
-      const text = stripAttachmentRefs(m.content, fileKeys).trim();
-      if (!text) return '';
-      return annotate ? `${senderAnnotation(m)} ${text}` : text;
-    })
-    .filter(Boolean);
-  const userPart =
-    texts.length > 0
-      ? texts.join('\n\n')
-      : attachments.length > 0
-        ? '请看下面的附件。'
-        : '（对方发来一条没有正文的消息——通常是只 @ 了你的唤醒（ping）。请简短回应。）';
 
   const senderType = senderTypeOf(first);
   const mentions = mergeMentions(batch);
@@ -1808,6 +1794,24 @@ function buildPrompt(
     interactiveCards: batch.map(toPromptInteractiveCard).filter(isDefined),
     attachments: attachments.map(toPromptAttachment),
   });
+}
+
+function buildUserPart(batch: NormalizedMessage[], attachments: LocalAttachment[]): string {
+  const fileKeys = batch.flatMap((message) =>
+    message.resources.map((resource) => resource.fileKey),
+  );
+  // Debounced messages may come from different senders in bot-at-bot chats.
+  const annotate = batch.length > 1;
+  const texts = batch
+    .map((message) => {
+      const text = stripAttachmentRefs(message.content, fileKeys).trim();
+      if (!text) return '';
+      return annotate ? `${senderAnnotation(message)} ${text}` : text;
+    })
+    .filter(Boolean);
+  if (texts.length > 0) return texts.join('\n\n');
+  if (attachments.length > 0) return '请看下面的附件。';
+  return '（对方发来一条没有正文的消息——通常是只 @ 了你的唤醒（ping）。请简短回应。）';
 }
 
 /**

--- a/src/bot/comments.ts
+++ b/src/bot/comments.ts
@@ -13,6 +13,7 @@ import { resolveWorkingDirectory } from '../policy/workspace';
 import { RunRejected } from '../runtime/errors';
 import type { ActiveRuns } from './active-runs';
 import { recordRunSessionEvent } from './run-flow';
+import { buildBridgeThreadName } from './thread-name';
 import type { RunExecutor } from '../runtime/run-executor';
 import type { SessionCatalog } from '../session/catalog';
 import type { SessionStore } from '../session/store';
@@ -259,6 +260,7 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
       const execution = await deps.executor.submit({
         scopeId: runScopeId,
         policy,
+        threadName: buildBridgeThreadName('飞书评论', ctx.question),
         sessionId,
         threadId,
         stopGraceMs: getAgentStopGraceMs(controls.cfg),

--- a/src/bot/run-flow.ts
+++ b/src/bot/run-flow.ts
@@ -25,6 +25,7 @@ export interface StartRunFlowInput {
   scopeId: string;
   scope: ScopeContext;
   prompt: string;
+  threadName?: string;
   attachments: AgentAttachment[];
   access: AccessDecision;
   capability: AgentCapability;
@@ -142,6 +143,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
     execution = await input.executor.submit({
       scopeId: input.scopeId,
       policy,
+      threadName: input.threadName,
       sessionId,
       threadId,
       model: resolveModelArg(
@@ -197,6 +199,7 @@ export function recordRunSessionEvent(input: RecordRunSessionEventInput): void {
       cwdRealpath,
       policyFingerprint: input.policy.policyFingerprint,
       sessionId: input.event.sessionId,
+      ...(input.event.model ? { model: input.event.model } : {}),
     });
     return;
   }
@@ -207,6 +210,7 @@ export function recordRunSessionEvent(input: RecordRunSessionEventInput): void {
       cwdRealpath: input.policy.cwdRealpath,
       policyFingerprint: input.policy.policyFingerprint,
       threadId: input.event.threadId,
+      ...(input.event.model ? { model: input.event.model } : {}),
     });
   }
 }

--- a/src/bot/thread-name.ts
+++ b/src/bot/thread-name.ts
@@ -1,0 +1,15 @@
+const MAX_THREAD_NAME_CHARS = 96;
+
+/** Build a compact, user-visible Codex App thread name from the original user text. */
+export function buildBridgeThreadName(prefix: string, input: string): string {
+  const normalizedPrefix = prefix.replace(/\s+/gu, ' ').trim() || '飞书';
+  const normalizedInput = input.replace(/\s+/gu, ' ').trim() || '新会话';
+  const leading = `${normalizedPrefix} · `;
+  const available = Math.max(1, MAX_THREAD_NAME_CHARS - Array.from(leading).length);
+  const inputChars = Array.from(normalizedInput);
+  const body =
+    inputChars.length <= available
+      ? normalizedInput
+      : `${inputChars.slice(0, Math.max(1, available - 1)).join('')}…`;
+  return `${leading}${body}`;
+}

--- a/src/card/templates.ts
+++ b/src/card/templates.ts
@@ -68,6 +68,8 @@ export interface StatusInfo {
   emptySessionText?: string;
   sessionStale: boolean;
   agentName: string;
+  requestedModel?: string;
+  actualModel?: string;
   runtimeAccess: {
     label: string;
     value: string;
@@ -104,6 +106,11 @@ export function statusCard(info: StatusInfo): object {
     `📁 **cwd**: ${cwdLine}`,
     `🔗 **session**: ${sessionLine}`,
     `🤖 **agent**: ${escapeMd(info.agentName)}`,
+    ...(info.requestedModel
+      ? [
+          `🧠 **model**: requested=${escapeMd(info.requestedModel)}, actual=${escapeMd(info.actualModel ?? 'unconfirmed')}`,
+        ]
+      : []),
     `🛡 **${escapeMd(info.runtimeAccess.label)}**: ${escapeMd(info.runtimeAccess.value)}`,
     ...(info.larkCliStatus ? [`🔐 **lark-cli**: ${info.larkCliStatus}`] : []),
     `🏃 **active run**: ${info.activeRun ? 'yes' : 'no'}`,
@@ -192,6 +199,7 @@ export function helpCard(agentName = 'Agent'): object {
         '- `/account` — 查看当前应用；`/account change` 换 appId/secret 并重连',
         '- `/config` — 调整偏好、访问控制和 lark-cli 身份策略',
         '- `/status` — 当前状态',
+        '- `/model` — 查看配置模型和当前 session 最近实际使用的模型',
         '- `/stop` — 结束当前正在跑的任务（也可点卡片底部 ⏹ 终止 按钮）',
         '- `/stop comment:<scopeHash>` — 管理员停止云文档评论任务',
         '- `/timeout [N|off|default]` — 当前 session 的探活分钟数,`/config` 改全局默认',
@@ -202,7 +210,7 @@ export function helpCard(agentName = 'Agent'): object {
         `- \`/doctor [描述]\` — 把日志和描述交给 ${escapedAgentName} 自助诊断`,
         '- `/help` — 本帮助',
         '',
-        `其他内容直接交给 ${escapedAgentName}。`,
+        `不以 \`/\` 开头的其他内容直接交给 ${escapedAgentName}。`,
       ].join('\n'),
     ),
     HR,

--- a/src/card/templates.ts
+++ b/src/card/templates.ts
@@ -210,7 +210,7 @@ export function helpCard(agentName = 'Agent'): object {
         `- \`/doctor [描述]\` — 把日志和描述交给 ${escapedAgentName} 自助诊断`,
         '- `/help` — 本帮助',
         '',
-        `不以 \`/\` 开头的其他内容直接交给 ${escapedAgentName}。`,
+        `其他内容直接交给 ${escapedAgentName}。`,
       ].join('\n'),
     ),
     HR,

--- a/src/cli/commands/codex-task.ts
+++ b/src/cli/commands/codex-task.ts
@@ -8,6 +8,7 @@ import { initializeControllerWorkspace } from '../../codex-task/workspace';
 import { resolveCodexTaskContext } from '../../codex-task/context';
 
 interface CodexTaskCommandBaseOptions {
+  config?: string;
   profile?: string;
   rootDir?: string;
 }
@@ -107,6 +108,8 @@ export async function runCodexTaskCreate(options: CodexTaskCreateOptions): Promi
       task: compactTaskForOutput(result.task),
       output: result.output,
       terminationReason: result.terminationReason,
+      registrySync: result.registrySync,
+      ...(result.registryError ? { registryError: result.registryError } : {}),
     };
     if (options.json) printJson(payload);
     else printExecution(payload);
@@ -166,6 +169,8 @@ export async function runCodexTaskSend(
     task: compactTaskForOutput(result.task),
     output: result.output,
     terminationReason: result.terminationReason,
+    registrySync: result.registrySync,
+    ...(result.registryError ? { registryError: result.registryError } : {}),
   };
   if (options.json) printJson(payload);
   else printExecution(payload);
@@ -188,11 +193,16 @@ function printExecution(payload: {
   task: ReturnType<typeof compactTaskForOutput>;
   output: string;
   terminationReason: string;
+  registrySync: 'synced' | 'pending';
+  registryError?: string;
 }): void {
   console.log(`✓ ${payload.task.handle} ${payload.task.title}`);
   console.log(`  status: ${payload.task.status}`);
   console.log(`  cwd: ${payload.task.cwd}`);
   console.log(`  model: ${payload.task.model ?? 'default'}`);
   console.log(`  termination: ${payload.terminationReason}`);
+  if (payload.registrySync === 'pending') {
+    console.error(`  registry: pending reconciliation (${payload.registryError ?? 'unknown error'})`);
+  }
   if (payload.output) console.log(`\n${payload.output}`);
 }

--- a/src/cli/commands/codex-task.ts
+++ b/src/cli/commands/codex-task.ts
@@ -1,0 +1,198 @@
+import { isAbsolute } from 'node:path';
+import { resolveWorkingDirectory } from '../../policy/workspace';
+import {
+  compactTaskForOutput,
+  conversationMessages,
+} from '../../codex-task/controller';
+import { initializeControllerWorkspace } from '../../codex-task/workspace';
+import { resolveCodexTaskContext } from '../../codex-task/context';
+
+interface CodexTaskCommandBaseOptions {
+  profile?: string;
+  rootDir?: string;
+}
+
+export interface CodexTaskInitOptions extends CodexTaskCommandBaseOptions {
+  workspace?: string;
+  force?: boolean;
+  json?: boolean;
+}
+
+export interface CodexTaskListOptions extends CodexTaskCommandBaseOptions {
+  json?: boolean;
+}
+
+export interface CodexTaskCreateOptions extends CodexTaskCommandBaseOptions {
+  title: string;
+  cwd: string;
+  model?: string;
+  message?: string;
+  json?: boolean;
+}
+
+export interface CodexTaskReadOptions extends CodexTaskCommandBaseOptions {
+  json?: boolean;
+  limit?: string;
+}
+
+export interface CodexTaskSendOptions extends CodexTaskCommandBaseOptions {
+  message: string;
+  model?: string;
+  json?: boolean;
+}
+
+export async function runCodexTaskInit(options: CodexTaskInitOptions): Promise<void> {
+  const context = await resolveCodexTaskContext(options);
+  const configured = context.profileConfig.workspaces.default;
+  if (!configured) {
+    throw new Error('controller workspace is not configured in profiles.<name>.workspaces.default');
+  }
+  const workspace = await resolveWorkingDirectory(configured);
+  if (!workspace.ok) throw new Error(workspace.userVisible);
+  if (options.workspace) {
+    const explicit = await resolveWorkingDirectory(options.workspace);
+    if (!explicit.ok) throw new Error(explicit.userVisible);
+    if (explicit.cwdRealpath !== workspace.cwdRealpath) {
+      throw new Error('--workspace must match the profile default workspace; update the profile first');
+    }
+  }
+  const result = await initializeControllerWorkspace({
+    workspace: workspace.cwdRealpath,
+    force: options.force,
+  });
+  if (options.json) {
+    printJson(result);
+    return;
+  }
+  console.log(`✓ controller workspace: ${result.workspace}`);
+  for (const path of result.created) console.log(`  created ${path}`);
+  for (const path of result.skipped) console.log(`  kept    ${path}`);
+}
+
+export async function runCodexTaskList(options: CodexTaskListOptions): Promise<void> {
+  const { controller } = await resolveCodexTaskContext(options);
+  const tasks = await controller.list();
+  if (options.json) {
+    printJson(tasks.map(compactTaskForOutput));
+    return;
+  }
+  if (tasks.length === 0) {
+    console.log('暂无已注册的 Codex worker task。');
+    return;
+  }
+  for (const task of tasks) {
+    console.log([
+      task.handle,
+      task.status,
+      task.model ?? 'default',
+      task.cwd,
+      task.title,
+    ].join('\t'));
+  }
+}
+
+export async function runCodexTaskCreate(options: CodexTaskCreateOptions): Promise<void> {
+  const { controller } = await resolveCodexTaskContext(options);
+  if (!isAbsolute(options.cwd)) throw new Error('--cwd must be an absolute path');
+  const workspace = await resolveWorkingDirectory(options.cwd);
+  if (!workspace.ok) throw new Error(workspace.userVisible);
+  const result = await controller.create({
+    title: options.title,
+    cwd: workspace.cwdRealpath,
+    ...(options.model ? { model: options.model } : {}),
+    ...(options.message ? { message: options.message } : {}),
+  });
+  if ('output' in result) {
+    const payload = {
+      task: compactTaskForOutput(result.task),
+      output: result.output,
+      terminationReason: result.terminationReason,
+    };
+    if (options.json) printJson(payload);
+    else printExecution(payload);
+    return;
+  }
+  const task = compactTaskForOutput(result);
+  if (options.json) printJson(task);
+  else console.log(`✓ ${task.handle} ${task.title}\n  cwd: ${task.cwd}\n  model: ${task.model ?? 'default'}`);
+}
+
+export async function runCodexTaskRead(handle: string, options: CodexTaskReadOptions): Promise<void> {
+  const limit = parseLimit(options.limit);
+  const { controller } = await resolveCodexTaskContext(options);
+  const result = await controller.read(handle, true);
+  const messages = conversationMessages(result.thread, limit);
+  const turns = Array.isArray(result.thread.turns) ? result.thread.turns : [];
+  const lastTurn = turns.length > 0 && turns.at(-1) && typeof turns.at(-1) === 'object'
+    ? turns.at(-1) as Record<string, unknown>
+    : undefined;
+  const payload = {
+    task: compactTaskForOutput(result.task),
+    runtimeStatus: result.thread.status ?? null,
+    lastTurnStatus: lastTurn?.status ?? null,
+    thread: {
+      name: result.thread.name ?? result.task.title,
+      cwd: result.thread.cwd ?? result.task.cwd,
+      preview: result.thread.preview ?? null,
+      createdAt: result.thread.createdAt ?? null,
+      updatedAt: result.thread.updatedAt ?? null,
+      modelProvider: result.thread.modelProvider ?? null,
+    },
+    messages,
+  };
+  if (options.json) {
+    printJson(payload);
+    return;
+  }
+  console.log(`${payload.task.handle} ${payload.task.title}`);
+  console.log(`cwd: ${payload.task.cwd}`);
+  console.log(`model: ${payload.task.model ?? 'default'}`);
+  console.log(`runtime status: ${JSON.stringify(payload.runtimeStatus)}`);
+  console.log(`last turn status: ${String(payload.lastTurnStatus ?? 'none')}`);
+  if (payload.messages.length === 0) console.log('(尚无 agent 回复)');
+  for (const message of payload.messages) console.log(`\n${message.role}: ${message.text}`);
+}
+
+export async function runCodexTaskSend(
+  handle: string,
+  options: CodexTaskSendOptions,
+): Promise<void> {
+  const { controller } = await resolveCodexTaskContext(options);
+  const result = await controller.send(handle, {
+    message: options.message,
+    ...(options.model ? { model: options.model } : {}),
+  });
+  const payload = {
+    task: compactTaskForOutput(result.task),
+    output: result.output,
+    terminationReason: result.terminationReason,
+  };
+  if (options.json) printJson(payload);
+  else printExecution(payload);
+}
+
+function parseLimit(value: string | undefined): number {
+  if (value === undefined) return 5;
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 50) {
+    throw new Error('--limit must be an integer between 1 and 50');
+  }
+  return parsed;
+}
+
+function printJson(value: unknown): void {
+  console.log(JSON.stringify(value, null, 2));
+}
+
+function printExecution(payload: {
+  task: ReturnType<typeof compactTaskForOutput>;
+  output: string;
+  terminationReason: string;
+}): void {
+  console.log(`✓ ${payload.task.handle} ${payload.task.title}`);
+  console.log(`  status: ${payload.task.status}`);
+  console.log(`  cwd: ${payload.task.cwd}`);
+  console.log(`  model: ${payload.task.model ?? 'default'}`);
+  console.log(`  termination: ${payload.terminationReason}`);
+  if (payload.output) console.log(`\n${payload.output}`);
+}

--- a/src/cli/commands/codex-task.ts
+++ b/src/cli/commands/codex-task.ts
@@ -29,6 +29,7 @@ export interface CodexTaskCreateOptions extends CodexTaskCommandBaseOptions {
   model?: string;
   message?: string;
   json?: boolean;
+  signal?: AbortSignal;
 }
 
 export interface CodexTaskReadOptions extends CodexTaskCommandBaseOptions {
@@ -40,6 +41,7 @@ export interface CodexTaskSendOptions extends CodexTaskCommandBaseOptions {
   message: string;
   model?: string;
   json?: boolean;
+  signal?: AbortSignal;
 }
 
 export async function runCodexTaskInit(options: CodexTaskInitOptions): Promise<void> {
@@ -93,6 +95,13 @@ export async function runCodexTaskList(options: CodexTaskListOptions): Promise<v
 }
 
 export async function runCodexTaskCreate(options: CodexTaskCreateOptions): Promise<void> {
+  return withCodexTaskSignals(options.signal, (signal) => runCodexTaskCreateInternal(options, signal));
+}
+
+async function runCodexTaskCreateInternal(
+  options: CodexTaskCreateOptions,
+  signal: AbortSignal,
+): Promise<void> {
   const { controller } = await resolveCodexTaskContext(options);
   if (!isAbsolute(options.cwd)) throw new Error('--cwd must be an absolute path');
   const workspace = await resolveWorkingDirectory(options.cwd);
@@ -102,6 +111,7 @@ export async function runCodexTaskCreate(options: CodexTaskCreateOptions): Promi
     cwd: workspace.cwdRealpath,
     ...(options.model ? { model: options.model } : {}),
     ...(options.message ? { message: options.message } : {}),
+    signal,
   });
   if ('output' in result) {
     const payload = {
@@ -111,13 +121,22 @@ export async function runCodexTaskCreate(options: CodexTaskCreateOptions): Promi
       registrySync: result.registrySync,
       ...(result.registryError ? { registryError: result.registryError } : {}),
     };
+    setExecutionExitCode(result.terminationReason);
     if (options.json) printJson(payload);
     else printExecution(payload);
     return;
   }
   const task = compactTaskForOutput(result);
   if (options.json) printJson(task);
-  else console.log(`✓ ${task.handle} ${task.title}\n  cwd: ${task.cwd}\n  model: ${task.model ?? 'default'}`);
+  else {
+    console.log(`✓ ${task.handle} ${task.title}`);
+    console.log(`  status: ${task.status}`);
+    console.log(`  cwd: ${task.cwd}`);
+    console.log(`  model: ${task.model ?? 'default'}`);
+    if (task.status === 'pending') {
+      console.log('  thread: pending until the first codex-task send');
+    }
+  }
 }
 
 export async function runCodexTaskRead(handle: string, options: CodexTaskReadOptions): Promise<void> {
@@ -160,10 +179,22 @@ export async function runCodexTaskSend(
   handle: string,
   options: CodexTaskSendOptions,
 ): Promise<void> {
+  return withCodexTaskSignals(
+    options.signal,
+    (signal) => runCodexTaskSendInternal(handle, options, signal),
+  );
+}
+
+async function runCodexTaskSendInternal(
+  handle: string,
+  options: CodexTaskSendOptions,
+  signal: AbortSignal,
+): Promise<void> {
   const { controller } = await resolveCodexTaskContext(options);
   const result = await controller.send(handle, {
     message: options.message,
     ...(options.model ? { model: options.model } : {}),
+    signal,
   });
   const payload = {
     task: compactTaskForOutput(result.task),
@@ -172,6 +203,7 @@ export async function runCodexTaskSend(
     registrySync: result.registrySync,
     ...(result.registryError ? { registryError: result.registryError } : {}),
   };
+  setExecutionExitCode(result.terminationReason);
   if (options.json) printJson(payload);
   else printExecution(payload);
 }
@@ -196,7 +228,8 @@ function printExecution(payload: {
   registrySync: 'synced' | 'pending';
   registryError?: string;
 }): void {
-  console.log(`✓ ${payload.task.handle} ${payload.task.title}`);
+  const marker = payload.terminationReason === 'normal' ? '✓' : '✗';
+  console.log(`${marker} ${payload.task.handle} ${payload.task.title}`);
   console.log(`  status: ${payload.task.status}`);
   console.log(`  cwd: ${payload.task.cwd}`);
   console.log(`  model: ${payload.task.model ?? 'default'}`);
@@ -205,4 +238,33 @@ function printExecution(payload: {
     console.error(`  registry: pending reconciliation (${payload.registryError ?? 'unknown error'})`);
   }
   if (payload.output) console.log(`\n${payload.output}`);
+}
+
+function setExecutionExitCode(terminationReason: string): void {
+  if (terminationReason === 'normal') return;
+  if (process.exitCode === undefined || process.exitCode === 0) process.exitCode = 1;
+}
+
+async function withCodexTaskSignals<T>(
+  providedSignal: AbortSignal | undefined,
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  if (providedSignal) return operation(providedSignal);
+
+  const abort = new AbortController();
+  const interrupt = (exitCode: number): void => {
+    if (abort.signal.aborted) return;
+    process.exitCode = exitCode;
+    abort.abort();
+  };
+  const onSigint = (): void => interrupt(130);
+  const onSigterm = (): void => interrupt(143);
+  process.once('SIGINT', onSigint);
+  process.once('SIGTERM', onSigterm);
+  try {
+    return await operation(abort.signal);
+  } finally {
+    process.removeListener('SIGINT', onSigint);
+    process.removeListener('SIGTERM', onSigterm);
+  }
 }

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -11,8 +11,13 @@ import {
   type MigrateV2Result,
 } from '../../config/migrate-v2';
 import { legacyPaths, paths } from '../../config/paths';
-import { agentKindFromString } from '../../config/profile-store';
-import type { RootConfig } from '../../config/profile-schema';
+import { agentKindFromString, loadRootConfig } from '../../config/profile-store';
+import {
+  codexTransportFromString,
+  effectiveCodexTransport,
+  type CodexTransport,
+  type RootConfig,
+} from '../../config/profile-schema';
 import { isComplete, type AppCredentials, type AppConfig } from '../../config/schema';
 import { saveConfig } from '../../config/store';
 
@@ -20,6 +25,7 @@ export interface MigrateOptions {
   config?: string;
   profile?: string;
   agent?: string;
+  codexTransport?: string;
   confirmStopActiveBridgeProcesses?: (
     processes: ActiveBridgeMigrationProcess[],
   ) => Promise<boolean> | boolean;
@@ -44,14 +50,24 @@ export async function runMigrate(opts: MigrateOptions): Promise<void> {
   await migrateLegacyPaths();
   await migrateConfigShape(configPath);
   const agentKind = agentKindFromString(opts.agent) ?? (opts.profile === 'codex' ? 'codex' : undefined);
+  const codexTransport = codexTransportFromString(opts.codexTransport);
+  if (codexTransport && agentKind === 'claude') {
+    throw new Error('--codex-transport can only be used with a Codex profile');
+  }
   const needsV2Migration = await hasLegacyProfileConfig(configPath);
+  if (codexTransport && !needsV2Migration) {
+    await assertExistingCodexTransport(configPath, opts.profile, codexTransport);
+  }
+  if (codexTransport && needsV2Migration && agentKind !== 'codex') {
+    throw new Error('--codex-transport can only be used with a Codex profile');
+  }
   const result = await migrateProfileV2WithActiveBridgePrompt({
     rootDir: dirname(configPath),
     configFile: configPath,
     profile: opts.profile,
     ...(agentKind ? { agentKind } : {}),
     ...(needsV2Migration && agentKind === 'codex'
-      ? { codex: await createBootstrapCodexConfig(undefined) }
+      ? { codex: await createBootstrapCodexConfig(undefined, codexTransport) }
       : {}),
   }, opts);
   if (!result) return;
@@ -60,6 +76,28 @@ export async function runMigrate(opts: MigrateOptions): Promise<void> {
   } else {
     console.log(`✓ profile 目录结构已是最新：${result.profile}`);
   }
+}
+
+async function assertExistingCodexTransport(
+  configPath: string,
+  requestedProfile: string | undefined,
+  requestedTransport: CodexTransport,
+): Promise<void> {
+  const root = await loadRootConfig(configPath);
+  if (!root) return;
+  const profileName = requestedProfile ?? root.activeProfile;
+  const profile = root.profiles[profileName];
+  if (!profile) throw new Error(`profile not found: ${profileName}`);
+  if (profile.agentKind !== 'codex') {
+    throw new Error('--codex-transport can only be used with a Codex profile');
+  }
+  const configuredTransport = effectiveCodexTransport(profile.codex);
+  if (configuredTransport === requestedTransport) return;
+  throw new Error(
+    `profile ${profileName} already uses Codex transport ${configuredTransport}, ` +
+      `but this command requested --codex-transport ${requestedTransport}. ` +
+      'Update the persisted profile config and restart the profile to change transports.',
+  );
 }
 
 async function migrateProfileV2WithActiveBridgePrompt(

--- a/src/cli/commands/profile.ts
+++ b/src/cli/commands/profile.ts
@@ -29,6 +29,7 @@ export interface ProfileCommandOptions {
 
 export interface ProfileCreateOptions extends ProfileCommandOptions {
   agent?: string;
+  codexTransport?: string;
   workspace?: string;
   appId?: string;
   appSecret?: string;
@@ -126,6 +127,7 @@ export async function runProfileCreate(
       config: configFile,
       profile: name,
       agent: opts.agent,
+      codexTransport: opts.codexTransport,
       workspace: opts.workspace,
       appId: opts.appId,
       appSecret: opts.appSecret,

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -21,6 +21,7 @@ import { stopProcessEntry, type StopProcessEntryResult } from './ps';
 export interface ServiceStartOptions {
   profile?: string;
   agent?: string;
+  codexTransport?: string;
   workspace?: string;
   appId?: string;
   appSecret?: string;
@@ -153,6 +154,7 @@ async function ensureBridgeConfigured(
   const { cfg, profile, profileConfig, appPaths, configPath } = await resolveProfileRuntime({
     profile: opts.profile,
     agent: opts.agent,
+    codexTransport: opts.codexTransport,
     workspace: opts.workspace,
     appId: opts.appId,
     appSecret: opts.appSecret,
@@ -281,7 +283,8 @@ async function reportConnectAfter(
   profile: string,
   fn: () => ServiceResultLike,
 ): Promise<void> {
-  const { cfg } = await resolveProfileRuntime({ profile, allowBootstrap: false });
+  const runtime = await resolveProfileRuntime({ profile, allowBootstrap: false });
+  const { cfg } = runtime;
   const appId = cfg.accounts?.app?.id ?? '';
   const beforePids = new Set(
     readAndPrune()
@@ -301,7 +304,7 @@ async function reportConnectAfter(
   const entry = await waitForServiceConnect(appId, profile, beforePids);
   if (entry) {
     const verbZh = verb === 'started' ? '已启动' : '已重启';
-    const agent = agentDisplay(entry.agentKind);
+    const agent = agentDisplay(entry.agentKind, runtime.profileConfig?.codex?.transport);
     console.log(
       `✓ ${verbZh}  bot: ${entry.botName} (${entry.appId})  agent: ${agent.displayName} (${agent.id})  进程: ${entry.id}`,
     );
@@ -604,8 +607,14 @@ async function maybeResolveProfileRuntime(
   }
 }
 
-function agentDisplay(agentKind: ProcessEntry['agentKind']): { id: string; displayName: string } {
+function agentDisplay(
+  agentKind: ProcessEntry['agentKind'],
+  codexTransport?: string,
+): { id: string; displayName: string } {
   return agentKind === 'codex'
-    ? { id: 'codex', displayName: 'Codex CLI' }
+    ? {
+        id: 'codex',
+        displayName: codexTransport === 'app-server' ? 'Codex App Server' : 'Codex CLI',
+      }
     : { id: 'claude', displayName: 'Claude Code' };
 }

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -86,6 +86,7 @@ export interface StartOptions {
   config?: string;
   profile?: string;
   agent?: string;
+  codexTransport?: string;
   workspace?: string;
   appId?: string;
   appSecret?: string;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -120,7 +120,7 @@ codexTask
 
 codexTask
   .command('create')
-  .description('Create and register a persistent Codex worker task')
+  .description('Reserve a Codex worker task and optionally run its first turn')
   .requiredOption('--title <title>', 'user-facing task title')
   .requiredOption('--cwd <path>', 'absolute worker working directory')
   .option('-c, --config <path>', 'path to Bridge root config file')
@@ -153,7 +153,7 @@ codexTask
 
 codexTask
   .command('send <handle>')
-  .description('Resume a registered task, send one instruction, and wait for completion')
+  .description('Materialize or resume a registered task and wait for completion')
   .option('-c, --config <path>', 'path to Bridge root config file')
   .requiredOption('--message <text>', 'instruction to send')
   .option('--model <slug>', 'per-turn model override, persisted for later sends')
@@ -354,7 +354,7 @@ program.parseAsync(process.argv).catch((err: unknown) => {
   const diagnostic = getAgentPreflightDiagnostic(err);
   if (diagnostic) {
     console.error(formatAgentPreflightDiagnostic(diagnostic));
-    process.exit(1);
+    process.exit(process.exitCode && process.exitCode !== 0 ? process.exitCode : 1);
   }
   if (err instanceof Error) {
     if (err.name === 'UserCancelledError') {
@@ -365,5 +365,5 @@ program.parseAsync(process.argv).catch((err: unknown) => {
   } else {
     console.error(err);
   }
-  process.exit(1);
+  process.exit(process.exitCode && process.exitCode !== 0 ? process.exitCode : 1);
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -99,20 +99,22 @@ const codexTask = program
 codexTask
   .command('init')
   .description('Install the controller AGENTS.md and repo-scoped Skill into a workspace')
+  .option('-c, --config <path>', 'path to Bridge root config file')
   .option('--profile <name>', 'Codex profile (defaults to LARK_CHANNEL_PROFILE or active profile)')
   .option('--workspace <path>', 'controller workspace (defaults to the profile workspace)')
   .option('--force', 'overwrite existing controller AGENTS.md and Skill')
   .option('--json', 'print machine-readable JSON')
-  .action(async (opts: { profile?: string; workspace?: string; force?: boolean; json?: boolean }) => {
+  .action(async (opts: { config?: string; profile?: string; workspace?: string; force?: boolean; json?: boolean }) => {
     await runCodexTaskInit(opts);
   });
 
 codexTask
   .command('list')
   .description('List worker tasks registered by this profile')
+  .option('-c, --config <path>', 'path to Bridge root config file')
   .option('--profile <name>', 'Codex profile (defaults to LARK_CHANNEL_PROFILE or active profile)')
   .option('--json', 'print machine-readable JSON')
-  .action(async (opts: { profile?: string; json?: boolean }) => {
+  .action(async (opts: { config?: string; profile?: string; json?: boolean }) => {
     await runCodexTaskList(opts);
   });
 
@@ -121,6 +123,7 @@ codexTask
   .description('Create and register a persistent Codex worker task')
   .requiredOption('--title <title>', 'user-facing task title')
   .requiredOption('--cwd <path>', 'absolute worker working directory')
+  .option('-c, --config <path>', 'path to Bridge root config file')
   .option('--model <slug>', 'per-task model override')
   .option('--message <text>', 'optional first instruction; waits for the turn to finish')
   .option('--profile <name>', 'Codex profile (defaults to LARK_CHANNEL_PROFILE or active profile)')
@@ -130,6 +133,7 @@ codexTask
     cwd: string;
     model?: string;
     message?: string;
+    config?: string;
     profile?: string;
     json?: boolean;
   }) => {
@@ -139,16 +143,18 @@ codexTask
 codexTask
   .command('read <handle>')
   .description('Read a registered task without resuming it')
+  .option('-c, --config <path>', 'path to Bridge root config file')
   .option('--limit <count>', 'maximum recent conversation messages to print (1-50)', '5')
   .option('--profile <name>', 'Codex profile (defaults to LARK_CHANNEL_PROFILE or active profile)')
   .option('--json', 'print filtered machine-readable task metadata and conversation text')
-  .action(async (handle: string, opts: { limit?: string; profile?: string; json?: boolean }) => {
+  .action(async (handle: string, opts: { config?: string; limit?: string; profile?: string; json?: boolean }) => {
     await runCodexTaskRead(handle, opts);
   });
 
 codexTask
   .command('send <handle>')
   .description('Resume a registered task, send one instruction, and wait for completion')
+  .option('-c, --config <path>', 'path to Bridge root config file')
   .requiredOption('--message <text>', 'instruction to send')
   .option('--model <slug>', 'per-turn model override, persisted for later sends')
   .option('--profile <name>', 'Codex profile (defaults to LARK_CHANNEL_PROFILE or active profile)')
@@ -156,6 +162,7 @@ codexTask
   .action(async (handle: string, opts: {
     message: string;
     model?: string;
+    config?: string;
     profile?: string;
     json?: boolean;
   }) => {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,13 @@ import {
 } from './commands/service';
 import { runStart } from './commands/start';
 import { runUi } from './commands/ui';
+import {
+  runCodexTaskCreate,
+  runCodexTaskInit,
+  runCodexTaskList,
+  runCodexTaskRead,
+  runCodexTaskSend,
+} from './commands/codex-task';
 
 const program = new Command();
 
@@ -42,6 +49,7 @@ program
   .option('--profile <name>', 'profile name to run')
   .option('--web-ui', 'run the machine-wide supervisor + local web console (hosts all profiles); default is a single-profile headless run')
   .option('--agent <kind>', 'agent kind for a new profile (claude or codex)')
+  .option('--codex-transport <transport>', 'Codex transport for a new profile (exec or app-server; default exec)')
   .option('--workspace <path>', 'initial working directory for first-run profile bootstrap')
   .option('--app-id <id>', 'use an existing Lark/Feishu app instead of QR app creation')
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')
@@ -52,6 +60,7 @@ program
     profile?: string;
     webUi?: boolean;
     agent?: string;
+    codexTransport?: string;
     workspace?: string;
     appId?: string;
     appSecret?: string;
@@ -67,7 +76,8 @@ program
   .option('-c, --config <path>', 'path to config file')
   .option('--profile <name>', 'target profile name for legacy v1 config migration')
   .option('--agent <kind>', 'agent kind for legacy v1 profile migration (claude or codex)')
-  .action(async (opts: { config?: string; profile?: string; agent?: string }) => {
+  .option('--codex-transport <transport>', 'Codex transport for the migrated profile (exec or app-server; default exec)')
+  .action(async (opts: { config?: string; profile?: string; agent?: string; codexTransport?: string }) => {
     await runMigrate(opts);
   });
 
@@ -82,16 +92,88 @@ profile
     await runProfileList();
   });
 
+const codexTask = program
+  .command('codex-task')
+  .description('Manage persistent Codex worker tasks for a controller workspace');
+
+codexTask
+  .command('init')
+  .description('Install the controller AGENTS.md and repo-scoped Skill into a workspace')
+  .option('--profile <name>', 'Codex profile (defaults to LARK_CHANNEL_PROFILE or active profile)')
+  .option('--workspace <path>', 'controller workspace (defaults to the profile workspace)')
+  .option('--force', 'overwrite existing controller AGENTS.md and Skill')
+  .option('--json', 'print machine-readable JSON')
+  .action(async (opts: { profile?: string; workspace?: string; force?: boolean; json?: boolean }) => {
+    await runCodexTaskInit(opts);
+  });
+
+codexTask
+  .command('list')
+  .description('List worker tasks registered by this profile')
+  .option('--profile <name>', 'Codex profile (defaults to LARK_CHANNEL_PROFILE or active profile)')
+  .option('--json', 'print machine-readable JSON')
+  .action(async (opts: { profile?: string; json?: boolean }) => {
+    await runCodexTaskList(opts);
+  });
+
+codexTask
+  .command('create')
+  .description('Create and register a persistent Codex worker task')
+  .requiredOption('--title <title>', 'user-facing task title')
+  .requiredOption('--cwd <path>', 'absolute worker working directory')
+  .option('--model <slug>', 'per-task model override')
+  .option('--message <text>', 'optional first instruction; waits for the turn to finish')
+  .option('--profile <name>', 'Codex profile (defaults to LARK_CHANNEL_PROFILE or active profile)')
+  .option('--json', 'print machine-readable JSON')
+  .action(async (opts: {
+    title: string;
+    cwd: string;
+    model?: string;
+    message?: string;
+    profile?: string;
+    json?: boolean;
+  }) => {
+    await runCodexTaskCreate(opts);
+  });
+
+codexTask
+  .command('read <handle>')
+  .description('Read a registered task without resuming it')
+  .option('--limit <count>', 'maximum recent conversation messages to print (1-50)', '5')
+  .option('--profile <name>', 'Codex profile (defaults to LARK_CHANNEL_PROFILE or active profile)')
+  .option('--json', 'print filtered machine-readable task metadata and conversation text')
+  .action(async (handle: string, opts: { limit?: string; profile?: string; json?: boolean }) => {
+    await runCodexTaskRead(handle, opts);
+  });
+
+codexTask
+  .command('send <handle>')
+  .description('Resume a registered task, send one instruction, and wait for completion')
+  .requiredOption('--message <text>', 'instruction to send')
+  .option('--model <slug>', 'per-turn model override, persisted for later sends')
+  .option('--profile <name>', 'Codex profile (defaults to LARK_CHANNEL_PROFILE or active profile)')
+  .option('--json', 'print machine-readable JSON')
+  .action(async (handle: string, opts: {
+    message: string;
+    model?: string;
+    profile?: string;
+    json?: boolean;
+  }) => {
+    await runCodexTaskSend(handle, opts);
+  });
+
 profile
   .command('create <name>')
   .description('Create a profile from QR registration or existing app credentials')
   .option('--agent <kind>', 'agent kind (claude or codex)')
+  .option('--codex-transport <transport>', 'Codex transport (exec or app-server; default exec)')
   .option('--workspace <path>', 'initial working directory for this profile')
   .option('--app-id <id>', 'use an existing Lark/Feishu app instead of QR app creation')
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')
   .option('--tenant <tenant>', 'tenant for --app-id (feishu or lark; default feishu)')
   .action(async (name: string, opts: {
     agent?: string;
+    codexTransport?: string;
     workspace?: string;
     appId?: string;
     appSecret?: string;
@@ -168,6 +250,7 @@ program
   .option('--profile <name>', 'profile name (defaults to active profile)')
   .option('--web-ui', 'run the supervisor + web console as the background service (hosts all profiles) instead of a single profile')
   .option('--agent <kind>', 'agent kind for first-run profile bootstrap (claude or codex)')
+  .option('--codex-transport <transport>', 'Codex transport for first-run profile bootstrap (exec or app-server; default exec)')
   .option('--workspace <path>', 'initial working directory for first-run profile bootstrap')
   .option('--app-id <id>', 'use an existing Lark/Feishu app instead of QR app creation')
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')
@@ -177,6 +260,7 @@ program
     profile?: string;
     webUi?: boolean;
     agent?: string;
+    codexTransport?: string;
     workspace?: string;
     appId?: string;
     appSecret?: string;

--- a/src/cli/profile-bootstrap.ts
+++ b/src/cli/profile-bootstrap.ts
@@ -1,7 +1,12 @@
 import { mkdir, realpath } from 'node:fs/promises';
 import { join } from 'node:path';
 import { AgentPreflightError } from '../agent/preflight';
-import { createDefaultProfileConfig, type AgentKind, type ProfileConfig } from '../config/profile-schema';
+import {
+  createDefaultProfileConfig,
+  type AgentKind,
+  type CodexTransport,
+  type ProfileConfig,
+} from '../config/profile-schema';
 import type { AppConfig } from '../config/schema';
 import { resolveWorkingDirectory } from '../policy/workspace';
 import { resolveExecutablePath } from './agent-detection';
@@ -14,12 +19,16 @@ export interface BootstrapProfileInput {
   workspace?: string;
   defaultWorkspace?: string;
   codexBinaryPath?: string;
+  codexTransport?: CodexTransport;
   profileDir?: string;
 }
 
 export async function createBootstrapProfileConfig(
   input: BootstrapProfileInput,
 ): Promise<ProfileConfig> {
+  if (input.codexTransport && input.agentKind !== 'codex') {
+    throw new Error('codex transport can only be configured for a Codex profile');
+  }
   const workspace = input.workspace
     ? await resolveBootstrapWorkspace(input.workspace)
     : input.defaultWorkspace
@@ -27,7 +36,7 @@ export async function createBootstrapProfileConfig(
       : undefined;
   const codex =
     input.agentKind === 'codex'
-      ? await createBootstrapCodexConfig(input.codexBinaryPath)
+      ? await createBootstrapCodexConfig(input.codexBinaryPath, input.codexTransport)
       : undefined;
   const profile = createDefaultProfileConfig({
     agentKind: input.agentKind,
@@ -59,7 +68,10 @@ async function ensureManagedDefaultWorkspace(path: string): Promise<string> {
   return realpath(path);
 }
 
-export async function createBootstrapCodexConfig(binaryPath: string | undefined) {
+export async function createBootstrapCodexConfig(
+  binaryPath: string | undefined,
+  transport?: CodexTransport,
+) {
   const command = binaryPath ?? process.env.LARK_CHANNEL_CODEX_BIN ?? 'codex';
   let resolvedBinary: string;
   try {
@@ -75,7 +87,10 @@ export async function createBootstrapCodexConfig(binaryPath: string | undefined)
       errno,
     });
   }
-  return { binaryPath: resolvedBinary };
+  return {
+    binaryPath: resolvedBinary,
+    ...(transport === 'app-server' ? { transport } : {}),
+  };
 }
 
 function codexBootstrapBinaryErrorCode(errno: string | undefined) {

--- a/src/codex-task/context.ts
+++ b/src/codex-task/context.ts
@@ -1,3 +1,4 @@
+import { dirname, resolve } from 'node:path';
 import { resolveAppPaths, type AppPaths } from '../config/app-paths';
 import type { ProfileConfig } from '../config/profile-schema';
 import { loadRootConfig, readActiveProfile } from '../config/profile-store';
@@ -5,6 +6,7 @@ import { CodexTaskController } from './controller';
 import { CodexTaskRegistry } from './registry';
 
 export interface ResolveCodexTaskContextOptions {
+  config?: string;
   profile?: string;
   rootDir?: string;
 }
@@ -12,6 +14,7 @@ export interface ResolveCodexTaskContextOptions {
 export interface CodexTaskContext {
   profile: string;
   profileConfig: ProfileConfig;
+  configPath: string;
   appPaths: AppPaths;
   controller: CodexTaskController;
 }
@@ -19,9 +22,15 @@ export interface CodexTaskContext {
 export async function resolveCodexTaskContext(
   options: ResolveCodexTaskContextOptions,
 ): Promise<CodexTaskContext> {
-  const rootPaths = resolveAppPaths({ rootDir: options.rootDir });
-  const root = await loadRootConfig(rootPaths.configFile);
-  if (!root) throw new Error(`root config not found: ${rootPaths.configFile}`);
+  const configuredPath = nonEmpty(options.config)
+    ?? (options.rootDir ? undefined : nonEmpty(process.env.LARK_CHANNEL_BRIDGE_CONFIG));
+  const configPath = configuredPath ? resolve(configuredPath) : undefined;
+  const rootPaths = resolveAppPaths({
+    rootDir: options.rootDir ?? (configPath ? dirname(configPath) : undefined),
+  });
+  const actualConfigPath = configPath ?? rootPaths.configFile;
+  const root = await loadRootConfig(actualConfigPath);
+  if (!root) throw new Error(`root config not found: ${actualConfigPath}`);
   const profile = options.profile?.trim()
     || process.env.LARK_CHANNEL_PROFILE?.trim()
     || await readActiveProfile(rootPaths.rootDir)
@@ -47,10 +56,15 @@ export async function resolveCodexTaskContext(
     larkChannel: {
       profile,
       rootDir: appPaths.rootDir,
-      configPath: appPaths.configFile,
+      configPath: actualConfigPath,
       larkCliConfigDir: appPaths.larkCliConfigDir,
       larkCliSourceConfigFile: appPaths.larkCliSourceConfigFile,
     },
   });
-  return { profile, profileConfig, appPaths, controller };
+  return { profile, profileConfig, configPath: actualConfigPath, appPaths, controller };
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed || undefined;
 }

--- a/src/codex-task/context.ts
+++ b/src/codex-task/context.ts
@@ -1,0 +1,56 @@
+import { resolveAppPaths, type AppPaths } from '../config/app-paths';
+import type { ProfileConfig } from '../config/profile-schema';
+import { loadRootConfig, readActiveProfile } from '../config/profile-store';
+import { CodexTaskController } from './controller';
+import { CodexTaskRegistry } from './registry';
+
+export interface ResolveCodexTaskContextOptions {
+  profile?: string;
+  rootDir?: string;
+}
+
+export interface CodexTaskContext {
+  profile: string;
+  profileConfig: ProfileConfig;
+  appPaths: AppPaths;
+  controller: CodexTaskController;
+}
+
+export async function resolveCodexTaskContext(
+  options: ResolveCodexTaskContextOptions,
+): Promise<CodexTaskContext> {
+  const rootPaths = resolveAppPaths({ rootDir: options.rootDir });
+  const root = await loadRootConfig(rootPaths.configFile);
+  if (!root) throw new Error(`root config not found: ${rootPaths.configFile}`);
+  const profile = options.profile?.trim()
+    || process.env.LARK_CHANNEL_PROFILE?.trim()
+    || await readActiveProfile(rootPaths.rootDir)
+    || root.activeProfile;
+  if (!profile) throw new Error('profile is required');
+  const profileConfig = root.profiles[profile];
+  if (!profileConfig) throw new Error(`profile not found: ${profile}`);
+  if (profileConfig.agentKind !== 'codex' || !profileConfig.codex) {
+    throw new Error(`profile is not a Codex profile: ${profile}`);
+  }
+  if (profileConfig.codex.transport !== 'app-server') {
+    throw new Error(`profile does not use Codex App Server transport: ${profile}`);
+  }
+  const appPaths = resolveAppPaths({ rootDir: rootPaths.rootDir, profile });
+  const registry = new CodexTaskRegistry(appPaths.codexTasksFile);
+  const controller = new CodexTaskController({
+    binary: profileConfig.codex.binaryPath,
+    profileStateDir: appPaths.profileDir,
+    registry,
+    ...(profileConfig.codex.codexHome ? { codexHome: profileConfig.codex.codexHome } : {}),
+    inheritCodexHome: profileConfig.codex.inheritCodexHome === true,
+    sandbox: profileConfig.sandbox.defaultMode,
+    larkChannel: {
+      profile,
+      rootDir: appPaths.rootDir,
+      configPath: appPaths.configFile,
+      larkCliConfigDir: appPaths.larkCliConfigDir,
+      larkCliSourceConfigFile: appPaths.larkCliSourceConfigFile,
+    },
+  });
+  return { profile, profileConfig, appPaths, controller };
+}

--- a/src/codex-task/controller.ts
+++ b/src/codex-task/controller.ts
@@ -26,6 +26,8 @@ export interface CodexTaskExecutionResult {
   task: CodexTaskRecord;
   output: string;
   terminationReason: CodexTaskTerminationReason;
+  registrySync: 'synced' | 'pending';
+  registryError?: string;
 }
 
 export interface CodexTaskReadResult {
@@ -53,44 +55,67 @@ export class CodexTaskController {
   }
 
   list(): Promise<CodexTaskRecord[]> {
-    return this.options.registry.list();
+    return this.reconciledList();
   }
 
   async create(input: CreateCodexTaskInput): Promise<CodexTaskRecord | CodexTaskExecutionResult> {
     const title = nonEmpty(input.title, 'title');
     const cwd = nonEmpty(input.cwd, 'cwd');
-    const response = recordValue(await withCodexAppServerConnection(
-      { ...this.options, cwd },
-      async (connection) => {
-        const started = await connection.request('thread/start', {
-          cwd,
-          approvalPolicy: 'never',
-          sandbox: this.options.sandbox ?? 'danger-full-access',
-          serviceName: 'lark-channel-bridge-task-controller',
-          threadSource: 'user',
-          ephemeral: false,
-          ...(input.model ? { model: input.model } : {}),
-        });
-        const raw = recordValue(started);
-        const threadId = stringValue(recordValue(raw?.thread)?.id);
-        if (!threadId) throw new Error('codex app-server returned no thread id');
-        await connection.request('thread/name/set', { threadId, name: title });
-        return started;
-      },
-    ));
-    const thread = recordValue(response?.thread);
-    const threadId = stringValue(thread?.id);
-    if (!threadId) throw new Error('codex app-server returned no thread id');
-    const model = stringValue(response?.model) ?? input.model;
-    const task = await this.options.registry.register({
-      threadId,
+    const pending = await this.options.registry.reserve({
       title,
       cwd,
-      ...(model ? { model } : {}),
-      status: 'idle',
+      ...(input.model ? { model: input.model } : {}),
     });
+    let threadId: string | undefined;
+    let named = false;
+    let task: CodexTaskRecord;
+    try {
+      await withCodexAppServerConnection(
+        { ...this.options, cwd },
+        async (connection) => {
+          const started = recordValue(await connection.request('thread/start', {
+            cwd,
+            approvalPolicy: 'never',
+            sandbox: this.options.sandbox ?? 'danger-full-access',
+            serviceName: 'lark-channel-bridge-task-controller',
+            threadSource: 'user',
+            ephemeral: false,
+            ...(input.model ? { model: input.model } : {}),
+          }));
+          threadId = stringValue(recordValue(started?.thread)?.id);
+          if (!threadId) throw new Error('codex app-server returned no thread id');
+          await this.options.registry.importThread(pending.handle, threadId);
+          await connection.request('thread/name/set', { threadId, name: title });
+          named = true;
+        },
+      );
+      task = await this.options.registry.update(pending.handle, { status: 'idle' });
+    } catch (err) {
+      const message = errorMessage(err);
+      const desiredStatus = named ? 'idle' : 'failed';
+      let recoveryError: string | undefined;
+      try {
+        await this.options.registry.markReconcile(pending.handle, {
+          desiredStatus,
+          error: message,
+          ...(threadId ? { threadId } : {}),
+          lastResult: truncate(message, 4_000),
+        });
+      } catch (recoveryErr) {
+        recoveryError = errorMessage(recoveryErr);
+      }
+      throw new Error([
+        `Codex task ${pending.handle} creation requires recovery`,
+        threadId ? `durable thread ${threadId}` : 'thread start was not confirmed',
+        message,
+        ...(recoveryError ? [`registry recovery record failed: ${recoveryError}`] : []),
+      ].join(': '), { cause: err });
+    }
     if (!input.message?.trim()) return task;
-    return this.send(task.handle, { message: input.message, ...(input.model ? { model: input.model } : {}) });
+    return this.send(task.handle, {
+      message: input.message,
+      ...(input.model ? { model: input.model } : {}),
+    });
   }
 
   async read(handle: string, includeTurns = true): Promise<CodexTaskReadResult> {
@@ -113,35 +138,78 @@ export class CodexTaskController {
     const runLockPath = join(this.options.profileStateDir, 'codex-task-runs', task.handle);
     return withConfigFileLock(runLockPath, async () => {
       const model = input.model ?? task.model;
-      await this.options.registry.update(task.handle, {
+      const running = await this.options.registry.update(task.handle, {
         status: 'running',
-        ...(model ? { model } : {}),
+        ...(input.model ? { model: input.model } : {}),
       });
+      let outcome: Awaited<ReturnType<CodexTaskController['executeTurn']>>;
       try {
-        const outcome = await this.executeTurn(task, message, model);
+        outcome = await this.executeTurn(task, message, model);
+      } catch (err) {
+        try {
+          await this.options.registry.update(task.handle, {
+            status: 'failed',
+            ...(input.model ? { model: input.model } : {}),
+            lastResult: truncate(errorMessage(err), 4_000),
+          });
+        } catch (registryErr) {
+          throw new Error(
+            `${errorMessage(err)}; registry failure state was not persisted: ${errorMessage(registryErr)}`,
+            { cause: err },
+          );
+        }
+        throw err;
+      }
+
+      const status = executionStatus(outcome.terminationReason);
+      const lastResult = truncate(outcome.output, 4_000);
+      try {
         const updated = await this.options.registry.update(task.handle, {
-          status: executionStatus(outcome.terminationReason),
-          ...(model ? { model } : {}),
-          lastResult: truncate(outcome.output, 4_000),
+          status,
+          ...(input.model ? { model: input.model } : {}),
+          lastResult,
         });
         return {
           task: updated,
           output: outcome.output,
           terminationReason: outcome.terminationReason,
+          registrySync: 'synced',
         };
-      } catch (err) {
-        await this.options.registry.update(task.handle, {
-          status: 'failed',
-          ...(model ? { model } : {}),
-          lastResult: truncate(err instanceof Error ? err.message : String(err), 4_000),
-        });
-        throw err;
+      } catch (registryErr) {
+        const registryError = errorMessage(registryErr);
+        const lastTurnId = await this.readLatestTurnId(task).catch(() => undefined);
+        let recoveryError: string | undefined;
+        try {
+          await this.options.registry.markReconcile(task.handle, {
+            desiredStatus: status,
+            error: registryError,
+            threadId: task.threadId,
+            ...(lastTurnId ? { lastTurnId } : {}),
+            lastResult,
+          });
+        } catch (err) {
+          recoveryError = errorMessage(err);
+        }
+        return {
+          task: {
+            ...running,
+            status,
+            lastResult,
+            ...(lastTurnId ? { lastTurnId } : {}),
+          },
+          output: outcome.output,
+          terminationReason: outcome.terminationReason,
+          registrySync: 'pending',
+          registryError: recoveryError
+            ? `${registryError}; recovery record failed: ${recoveryError}`
+            : registryError,
+        };
       }
     });
   }
 
   private async executeTurn(
-    task: CodexTaskRecord,
+    task: CodexTaskRecord & { threadId: string },
     message: string,
     model: string | undefined,
   ): Promise<{ output: string; terminationReason: CodexTaskTerminationReason }> {
@@ -181,14 +249,38 @@ export class CodexTaskController {
     return { output, terminationReason };
   }
 
-  private async requireTask(handle: string): Promise<CodexTaskRecord> {
+  private async readLatestTurnId(task: CodexTaskRecord & { threadId: string }): Promise<string | undefined> {
+    const result = recordValue(await withCodexAppServerConnection(
+      { ...this.options, cwd: task.cwd },
+      (connection) => connection.request('thread/read', {
+        threadId: task.threadId,
+        includeTurns: true,
+      }),
+    ));
+    const thread = recordValue(result?.thread);
+    const turns = Array.isArray(thread?.turns) ? thread.turns : [];
+    return stringValue(recordValue(turns.at(-1))?.id);
+  }
+
+  private async reconciledList(): Promise<CodexTaskRecord[]> {
+    await this.options.registry.reconcile();
+    return this.options.registry.list();
+  }
+
+  private async requireTask(handle: string): Promise<CodexTaskRecord & { threadId: string }> {
+    await this.options.registry.reconcile(handle);
     const task = await this.options.registry.get(handle);
     if (!task) throw new Error(`Codex task not found: ${handle.trim().toUpperCase()}`);
-    return task;
+    if (!task.threadId) {
+      throw new Error(`Codex task ${task.handle} has no imported durable thread and requires recovery`);
+    }
+    return { ...task, threadId: task.threadId };
   }
 }
 
-function executionStatus(reason: CodexTaskTerminationReason): CodexTaskStatus {
+function executionStatus(
+  reason: CodexTaskTerminationReason,
+): Exclude<CodexTaskStatus, 'pending' | 'reconcile' | 'idle' | 'running' | 'failed'> {
   if (reason === 'normal') return 'completed';
   return reason;
 }
@@ -211,6 +303,10 @@ function recordValue(value: unknown): Record<string, unknown> | undefined {
 
 function truncate(value: string, max: number): string {
   return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 export function finalAgentMessages(thread: Record<string, unknown>, limit = 5): string[] {
@@ -250,6 +346,8 @@ function contentText(value: unknown): string | undefined {
 }
 
 export function compactTaskForOutput(task: CodexTaskRecord): Omit<CodexTaskRecord, 'threadId'> {
-  const { threadId: _threadId, ...publicTask } = task;
-  return publicTask;
+  const { threadId: _threadId, reconciliation, ...publicTask } = task;
+  if (!reconciliation) return publicTask;
+  const { threadId: _recoveryThreadId, ...publicReconciliation } = reconciliation;
+  return { ...publicTask, reconciliation: publicReconciliation };
 }

--- a/src/codex-task/controller.ts
+++ b/src/codex-task/controller.ts
@@ -1,13 +1,17 @@
 import { randomUUID } from 'node:crypto';
-import { join } from 'node:path';
 import { CodexAppServerAdapter, type CodexAppServerAdapterOptions } from '../agent/codex/app-server-adapter';
-import { withCodexAppServerConnection } from '../agent/codex/app-server-client';
-import { withConfigFileLock } from '../config/profile-store';
+import {
+  CodexAppServerRpcError,
+  withCodexAppServerConnection,
+} from '../agent/codex/app-server-client';
+import type { AgentRunOptions } from '../agent/types';
 import type { CodexTaskRecord, CodexTaskStatus } from './registry';
 import { CodexTaskRegistry } from './registry';
 
 export interface CodexTaskControllerOptions extends CodexAppServerAdapterOptions {
   registry: CodexTaskRegistry;
+  /** Stop a worker after this many milliseconds without an agent event. Set to 0 to disable. */
+  turnIdleTimeoutMs?: number;
 }
 
 export interface CreateCodexTaskInput {
@@ -15,11 +19,13 @@ export interface CreateCodexTaskInput {
   cwd: string;
   model?: string;
   message?: string;
+  signal?: AbortSignal;
 }
 
 export interface SendCodexTaskInput {
   message: string;
   model?: string;
+  signal?: AbortSignal;
 }
 
 export interface CodexTaskExecutionResult {
@@ -41,6 +47,21 @@ export interface CodexTaskMessage {
   role: 'user' | 'assistant';
   text: string;
 }
+
+export class CodexTaskAmbiguousOutcomeError extends Error {
+  readonly code = 'codex-task-outcome-ambiguous';
+
+  constructor(readonly handle: string, cause?: unknown) {
+    super(
+      `Codex task ${handle} recovered a durable thread, but its previous first-turn outcome is ambiguous; `
+        + 'inspect it with codex-task read before sending more work',
+    );
+    this.name = 'CodexTaskAmbiguousOutcomeError';
+    this.cause = cause;
+  }
+}
+
+const DEFAULT_TURN_IDLE_TIMEOUT_MS = 5 * 60_000;
 
 const WORKER_DEVELOPER_INSTRUCTIONS = `You are a persistent Codex worker task managed by lark-channel-bridge.
 Work only on the instruction sent to this worker and follow the target repository's AGENTS.md and skills.
@@ -66,60 +87,23 @@ export class CodexTaskController {
       cwd,
       ...(input.model ? { model: input.model } : {}),
     });
-    let threadId: string | undefined;
-    let named = false;
-    let task: CodexTaskRecord;
+    if (!input.message?.trim()) return pending;
     try {
-      await withCodexAppServerConnection(
-        { ...this.options, cwd },
-        async (connection) => {
-          const started = recordValue(await connection.request('thread/start', {
-            cwd,
-            approvalPolicy: 'never',
-            sandbox: this.options.sandbox ?? 'danger-full-access',
-            serviceName: 'lark-channel-bridge-task-controller',
-            threadSource: 'user',
-            ephemeral: false,
-            ...(input.model ? { model: input.model } : {}),
-          }));
-          threadId = stringValue(recordValue(started?.thread)?.id);
-          if (!threadId) throw new Error('codex app-server returned no thread id');
-          await this.options.registry.importThread(pending.handle, threadId);
-          await connection.request('thread/name/set', { threadId, name: title });
-          named = true;
-        },
-      );
-      task = await this.options.registry.update(pending.handle, { status: 'idle' });
+      return await this.send(pending.handle, {
+        message: input.message,
+        ...(input.model ? { model: input.model } : {}),
+        ...(input.signal ? { signal: input.signal } : {}),
+      });
     } catch (err) {
-      const message = errorMessage(err);
-      const desiredStatus = named ? 'idle' : 'failed';
-      let recoveryError: string | undefined;
-      try {
-        await this.options.registry.markReconcile(pending.handle, {
-          desiredStatus,
-          error: message,
-          ...(threadId ? { threadId } : {}),
-          lastResult: truncate(message, 4_000),
-        });
-      } catch (recoveryErr) {
-        recoveryError = errorMessage(recoveryErr);
-      }
-      throw new Error([
-        `Codex task ${pending.handle} creation requires recovery`,
-        threadId ? `durable thread ${threadId}` : 'thread start was not confirmed',
-        message,
-        ...(recoveryError ? [`registry recovery record failed: ${recoveryError}`] : []),
-      ].join(': '), { cause: err });
+      throw new Error(
+        `Codex task ${pending.handle} was reserved, but its first turn failed: ${errorMessage(err)}`,
+        { cause: err },
+      );
     }
-    if (!input.message?.trim()) return task;
-    return this.send(task.handle, {
-      message: input.message,
-      ...(input.model ? { model: input.model } : {}),
-    });
   }
 
   async read(handle: string, includeTurns = true): Promise<CodexTaskReadResult> {
-    const task = await this.requireTask(handle);
+    const task = await this.requireDurableTask(handle);
     const result = recordValue(await withCodexAppServerConnection(
       { ...this.options, cwd: task.cwd },
       (connection) => connection.request('thread/read', {
@@ -134,27 +118,103 @@ export class CodexTaskController {
 
   async send(handle: string, input: SendCodexTaskInput): Promise<CodexTaskExecutionResult> {
     const message = nonEmpty(input.message, 'message');
-    const task = await this.requireTask(handle);
-    const runLockPath = join(this.options.profileStateDir, 'codex-task-runs', task.handle);
-    return withConfigFileLock(runLockPath, async () => {
+    return this.options.registry.withTaskLock(handle, async () => {
+      // Read only after acquiring the execution lock. Otherwise a queued sender
+      // can use a model or thread id that a preceding sender has just replaced.
+      let task = await this.requireRegisteredTask(handle);
+      task = await this.resolveThreadCandidate(task);
+      if (task.status === 'running' && !task.threadId) {
+        throw new Error(
+          `Codex task ${task.handle} was left running without a recoverable thread; `
+            + 'refusing to create a replacement that could duplicate work',
+        );
+      }
       const model = input.model ?? task.model;
+      if (input.signal?.aborted) {
+        const interrupted = await this.options.registry.update(task.handle, {
+          status: 'interrupted',
+          ...(input.model ? { model: input.model } : {}),
+          lastResult: 'Interrupted before the Codex turn started',
+        });
+        return {
+          task: interrupted,
+          output: '',
+          terminationReason: 'interrupted',
+          registrySync: 'synced',
+        };
+      }
       const running = await this.options.registry.update(task.handle, {
         status: 'running',
         ...(input.model ? { model: input.model } : {}),
       });
+
+      let durableThreadId = task.threadId;
+      let threadImported = Boolean(task.threadId);
       let outcome: Awaited<ReturnType<CodexTaskController['executeTurn']>>;
       try {
-        outcome = await this.executeTurn(task, message, model);
+        outcome = await this.executeTurn(
+          running,
+          message,
+          model,
+          input.signal,
+          async (threadId) => {
+            await this.options.registry.setThreadCandidate(task.handle, threadId);
+          },
+          async (threadId) => {
+            durableThreadId = threadId;
+            if (task.threadId) {
+              if (task.threadId !== threadId) {
+                throw new Error(`codex app-server resumed an unexpected thread: ${threadId}`);
+              }
+              return;
+            }
+            await this.options.registry.importThread(task.handle, threadId);
+            threadImported = true;
+          },
+        );
+        durableThreadId = outcome.threadId ?? durableThreadId;
       } catch (err) {
-        try {
-          await this.options.registry.update(task.handle, {
-            status: 'failed',
-            ...(input.model ? { model: input.model } : {}),
-            lastResult: truncate(errorMessage(err), 4_000),
-          });
-        } catch (registryErr) {
+        const messageText = errorMessage(err);
+        const lastResult = truncate(messageText, 4_000);
+        const desiredStatus = input.signal?.aborted ? 'interrupted' : 'failed';
+        let registryFailure: string | undefined;
+
+        if (durableThreadId && !threadImported) {
+          try {
+            await this.options.registry.markReconcile(task.handle, {
+              desiredStatus,
+              error: messageText,
+              threadId: durableThreadId,
+              lastResult,
+            });
+          } catch (recoveryErr) {
+            registryFailure = errorMessage(recoveryErr);
+          }
+        } else {
+          try {
+            await this.options.registry.update(task.handle, {
+              status: desiredStatus,
+              ...(input.model ? { model: input.model } : {}),
+              lastResult,
+            });
+          } catch (updateErr) {
+            const updateMessage = errorMessage(updateErr);
+            try {
+              await this.options.registry.markReconcile(task.handle, {
+                desiredStatus,
+                error: updateMessage,
+                ...(durableThreadId ? { threadId: durableThreadId } : {}),
+                lastResult,
+              });
+            } catch (recoveryErr) {
+              registryFailure = `${updateMessage}; recovery record failed: ${errorMessage(recoveryErr)}`;
+            }
+          }
+        }
+
+        if (registryFailure) {
           throw new Error(
-            `${errorMessage(err)}; registry failure state was not persisted: ${errorMessage(registryErr)}`,
+            `${messageText}; registry failure state was not persisted: ${registryFailure}`,
             { cause: err },
           );
         }
@@ -177,13 +237,15 @@ export class CodexTaskController {
         };
       } catch (registryErr) {
         const registryError = errorMessage(registryErr);
-        const lastTurnId = await this.readLatestTurnId(task).catch(() => undefined);
+        const lastTurnId = outcome.threadId
+          ? await this.readLatestTurnId({ ...task, threadId: outcome.threadId }).catch(() => undefined)
+          : undefined;
         let recoveryError: string | undefined;
         try {
           await this.options.registry.markReconcile(task.handle, {
             desiredStatus: status,
             error: registryError,
-            threadId: task.threadId,
+            ...(outcome.threadId ? { threadId: outcome.threadId } : {}),
             ...(lastTurnId ? { lastTurnId } : {}),
             lastResult,
           });
@@ -193,6 +255,7 @@ export class CodexTaskController {
         return {
           task: {
             ...running,
+            ...(outcome.threadId ? { threadId: outcome.threadId } : {}),
             status,
             lastResult,
             ...(lastTurnId ? { lastTurnId } : {}),
@@ -209,44 +272,144 @@ export class CodexTaskController {
   }
 
   private async executeTurn(
-    task: CodexTaskRecord & { threadId: string },
+    task: CodexTaskRecord,
     message: string,
     model: string | undefined,
-  ): Promise<{ output: string; terminationReason: CodexTaskTerminationReason }> {
+    signal: AbortSignal | undefined,
+    onThreadCandidate: (threadId: string) => Promise<void>,
+    onThreadReady: (threadId: string) => Promise<void>,
+  ): Promise<{
+    output: string;
+    terminationReason: CodexTaskTerminationReason;
+    threadId?: string;
+  }> {
+    let refreshActivity = (): void => {};
+    const inheritedActivity = this.options.onActivity;
+    const inheritedThreadCandidate = this.options.onThreadCandidate;
     const adapter = new CodexAppServerAdapter({
       ...this.options,
       ignoreRules: false,
       developerInstructions: WORKER_DEVELOPER_INSTRUCTIONS,
+      onActivity: () => {
+        try {
+          inheritedActivity?.();
+        } finally {
+          refreshActivity();
+        }
+      },
+      onThreadCandidate: async (threadId) => {
+        await onThreadCandidate(threadId);
+        await inheritedThreadCandidate?.(threadId);
+      },
     });
-    const runOptions = {
+    const runOptions: AgentRunOptions = {
       runId: randomUUID(),
       prompt: message,
       cwd: task.cwd,
-      threadId: task.threadId,
+      threadName: task.title,
+      ...(task.threadId ? { threadId: task.threadId } : {}),
       ...(model ? { model } : {}),
       sandbox: this.options.sandbox,
     };
-    await adapter.prepareRun(runOptions);
+    try {
+      await adapter.prepareRun(runOptions);
+    } catch (err) {
+      if (signal?.aborted) {
+        return { output: '', terminationReason: 'interrupted' };
+      }
+      throw err;
+    }
+    if (signal?.aborted) {
+      adapter.discardPreparedRun(runOptions);
+      return { output: '', terminationReason: 'interrupted' };
+    }
     const run = adapter.run(runOptions);
+    const idleTimeoutMs = this.options.turnIdleTimeoutMs ?? DEFAULT_TURN_IDLE_TIMEOUT_MS;
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    let stopPromise: Promise<void> | undefined;
+    let stopReason: Extract<CodexTaskTerminationReason, 'interrupted' | 'timeout'> | undefined;
+    let terminalObserved = false;
     let output = '';
+    let streamedOutput = '';
+    let threadId = task.threadId;
+    let threadReadyHandled = Boolean(task.threadId);
     let terminationReason: CodexTaskTerminationReason | undefined;
     let terminalError: string | undefined;
+
+    const clearIdleTimer = (): void => {
+      if (idleTimer) clearTimeout(idleTimer);
+      idleTimer = undefined;
+    };
+    const requestStop = (
+      reason: Extract<CodexTaskTerminationReason, 'interrupted' | 'timeout'>,
+    ): void => {
+      if (terminalObserved || stopReason) return;
+      stopReason = reason;
+      stopPromise = run.stop();
+      void stopPromise.catch(() => undefined);
+    };
+    const armIdleTimer = (): void => {
+      clearIdleTimer();
+      if (idleTimeoutMs <= 0 || stopReason) return;
+      idleTimer = setTimeout(() => requestStop('timeout'), idleTimeoutMs);
+      idleTimer.unref?.();
+    };
+    refreshActivity = armIdleTimer;
+    const abortTurn = (): void => requestStop('interrupted');
+    signal?.addEventListener('abort', abortTurn, { once: true });
+    if (signal?.aborted) abortTurn();
+    armIdleTimer();
+
     try {
       for await (const event of run.events) {
+        if (event.type === 'done' || event.type === 'error') {
+          terminalObserved = true;
+          clearIdleTimer();
+        } else {
+          armIdleTimer();
+        }
+
+        if (event.type === 'system' && event.threadId) {
+          if (threadId && threadId !== event.threadId) {
+            throw new Error(`codex app-server returned an unexpected thread: ${event.threadId}`);
+          }
+          threadId = event.threadId;
+          if (!threadReadyHandled) {
+            threadReadyHandled = true;
+            clearIdleTimer();
+            await onThreadReady(event.threadId);
+            armIdleTimer();
+          }
+        }
+        if (event.type === 'text') streamedOutput += event.delta;
         if (event.type === 'final_text') output = event.content;
-        if (event.type === 'error') terminalError = event.message;
         if (event.type === 'done') terminationReason = event.terminationReason;
+        if (event.type === 'error') {
+          if (event.terminationReason === 'failed') terminalError = event.message;
+          else terminationReason = event.terminationReason;
+        }
       }
     } finally {
+      terminalObserved = true;
+      refreshActivity = (): void => {};
+      signal?.removeEventListener('abort', abortTurn);
+      clearIdleTimer();
+      if (stopPromise) await stopPromise.catch(() => undefined);
       if (!(await run.waitForExit(2_000))) await run.stop().catch(() => undefined);
     }
-    if (terminalError) {
-      throw new Error(terminalError);
+
+    const finalOutput = output || streamedOutput;
+    if (stopReason) {
+      return {
+        output: finalOutput,
+        terminationReason: stopReason,
+        ...(threadId ? { threadId } : {}),
+      };
     }
-    if (!terminationReason) {
-      throw new Error('Codex turn ended without a terminal event');
-    }
-    return { output, terminationReason };
+    if (terminalError) throw new Error(terminalError);
+    if (!terminationReason) throw new Error('Codex turn ended without a terminal event');
+    if (!threadId) throw new Error('Codex turn ended without a durable thread id');
+    return { output: finalOutput, terminationReason, threadId };
   }
 
   private async readLatestTurnId(task: CodexTaskRecord & { threadId: string }): Promise<string | undefined> {
@@ -262,17 +425,83 @@ export class CodexTaskController {
     return stringValue(recordValue(turns.at(-1))?.id);
   }
 
+  private async resolveThreadCandidate(task: CodexTaskRecord): Promise<CodexTaskRecord> {
+    const candidate = task.candidateThreadId;
+    if (!candidate) return task;
+
+    try {
+      const result = recordValue(await withCodexAppServerConnection(
+        { ...this.options, cwd: task.cwd },
+        (connection) => connection.request('thread/read', {
+          threadId: candidate,
+          includeTurns: true,
+        }),
+      ));
+      if (!recordValue(result?.thread)) {
+        throw new Error('codex app-server returned no thread while verifying the candidate');
+      }
+    } catch (err) {
+      if (isExplicitMissingThread(err)) {
+        return this.options.registry.clearThreadCandidate(task.handle, candidate, {
+          status: 'failed',
+          lastResult: 'The previous thread candidate was not durable; materialization may be retried',
+        });
+      }
+      throw new Error(
+        `Codex task ${task.handle} has an unresolved thread candidate; `
+          + `refusing to start a replacement turn (${candidateVerificationError(err)})`,
+        { cause: err },
+      );
+    }
+
+    const ambiguous = new CodexTaskAmbiguousOutcomeError(task.handle);
+    try {
+      await this.options.registry.importThread(task.handle, candidate, {
+        status: 'failed',
+        lastResult: truncate(ambiguous.message, 4_000),
+      });
+    } catch (err) {
+      throw new Error(
+        `Codex task ${task.handle} has a durable but unresolved thread candidate; `
+          + `refusing to continue (${candidateVerificationError(err)})`,
+        { cause: err },
+      );
+    }
+    throw ambiguous;
+  }
+
   private async reconciledList(): Promise<CodexTaskRecord[]> {
     await this.options.registry.reconcile();
     return this.options.registry.list();
   }
 
-  private async requireTask(handle: string): Promise<CodexTaskRecord & { threadId: string }> {
+  private async requireRegisteredTask(handle: string): Promise<CodexTaskRecord> {
     await this.options.registry.reconcile(handle);
     const task = await this.options.registry.get(handle);
     if (!task) throw new Error(`Codex task not found: ${handle.trim().toUpperCase()}`);
+    return task;
+  }
+
+  private async requireDurableTask(handle: string): Promise<CodexTaskRecord & { threadId: string }> {
+    const task = await this.requireRegisteredTask(handle);
     if (!task.threadId) {
-      throw new Error(`Codex task ${task.handle} has no imported durable thread and requires recovery`);
+      if (task.candidateThreadId) {
+        throw new Error(
+          `Codex task ${task.handle} has an unresolved first-turn outcome; `
+            + 'send is required to verify its private thread candidate before reading',
+        );
+      }
+      if (task.status === 'pending') {
+        throw new Error(
+          `Codex task ${task.handle} is pending; send its first message to create a durable thread`,
+        );
+      }
+      throw new Error(
+        `Codex task ${task.handle} has no durable thread (status: ${task.status}); `
+          + (task.status === 'running'
+            ? 'refusing automatic retry because it could duplicate work'
+            : 'send a message to retry materialization'),
+      );
     }
     return { ...task, threadId: task.threadId };
   }
@@ -307,6 +536,24 @@ function truncate(value: string, max: number): string {
 
 function errorMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function isExplicitMissingThread(err: unknown): boolean {
+  return err instanceof CodexAppServerRpcError
+    && err.method === 'thread/read'
+    && err.code === -32600
+    && err.message.startsWith('thread not loaded:');
+}
+
+function candidateVerificationError(err: unknown): string {
+  if (err instanceof CodexAppServerRpcError) {
+    return `${err.method} failed with code ${String(err.code ?? 'unknown')}`;
+  }
+  if (err instanceof Error) {
+    const code = (err as NodeJS.ErrnoException).code;
+    return code ? `${err.name} (${code})` : err.name;
+  }
+  return 'unknown verification error';
 }
 
 export function finalAgentMessages(thread: Record<string, unknown>, limit = 5): string[] {
@@ -345,8 +592,15 @@ function contentText(value: unknown): string | undefined {
   return parts.length > 0 ? parts.join('\n') : undefined;
 }
 
-export function compactTaskForOutput(task: CodexTaskRecord): Omit<CodexTaskRecord, 'threadId'> {
-  const { threadId: _threadId, reconciliation, ...publicTask } = task;
+export function compactTaskForOutput(
+  task: CodexTaskRecord,
+): Omit<CodexTaskRecord, 'threadId' | 'candidateThreadId'> {
+  const {
+    threadId: _threadId,
+    candidateThreadId: _candidateThreadId,
+    reconciliation,
+    ...publicTask
+  } = task;
   if (!reconciliation) return publicTask;
   const { threadId: _recoveryThreadId, ...publicReconciliation } = reconciliation;
   return { ...publicTask, reconciliation: publicReconciliation };

--- a/src/codex-task/controller.ts
+++ b/src/codex-task/controller.ts
@@ -1,0 +1,255 @@
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { CodexAppServerAdapter, type CodexAppServerAdapterOptions } from '../agent/codex/app-server-adapter';
+import { withCodexAppServerConnection } from '../agent/codex/app-server-client';
+import { withConfigFileLock } from '../config/profile-store';
+import type { CodexTaskRecord, CodexTaskStatus } from './registry';
+import { CodexTaskRegistry } from './registry';
+
+export interface CodexTaskControllerOptions extends CodexAppServerAdapterOptions {
+  registry: CodexTaskRegistry;
+}
+
+export interface CreateCodexTaskInput {
+  title: string;
+  cwd: string;
+  model?: string;
+  message?: string;
+}
+
+export interface SendCodexTaskInput {
+  message: string;
+  model?: string;
+}
+
+export interface CodexTaskExecutionResult {
+  task: CodexTaskRecord;
+  output: string;
+  terminationReason: CodexTaskTerminationReason;
+}
+
+export interface CodexTaskReadResult {
+  task: CodexTaskRecord;
+  thread: Record<string, unknown>;
+}
+
+export type CodexTaskTerminationReason = 'normal' | 'interrupted' | 'timeout';
+
+export interface CodexTaskMessage {
+  role: 'user' | 'assistant';
+  text: string;
+}
+
+const WORKER_DEVELOPER_INSTRUCTIONS = `You are a persistent Codex worker task managed by lark-channel-bridge.
+Work only on the instruction sent to this worker and follow the target repository's AGENTS.md and skills.
+Do not manage, create, or send messages to other Codex tasks from this worker.
+Do not assume you are replying directly in Feishu; return a concise result for the controller to summarize.`;
+
+export class CodexTaskController {
+  private readonly options: CodexTaskControllerOptions;
+
+  constructor(options: CodexTaskControllerOptions) {
+    this.options = options;
+  }
+
+  list(): Promise<CodexTaskRecord[]> {
+    return this.options.registry.list();
+  }
+
+  async create(input: CreateCodexTaskInput): Promise<CodexTaskRecord | CodexTaskExecutionResult> {
+    const title = nonEmpty(input.title, 'title');
+    const cwd = nonEmpty(input.cwd, 'cwd');
+    const response = recordValue(await withCodexAppServerConnection(
+      { ...this.options, cwd },
+      async (connection) => {
+        const started = await connection.request('thread/start', {
+          cwd,
+          approvalPolicy: 'never',
+          sandbox: this.options.sandbox ?? 'danger-full-access',
+          serviceName: 'lark-channel-bridge-task-controller',
+          threadSource: 'user',
+          ephemeral: false,
+          ...(input.model ? { model: input.model } : {}),
+        });
+        const raw = recordValue(started);
+        const threadId = stringValue(recordValue(raw?.thread)?.id);
+        if (!threadId) throw new Error('codex app-server returned no thread id');
+        await connection.request('thread/name/set', { threadId, name: title });
+        return started;
+      },
+    ));
+    const thread = recordValue(response?.thread);
+    const threadId = stringValue(thread?.id);
+    if (!threadId) throw new Error('codex app-server returned no thread id');
+    const model = stringValue(response?.model) ?? input.model;
+    const task = await this.options.registry.register({
+      threadId,
+      title,
+      cwd,
+      ...(model ? { model } : {}),
+      status: 'idle',
+    });
+    if (!input.message?.trim()) return task;
+    return this.send(task.handle, { message: input.message, ...(input.model ? { model: input.model } : {}) });
+  }
+
+  async read(handle: string, includeTurns = true): Promise<CodexTaskReadResult> {
+    const task = await this.requireTask(handle);
+    const result = recordValue(await withCodexAppServerConnection(
+      { ...this.options, cwd: task.cwd },
+      (connection) => connection.request('thread/read', {
+        threadId: task.threadId,
+        includeTurns,
+      }),
+    ));
+    const thread = recordValue(result?.thread);
+    if (!thread) throw new Error(`codex app-server returned no thread for ${task.handle}`);
+    return { task, thread };
+  }
+
+  async send(handle: string, input: SendCodexTaskInput): Promise<CodexTaskExecutionResult> {
+    const message = nonEmpty(input.message, 'message');
+    const task = await this.requireTask(handle);
+    const runLockPath = join(this.options.profileStateDir, 'codex-task-runs', task.handle);
+    return withConfigFileLock(runLockPath, async () => {
+      const model = input.model ?? task.model;
+      await this.options.registry.update(task.handle, {
+        status: 'running',
+        ...(model ? { model } : {}),
+      });
+      try {
+        const outcome = await this.executeTurn(task, message, model);
+        const updated = await this.options.registry.update(task.handle, {
+          status: executionStatus(outcome.terminationReason),
+          ...(model ? { model } : {}),
+          lastResult: truncate(outcome.output, 4_000),
+        });
+        return {
+          task: updated,
+          output: outcome.output,
+          terminationReason: outcome.terminationReason,
+        };
+      } catch (err) {
+        await this.options.registry.update(task.handle, {
+          status: 'failed',
+          ...(model ? { model } : {}),
+          lastResult: truncate(err instanceof Error ? err.message : String(err), 4_000),
+        });
+        throw err;
+      }
+    });
+  }
+
+  private async executeTurn(
+    task: CodexTaskRecord,
+    message: string,
+    model: string | undefined,
+  ): Promise<{ output: string; terminationReason: CodexTaskTerminationReason }> {
+    const adapter = new CodexAppServerAdapter({
+      ...this.options,
+      ignoreRules: false,
+      developerInstructions: WORKER_DEVELOPER_INSTRUCTIONS,
+    });
+    const runOptions = {
+      runId: randomUUID(),
+      prompt: message,
+      cwd: task.cwd,
+      threadId: task.threadId,
+      ...(model ? { model } : {}),
+      sandbox: this.options.sandbox,
+    };
+    await adapter.prepareRun(runOptions);
+    const run = adapter.run(runOptions);
+    let output = '';
+    let terminationReason: CodexTaskTerminationReason | undefined;
+    let terminalError: string | undefined;
+    try {
+      for await (const event of run.events) {
+        if (event.type === 'final_text') output = event.content;
+        if (event.type === 'error') terminalError = event.message;
+        if (event.type === 'done') terminationReason = event.terminationReason;
+      }
+    } finally {
+      if (!(await run.waitForExit(2_000))) await run.stop().catch(() => undefined);
+    }
+    if (terminalError) {
+      throw new Error(terminalError);
+    }
+    if (!terminationReason) {
+      throw new Error('Codex turn ended without a terminal event');
+    }
+    return { output, terminationReason };
+  }
+
+  private async requireTask(handle: string): Promise<CodexTaskRecord> {
+    const task = await this.options.registry.get(handle);
+    if (!task) throw new Error(`Codex task not found: ${handle.trim().toUpperCase()}`);
+    return task;
+  }
+}
+
+function executionStatus(reason: CodexTaskTerminationReason): CodexTaskStatus {
+  if (reason === 'normal') return 'completed';
+  return reason;
+}
+
+function nonEmpty(value: string, label: string): string {
+  const trimmed = value.trim();
+  if (!trimmed) throw new Error(`${label} is required`);
+  return trimmed;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : undefined;
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+export function finalAgentMessages(thread: Record<string, unknown>, limit = 5): string[] {
+  return conversationMessages(thread, Number.MAX_SAFE_INTEGER)
+    .filter((message) => message.role === 'assistant')
+    .map((message) => message.text)
+    .slice(-Math.max(1, limit));
+}
+
+export function conversationMessages(
+  thread: Record<string, unknown>,
+  limit = 10,
+): CodexTaskMessage[] {
+  const turns = Array.isArray(thread.turns) ? thread.turns : [];
+  const messages: CodexTaskMessage[] = [];
+  for (const turn of turns) {
+    const items = Array.isArray(recordValue(turn)?.items) ? recordValue(turn)?.items as unknown[] : [];
+    for (const item of items) {
+      const record = recordValue(item);
+      if (record?.type === 'agentMessage') {
+        const text = stringValue(record.text);
+        if (text) messages.push({ role: 'assistant', text });
+        continue;
+      }
+      if (record?.type !== 'userMessage') continue;
+      const text = stringValue(record.text) ?? contentText(record.content);
+      if (text) messages.push({ role: 'user', text });
+    }
+  }
+  return messages.slice(-Math.max(1, limit));
+}
+
+function contentText(value: unknown): string | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const parts = value.map((item) => stringValue(recordValue(item)?.text)).filter(Boolean);
+  return parts.length > 0 ? parts.join('\n') : undefined;
+}
+
+export function compactTaskForOutput(task: CodexTaskRecord): Omit<CodexTaskRecord, 'threadId'> {
+  const { threadId: _threadId, ...publicTask } = task;
+  return publicTask;
+}

--- a/src/codex-task/registry.ts
+++ b/src/codex-task/registry.ts
@@ -1,0 +1,205 @@
+import { randomBytes } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { withConfigFileLock } from '../config/profile-store';
+import { writeFileAtomic } from '../platform/atomic-write';
+
+export type CodexTaskStatus =
+  | 'idle'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'interrupted'
+  | 'timeout';
+
+export interface CodexTaskRecord {
+  handle: string;
+  threadId: string;
+  title: string;
+  cwd: string;
+  model?: string;
+  status: CodexTaskStatus;
+  createdAt: string;
+  updatedAt: string;
+  lastResult?: string;
+}
+
+export interface RegisterCodexTaskInput {
+  threadId: string;
+  title: string;
+  cwd: string;
+  model?: string;
+  status?: CodexTaskStatus;
+  lastResult?: string;
+}
+
+export interface UpdateCodexTaskInput {
+  status?: CodexTaskStatus;
+  model?: string;
+  lastResult?: string;
+}
+
+const HANDLE_PATTERN = /^T-[A-F0-9]{6}$/;
+const REGISTRY_SCHEMA_VERSION = 1;
+
+export class CodexTaskRegistry {
+  constructor(
+    private readonly path: string,
+    private readonly now: () => Date = () => new Date(),
+    private readonly createHandle: () => string = randomHandle,
+  ) {}
+
+  async list(): Promise<CodexTaskRecord[]> {
+    const tasks = await readRegistry(this.path);
+    return tasks.sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+  }
+
+  async get(handle: string): Promise<CodexTaskRecord | undefined> {
+    const normalized = normalizeHandle(handle);
+    return (await readRegistry(this.path)).find((task) => task.handle === normalized);
+  }
+
+  async register(input: RegisterCodexTaskInput): Promise<CodexTaskRecord> {
+    return withConfigFileLock(this.path, async () => {
+      const tasks = await readRegistry(this.path);
+      const existing = tasks.find((task) => task.threadId === input.threadId);
+      const timestamp = this.now().toISOString();
+      if (existing) {
+        const updated = normalizeRecord({
+          ...existing,
+          title: input.title,
+          cwd: input.cwd,
+          ...(input.model ? { model: input.model } : {}),
+          status: input.status ?? existing.status,
+          updatedAt: timestamp,
+          ...(input.lastResult !== undefined ? { lastResult: input.lastResult } : {}),
+        });
+        if (!updated) throw new Error('failed to normalize existing Codex task');
+        await persistRegistry(this.path, tasks.map((task) => task.handle === existing.handle ? updated : task));
+        return updated;
+      }
+
+      const handles = new Set(tasks.map((task) => task.handle));
+      let handle = this.createHandle();
+      for (let attempt = 0; handles.has(handle); attempt++) {
+        if (attempt >= 99) throw new Error('failed to allocate a unique Codex task handle');
+        handle = this.createHandle();
+      }
+      const created = normalizeRecord({
+        handle,
+        threadId: input.threadId,
+        title: input.title,
+        cwd: input.cwd,
+        ...(input.model ? { model: input.model } : {}),
+        status: input.status ?? 'idle',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+        ...(input.lastResult !== undefined ? { lastResult: input.lastResult } : {}),
+      });
+      if (!created) throw new Error('failed to normalize new Codex task');
+      tasks.push(created);
+      await persistRegistry(this.path, tasks);
+      return created;
+    });
+  }
+
+  async update(handle: string, input: UpdateCodexTaskInput): Promise<CodexTaskRecord> {
+    const normalizedHandle = normalizeHandle(handle);
+    return withConfigFileLock(this.path, async () => {
+      const tasks = await readRegistry(this.path);
+      const index = tasks.findIndex((task) => task.handle === normalizedHandle);
+      if (index < 0) throw new Error(`Codex task not found: ${normalizedHandle}`);
+      const current = tasks[index]!;
+      const updated = normalizeRecord({
+        ...current,
+        ...(input.status ? { status: input.status } : {}),
+        ...(input.model ? { model: input.model } : {}),
+        ...(input.lastResult !== undefined ? { lastResult: input.lastResult } : {}),
+        updatedAt: this.now().toISOString(),
+      });
+      if (!updated) throw new Error(`failed to normalize Codex task: ${normalizedHandle}`);
+      tasks[index] = updated;
+      await persistRegistry(this.path, tasks);
+      return updated;
+    });
+  }
+}
+
+function randomHandle(): string {
+  return `T-${randomBytes(3).toString('hex').toUpperCase()}`;
+}
+
+function normalizeHandle(value: string): string {
+  const handle = value.trim().toUpperCase();
+  if (!HANDLE_PATTERN.test(handle)) throw new Error(`invalid Codex task handle: ${value}`);
+  return handle;
+}
+
+async function readRegistry(path: string): Promise<CodexTaskRecord[]> {
+  try {
+    const parsed = JSON.parse(await readFile(path, 'utf8')) as unknown;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error(`invalid Codex task registry: ${path}`);
+    }
+    const raw = parsed as Record<string, unknown>;
+    if (raw.schemaVersion !== REGISTRY_SCHEMA_VERSION || !Array.isArray(raw.tasks)) {
+      throw new Error(`unsupported or damaged Codex task registry: ${path}`);
+    }
+    const tasks = raw.tasks.map(normalizeRecord);
+    if (tasks.some((task) => !task)) {
+      throw new Error(`damaged Codex task registry entry: ${path}`);
+    }
+    return tasks as CodexTaskRecord[];
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+}
+
+async function persistRegistry(path: string, tasks: CodexTaskRecord[]): Promise<void> {
+  const sorted = [...tasks].sort((left, right) => left.createdAt.localeCompare(right.createdAt));
+  await writeFileAtomic(path, `${JSON.stringify({
+    schemaVersion: REGISTRY_SCHEMA_VERSION,
+    tasks: sorted,
+  }, null, 2)}\n`, { mode: 0o600 });
+}
+
+function normalizeRecord(value: unknown): CodexTaskRecord | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const raw = value as Record<string, unknown>;
+  const handle = typeof raw.handle === 'string' ? raw.handle.toUpperCase() : '';
+  const status = raw.status;
+  if (
+    !HANDLE_PATTERN.test(handle) ||
+    typeof raw.threadId !== 'string' ||
+    !raw.threadId ||
+    typeof raw.title !== 'string' ||
+    !raw.title.trim() ||
+    typeof raw.cwd !== 'string' ||
+    !raw.cwd ||
+    !isStatus(status) ||
+    typeof raw.createdAt !== 'string' ||
+    typeof raw.updatedAt !== 'string'
+  ) {
+    return undefined;
+  }
+  return {
+    handle,
+    threadId: raw.threadId,
+    title: raw.title.trim(),
+    cwd: raw.cwd,
+    ...(typeof raw.model === 'string' && raw.model ? { model: raw.model } : {}),
+    status,
+    createdAt: raw.createdAt,
+    updatedAt: raw.updatedAt,
+    ...(typeof raw.lastResult === 'string' ? { lastResult: raw.lastResult } : {}),
+  };
+}
+
+function isStatus(value: unknown): value is CodexTaskStatus {
+  return value === 'idle'
+    || value === 'running'
+    || value === 'completed'
+    || value === 'failed'
+    || value === 'interrupted'
+    || value === 'timeout';
+}

--- a/src/codex-task/registry.ts
+++ b/src/codex-task/registry.ts
@@ -4,6 +4,8 @@ import { withConfigFileLock } from '../config/profile-store';
 import { writeFileAtomic } from '../platform/atomic-write';
 
 export type CodexTaskStatus =
+  | 'pending'
+  | 'reconcile'
   | 'idle'
   | 'running'
   | 'completed'
@@ -13,7 +15,7 @@ export type CodexTaskStatus =
 
 export interface CodexTaskRecord {
   handle: string;
-  threadId: string;
+  threadId?: string;
   title: string;
   cwd: string;
   model?: string;
@@ -21,6 +23,22 @@ export interface CodexTaskRecord {
   createdAt: string;
   updatedAt: string;
   lastResult?: string;
+  lastTurnId?: string;
+  reconciliation?: CodexTaskReconciliation;
+}
+
+export interface CodexTaskReconciliation {
+  desiredStatus: Exclude<CodexTaskStatus, 'pending' | 'reconcile'>;
+  error: string;
+  threadId?: string;
+  lastTurnId?: string;
+  lastResult?: string;
+}
+
+export interface ReserveCodexTaskInput {
+  title: string;
+  cwd: string;
+  model?: string;
 }
 
 export interface RegisterCodexTaskInput {
@@ -35,6 +53,15 @@ export interface RegisterCodexTaskInput {
 export interface UpdateCodexTaskInput {
   status?: CodexTaskStatus;
   model?: string;
+  lastResult?: string;
+  lastTurnId?: string;
+}
+
+export interface MarkCodexTaskReconcileInput {
+  desiredStatus: CodexTaskReconciliation['desiredStatus'];
+  error: string;
+  threadId?: string;
+  lastTurnId?: string;
   lastResult?: string;
 }
 
@@ -58,6 +85,80 @@ export class CodexTaskRegistry {
     return (await readRegistry(this.path)).find((task) => task.handle === normalized);
   }
 
+  async reserve(input: ReserveCodexTaskInput): Promise<CodexTaskRecord> {
+    return withConfigFileLock(this.path, async () => {
+      const tasks = await readRegistry(this.path);
+      const timestamp = this.now().toISOString();
+      const created = normalizeRecord({
+        handle: allocateHandle(tasks, this.createHandle),
+        title: input.title,
+        cwd: input.cwd,
+        ...(input.model ? { model: input.model } : {}),
+        status: 'pending',
+        createdAt: timestamp,
+        updatedAt: timestamp,
+      });
+      if (!created) throw new Error('failed to reserve a Codex task');
+      tasks.push(created);
+      await persistRegistry(this.path, tasks);
+      return created;
+    });
+  }
+
+  async importThread(handle: string, threadId: string): Promise<CodexTaskRecord> {
+    const normalizedThreadId = threadId.trim();
+    if (!normalizedThreadId) throw new Error('thread id is required');
+    return this.mutate(handle, (current) => ({
+      ...current,
+      threadId: normalizedThreadId,
+      status: 'pending',
+    }));
+  }
+
+  async markReconcile(handle: string, input: MarkCodexTaskReconcileInput): Promise<CodexTaskRecord> {
+    return this.mutate(handle, (current) => ({
+      ...current,
+      ...(input.threadId ? { threadId: input.threadId } : {}),
+      status: 'reconcile',
+      reconciliation: {
+        desiredStatus: input.desiredStatus,
+        error: input.error,
+        ...(input.threadId ? { threadId: input.threadId } : {}),
+        ...(input.lastTurnId ? { lastTurnId: input.lastTurnId } : {}),
+        ...(input.lastResult !== undefined ? { lastResult: input.lastResult } : {}),
+      },
+    }));
+  }
+
+  async reconcile(handle?: string): Promise<CodexTaskRecord[]> {
+    const requested = handle ? normalizeHandle(handle) : undefined;
+    return withConfigFileLock(this.path, async () => {
+      const tasks = await readRegistry(this.path);
+      let changed = false;
+      const reconciled = tasks.map((task) => {
+        if (task.status !== 'reconcile' || !task.reconciliation) return task;
+        if (requested && task.handle !== requested) return task;
+        const recovery = task.reconciliation;
+        const updated = normalizeRecord({
+          ...task,
+          ...(recovery.threadId ? { threadId: recovery.threadId } : {}),
+          status: recovery.desiredStatus,
+          ...(recovery.lastTurnId ? { lastTurnId: recovery.lastTurnId } : {}),
+          ...(recovery.lastResult !== undefined ? { lastResult: recovery.lastResult } : {}),
+          reconciliation: undefined,
+          updatedAt: this.now().toISOString(),
+        });
+        if (!updated) throw new Error(`failed to reconcile Codex task: ${task.handle}`);
+        changed = true;
+        return updated;
+      });
+      if (changed) await persistRegistry(this.path, reconciled);
+      return reconciled
+        .filter((task) => !requested || task.handle === requested)
+        .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt));
+    });
+  }
+
   async register(input: RegisterCodexTaskInput): Promise<CodexTaskRecord> {
     return withConfigFileLock(this.path, async () => {
       const tasks = await readRegistry(this.path);
@@ -78,14 +179,8 @@ export class CodexTaskRegistry {
         return updated;
       }
 
-      const handles = new Set(tasks.map((task) => task.handle));
-      let handle = this.createHandle();
-      for (let attempt = 0; handles.has(handle); attempt++) {
-        if (attempt >= 99) throw new Error('failed to allocate a unique Codex task handle');
-        handle = this.createHandle();
-      }
       const created = normalizeRecord({
-        handle,
+        handle: allocateHandle(tasks, this.createHandle),
         threadId: input.threadId,
         title: input.title,
         cwd: input.cwd,
@@ -103,17 +198,31 @@ export class CodexTaskRegistry {
   }
 
   async update(handle: string, input: UpdateCodexTaskInput): Promise<CodexTaskRecord> {
+    return this.mutate(handle, (current) => ({
+      ...current,
+      ...(input.status ? { status: input.status } : {}),
+      ...(input.model ? { model: input.model } : {}),
+      ...(input.lastResult !== undefined ? { lastResult: input.lastResult } : {}),
+      ...(input.status === 'running'
+        ? { lastTurnId: undefined }
+        : input.lastTurnId
+          ? { lastTurnId: input.lastTurnId }
+          : {}),
+      reconciliation: undefined,
+    }));
+  }
+
+  private async mutate(
+    handle: string,
+    change: (current: CodexTaskRecord) => Record<string, unknown>,
+  ): Promise<CodexTaskRecord> {
     const normalizedHandle = normalizeHandle(handle);
     return withConfigFileLock(this.path, async () => {
       const tasks = await readRegistry(this.path);
       const index = tasks.findIndex((task) => task.handle === normalizedHandle);
       if (index < 0) throw new Error(`Codex task not found: ${normalizedHandle}`);
-      const current = tasks[index]!;
       const updated = normalizeRecord({
-        ...current,
-        ...(input.status ? { status: input.status } : {}),
-        ...(input.model ? { model: input.model } : {}),
-        ...(input.lastResult !== undefined ? { lastResult: input.lastResult } : {}),
+        ...change(tasks[index]!),
         updatedAt: this.now().toISOString(),
       });
       if (!updated) throw new Error(`failed to normalize Codex task: ${normalizedHandle}`);
@@ -131,6 +240,16 @@ function randomHandle(): string {
 function normalizeHandle(value: string): string {
   const handle = value.trim().toUpperCase();
   if (!HANDLE_PATTERN.test(handle)) throw new Error(`invalid Codex task handle: ${value}`);
+  return handle;
+}
+
+function allocateHandle(tasks: CodexTaskRecord[], createHandle: () => string): string {
+  const handles = new Set(tasks.map((task) => task.handle));
+  let handle = createHandle();
+  for (let attempt = 0; handles.has(handle); attempt++) {
+    if (attempt >= 99) throw new Error('failed to allocate a unique Codex task handle');
+    handle = createHandle();
+  }
   return handle;
 }
 
@@ -168,23 +287,24 @@ function normalizeRecord(value: unknown): CodexTaskRecord | undefined {
   const raw = value as Record<string, unknown>;
   const handle = typeof raw.handle === 'string' ? raw.handle.toUpperCase() : '';
   const status = raw.status;
+  const reconciliation = normalizeReconciliation(raw.reconciliation);
   if (
     !HANDLE_PATTERN.test(handle) ||
-    typeof raw.threadId !== 'string' ||
-    !raw.threadId ||
+    (raw.threadId !== undefined && (typeof raw.threadId !== 'string' || !raw.threadId)) ||
     typeof raw.title !== 'string' ||
     !raw.title.trim() ||
     typeof raw.cwd !== 'string' ||
     !raw.cwd ||
     !isStatus(status) ||
     typeof raw.createdAt !== 'string' ||
-    typeof raw.updatedAt !== 'string'
+    typeof raw.updatedAt !== 'string' ||
+    (status === 'reconcile' && !reconciliation)
   ) {
     return undefined;
   }
   return {
     handle,
-    threadId: raw.threadId,
+    ...(typeof raw.threadId === 'string' ? { threadId: raw.threadId } : {}),
     title: raw.title.trim(),
     cwd: raw.cwd,
     ...(typeof raw.model === 'string' && raw.model ? { model: raw.model } : {}),
@@ -192,10 +312,36 @@ function normalizeRecord(value: unknown): CodexTaskRecord | undefined {
     createdAt: raw.createdAt,
     updatedAt: raw.updatedAt,
     ...(typeof raw.lastResult === 'string' ? { lastResult: raw.lastResult } : {}),
+    ...(typeof raw.lastTurnId === 'string' && raw.lastTurnId ? { lastTurnId: raw.lastTurnId } : {}),
+    ...(reconciliation ? { reconciliation } : {}),
+  };
+}
+
+function normalizeReconciliation(value: unknown): CodexTaskReconciliation | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return undefined;
+  const raw = value as Record<string, unknown>;
+  if (!isSettledStatus(raw.desiredStatus) || typeof raw.error !== 'string' || !raw.error) return undefined;
+  return {
+    desiredStatus: raw.desiredStatus,
+    error: raw.error,
+    ...(typeof raw.threadId === 'string' && raw.threadId ? { threadId: raw.threadId } : {}),
+    ...(typeof raw.lastTurnId === 'string' && raw.lastTurnId ? { lastTurnId: raw.lastTurnId } : {}),
+    ...(typeof raw.lastResult === 'string' ? { lastResult: raw.lastResult } : {}),
   };
 }
 
 function isStatus(value: unknown): value is CodexTaskStatus {
+  return value === 'pending'
+    || value === 'reconcile'
+    || value === 'idle'
+    || value === 'running'
+    || value === 'completed'
+    || value === 'failed'
+    || value === 'interrupted'
+    || value === 'timeout';
+}
+
+function isSettledStatus(value: unknown): value is CodexTaskReconciliation['desiredStatus'] {
   return value === 'idle'
     || value === 'running'
     || value === 'completed'

--- a/src/codex-task/registry.ts
+++ b/src/codex-task/registry.ts
@@ -1,5 +1,7 @@
 import { randomBytes } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import * as lockfile from 'proper-lockfile';
 import { withConfigFileLock } from '../config/profile-store';
 import { writeFileAtomic } from '../platform/atomic-write';
 
@@ -16,6 +18,8 @@ export type CodexTaskStatus =
 export interface CodexTaskRecord {
   handle: string;
   threadId?: string;
+  /** Fresh App Server thread awaiting confirmation that its first turn is durable. */
+  candidateThreadId?: string;
   title: string;
   cwd: string;
   model?: string;
@@ -68,12 +72,53 @@ export interface MarkCodexTaskReconcileInput {
 const HANDLE_PATTERN = /^T-[A-F0-9]{6}$/;
 const REGISTRY_SCHEMA_VERSION = 1;
 
+export class CodexTaskBusyError extends Error {
+  readonly code = 'codex-task-busy';
+
+  constructor(readonly handle: string, cause?: unknown) {
+    super(`Codex task ${handle} is already running`);
+    this.name = 'CodexTaskBusyError';
+    this.cause = cause;
+  }
+}
+
 export class CodexTaskRegistry {
   constructor(
     private readonly path: string,
     private readonly now: () => Date = () => new Date(),
     private readonly createHandle: () => string = randomHandle,
   ) {}
+
+  async withTaskLock<T>(handle: string, fn: () => Promise<T>): Promise<T> {
+    const normalized = normalizeHandle(handle);
+    const target = join(dirname(this.path), 'codex-task-runs', normalized);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, '', { flag: 'a', mode: 0o600 });
+    await chmod(target, 0o600).catch(() => {});
+
+    let release: () => Promise<void>;
+    try {
+      release = await lockfile.lock(target, {
+        realpath: false,
+        // Task turns can legitimately take minutes. Heartbeats prevent a live
+        // worker from being mistaken for a stale lock.
+        stale: 2 * 60_000,
+        update: 10_000,
+        retries: 0,
+      });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ELOCKED') {
+        throw new CodexTaskBusyError(normalized, err);
+      }
+      throw err;
+    }
+
+    try {
+      return await fn();
+    } finally {
+      await release();
+    }
+  }
 
   async list(): Promise<CodexTaskRecord[]> {
     const tasks = await readRegistry(this.path);
@@ -105,20 +150,77 @@ export class CodexTaskRegistry {
     });
   }
 
-  async importThread(handle: string, threadId: string): Promise<CodexTaskRecord> {
+  async importThread(
+    handle: string,
+    threadId: string,
+    input: Pick<UpdateCodexTaskInput, 'status' | 'lastResult'> = {},
+  ): Promise<CodexTaskRecord> {
     const normalizedThreadId = threadId.trim();
     if (!normalizedThreadId) throw new Error('thread id is required');
-    return this.mutate(handle, (current) => ({
-      ...current,
-      threadId: normalizedThreadId,
-      status: 'pending',
-    }));
+    return this.mutate(handle, (current, tasks) => {
+      if (current.threadId && current.threadId !== normalizedThreadId) {
+        throw new Error(`Codex task ${current.handle} already owns thread ${current.threadId}`);
+      }
+      if (current.candidateThreadId && current.candidateThreadId !== normalizedThreadId) {
+        throw new Error(
+          `Codex task ${current.handle} candidate ${current.candidateThreadId} does not match ${normalizedThreadId}`,
+        );
+      }
+      assertThreadIdAvailable(tasks, current.handle, normalizedThreadId);
+      return {
+        ...current,
+        threadId: normalizedThreadId,
+        candidateThreadId: undefined,
+        ...(input.status ? { status: input.status } : {}),
+        ...(input.lastResult !== undefined ? { lastResult: input.lastResult } : {}),
+        ...(input.status || input.lastResult !== undefined ? { reconciliation: undefined } : {}),
+      };
+    });
+  }
+
+  async setThreadCandidate(handle: string, threadId: string): Promise<CodexTaskRecord> {
+    const normalizedThreadId = threadId.trim();
+    if (!normalizedThreadId) throw new Error('candidate thread id is required');
+    return this.mutate(handle, (current, tasks) => {
+      if (current.threadId) {
+        if (current.threadId === normalizedThreadId) return current;
+        throw new Error(`Codex task ${current.handle} already owns thread ${current.threadId}`);
+      }
+      if (current.candidateThreadId && current.candidateThreadId !== normalizedThreadId) {
+        throw new Error(
+          `Codex task ${current.handle} already has candidate ${current.candidateThreadId}`,
+        );
+      }
+      assertThreadIdAvailable(tasks, current.handle, normalizedThreadId);
+      return { ...current, candidateThreadId: normalizedThreadId };
+    });
+  }
+
+  async clearThreadCandidate(
+    handle: string,
+    threadId: string,
+    input: Pick<UpdateCodexTaskInput, 'status' | 'lastResult'> = {},
+  ): Promise<CodexTaskRecord> {
+    const normalizedThreadId = threadId.trim();
+    if (!normalizedThreadId) throw new Error('candidate thread id is required');
+    return this.mutate(handle, (current) => {
+      if (current.candidateThreadId !== normalizedThreadId) {
+        throw new Error(`Codex task ${current.handle} candidate changed before it could be cleared`);
+      }
+      return {
+        ...current,
+        candidateThreadId: undefined,
+        ...(input.status ? { status: input.status } : {}),
+        ...(input.lastResult !== undefined ? { lastResult: input.lastResult } : {}),
+        ...(input.status || input.lastResult !== undefined ? { reconciliation: undefined } : {}),
+      };
+    });
   }
 
   async markReconcile(handle: string, input: MarkCodexTaskReconcileInput): Promise<CodexTaskRecord> {
     return this.mutate(handle, (current) => ({
       ...current,
-      ...(input.threadId ? { threadId: input.threadId } : {}),
+      ...(input.threadId ? { threadId: input.threadId, candidateThreadId: undefined } : {}),
       status: 'reconcile',
       reconciliation: {
         desiredStatus: input.desiredStatus,
@@ -141,7 +243,7 @@ export class CodexTaskRegistry {
         const recovery = task.reconciliation;
         const updated = normalizeRecord({
           ...task,
-          ...(recovery.threadId ? { threadId: recovery.threadId } : {}),
+          ...(recovery.threadId ? { threadId: recovery.threadId, candidateThreadId: undefined } : {}),
           status: recovery.desiredStatus,
           ...(recovery.lastTurnId ? { lastTurnId: recovery.lastTurnId } : {}),
           ...(recovery.lastResult !== undefined ? { lastResult: recovery.lastResult } : {}),
@@ -162,11 +264,15 @@ export class CodexTaskRegistry {
   async register(input: RegisterCodexTaskInput): Promise<CodexTaskRecord> {
     return withConfigFileLock(this.path, async () => {
       const tasks = await readRegistry(this.path);
-      const existing = tasks.find((task) => task.threadId === input.threadId);
+      const existing = tasks.find((task) => (
+        task.threadId === input.threadId || task.candidateThreadId === input.threadId
+      ));
       const timestamp = this.now().toISOString();
       if (existing) {
         const updated = normalizeRecord({
           ...existing,
+          threadId: input.threadId,
+          candidateThreadId: undefined,
           title: input.title,
           cwd: input.cwd,
           ...(input.model ? { model: input.model } : {}),
@@ -214,7 +320,10 @@ export class CodexTaskRegistry {
 
   private async mutate(
     handle: string,
-    change: (current: CodexTaskRecord) => Record<string, unknown>,
+    change: (
+      current: CodexTaskRecord,
+      tasks: readonly CodexTaskRecord[],
+    ) => CodexTaskRecord | Record<string, unknown>,
   ): Promise<CodexTaskRecord> {
     const normalizedHandle = normalizeHandle(handle);
     return withConfigFileLock(this.path, async () => {
@@ -222,11 +331,12 @@ export class CodexTaskRegistry {
       const index = tasks.findIndex((task) => task.handle === normalizedHandle);
       if (index < 0) throw new Error(`Codex task not found: ${normalizedHandle}`);
       const updated = normalizeRecord({
-        ...change(tasks[index]!),
+        ...change(tasks[index]!, tasks),
         updatedAt: this.now().toISOString(),
       });
       if (!updated) throw new Error(`failed to normalize Codex task: ${normalizedHandle}`);
       tasks[index] = updated;
+      assertUniqueThreadOwnership(tasks);
       await persistRegistry(this.path, tasks);
       return updated;
     });
@@ -267,7 +377,9 @@ async function readRegistry(path: string): Promise<CodexTaskRecord[]> {
     if (tasks.some((task) => !task)) {
       throw new Error(`damaged Codex task registry entry: ${path}`);
     }
-    return tasks as CodexTaskRecord[];
+    const normalized = tasks as CodexTaskRecord[];
+    assertUniqueThreadOwnership(normalized);
+    return normalized;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
     throw err;
@@ -275,6 +387,7 @@ async function readRegistry(path: string): Promise<CodexTaskRecord[]> {
 }
 
 async function persistRegistry(path: string, tasks: CodexTaskRecord[]): Promise<void> {
+  assertUniqueThreadOwnership(tasks);
   const sorted = [...tasks].sort((left, right) => left.createdAt.localeCompare(right.createdAt));
   await writeFileAtomic(path, `${JSON.stringify({
     schemaVersion: REGISTRY_SCHEMA_VERSION,
@@ -291,6 +404,9 @@ function normalizeRecord(value: unknown): CodexTaskRecord | undefined {
   if (
     !HANDLE_PATTERN.test(handle) ||
     (raw.threadId !== undefined && (typeof raw.threadId !== 'string' || !raw.threadId)) ||
+    (raw.candidateThreadId !== undefined
+      && (typeof raw.candidateThreadId !== 'string' || !raw.candidateThreadId)) ||
+    (raw.threadId !== undefined && raw.candidateThreadId !== undefined) ||
     typeof raw.title !== 'string' ||
     !raw.title.trim() ||
     typeof raw.cwd !== 'string' ||
@@ -305,6 +421,9 @@ function normalizeRecord(value: unknown): CodexTaskRecord | undefined {
   return {
     handle,
     ...(typeof raw.threadId === 'string' ? { threadId: raw.threadId } : {}),
+    ...(typeof raw.candidateThreadId === 'string'
+      ? { candidateThreadId: raw.candidateThreadId }
+      : {}),
     title: raw.title.trim(),
     cwd: raw.cwd,
     ...(typeof raw.model === 'string' && raw.model ? { model: raw.model } : {}),
@@ -315,6 +434,32 @@ function normalizeRecord(value: unknown): CodexTaskRecord | undefined {
     ...(typeof raw.lastTurnId === 'string' && raw.lastTurnId ? { lastTurnId: raw.lastTurnId } : {}),
     ...(reconciliation ? { reconciliation } : {}),
   };
+}
+
+function assertThreadIdAvailable(
+  tasks: readonly CodexTaskRecord[],
+  handle: string,
+  threadId: string,
+): void {
+  const owner = tasks.find((task) => (
+    task.handle !== handle
+    && (task.threadId === threadId || task.candidateThreadId === threadId)
+  ));
+  if (owner) throw new Error(`Codex thread ${threadId} already belongs to task ${owner.handle}`);
+}
+
+function assertUniqueThreadOwnership(tasks: readonly CodexTaskRecord[]): void {
+  const owners = new Map<string, string>();
+  for (const task of tasks) {
+    for (const threadId of [task.threadId, task.candidateThreadId]) {
+      if (!threadId) continue;
+      const owner = owners.get(threadId);
+      if (owner && owner !== task.handle) {
+        throw new Error(`Codex thread ${threadId} already belongs to task ${owner}`);
+      }
+      owners.set(threadId, task.handle);
+    }
+  }
 }
 
 function normalizeReconciliation(value: unknown): CodexTaskReconciliation | undefined {

--- a/src/codex-task/workspace.ts
+++ b/src/codex-task/workspace.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { link, mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { writeFileAtomic } from '../platform/atomic-write';
 
@@ -57,36 +58,46 @@ Use the local \`lark-channel-bridge codex-task\` control plane for every cross-t
 When \`LARK_CHANNEL_PROFILE\` is set, pass \`--profile "$LARK_CHANNEL_PROFILE"\`.
 Otherwise ask for the profile name instead of guessing when more than one profile exists.
 
+Preserve the exact Bridge root config without reusing \`LARK_CHANNEL_CONFIG\`, which belongs to
+the lark-cli source projection:
+
+\`\`\`bash
+bridge_config_args=()
+if [[ -n "\${LARK_CHANNEL_BRIDGE_CONFIG:-}" ]]; then
+  bridge_config_args=(--config "$LARK_CHANNEL_BRIDGE_CONFIG")
+fi
+\`\`\`
+
 ## Commands
 
 List registered worker tasks:
 
 \`\`\`bash
-lark-channel-bridge codex-task list --profile "$LARK_CHANNEL_PROFILE" --json
+lark-channel-bridge codex-task list "\${bridge_config_args[@]}" --profile "$LARK_CHANNEL_PROFILE" --json
 \`\`\`
 
 Create an empty persistent worker task:
 
 \`\`\`bash
-lark-channel-bridge codex-task create --profile "$LARK_CHANNEL_PROFILE" --title "<title>" --cwd "<absolute-path>" --json
+lark-channel-bridge codex-task create "\${bridge_config_args[@]}" --profile "$LARK_CHANNEL_PROFILE" --title "<title>" --cwd "<absolute-path>" --json
 \`\`\`
 
 Create a worker and immediately give it work:
 
 \`\`\`bash
-lark-channel-bridge codex-task create --profile "$LARK_CHANNEL_PROFILE" --title "<title>" --cwd "<absolute-path>" --message "<instruction>" --json
+lark-channel-bridge codex-task create "\${bridge_config_args[@]}" --profile "$LARK_CHANNEL_PROFILE" --title "<title>" --cwd "<absolute-path>" --message "<instruction>" --json
 \`\`\`
 
 Read a worker without resuming it:
 
 \`\`\`bash
-lark-channel-bridge codex-task read <handle> --profile "$LARK_CHANNEL_PROFILE" --json
+lark-channel-bridge codex-task read <handle> "\${bridge_config_args[@]}" --profile "$LARK_CHANNEL_PROFILE" --json
 \`\`\`
 
 Send additional work and wait for the turn to finish:
 
 \`\`\`bash
-lark-channel-bridge codex-task send <handle> --profile "$LARK_CHANNEL_PROFILE" --message "<instruction>" --json
+lark-channel-bridge codex-task send <handle> "\${bridge_config_args[@]}" --profile "$LARK_CHANNEL_PROFILE" --message "<instruction>" --json
 \`\`\`
 
 After a command finishes, report the handle, title, cwd, model, status, and result. Keep long histories summarized unless the user asks for full detail.
@@ -106,22 +117,28 @@ export async function initializeControllerWorkspace(
   const result: InitializeControllerWorkspaceResult = { workspace, created: [], skipped: [] };
   await mkdir(workspace, { recursive: true });
   for (const file of files) {
-    if (!options.force && await exists(file.path)) {
-      result.skipped.push(file.path);
-      continue;
+    if (!options.force) {
+      try {
+        await writeFileAtomicNoClobber(file.path, file.content, 0o644);
+        result.created.push(file.path);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+        result.skipped.push(file.path);
+      }
+    } else {
+      await writeFileAtomic(file.path, file.content, { mode: 0o644 });
+      result.created.push(file.path);
     }
-    await writeFileAtomic(file.path, file.content, { mode: 0o644 });
-    result.created.push(file.path);
   }
   return result;
 }
 
-async function exists(path: string): Promise<boolean> {
+async function writeFileAtomicNoClobber(path: string, content: string, mode: number): Promise<void> {
+  const candidate = `${path}.new-${randomUUID()}`;
   try {
-    await readFile(path);
-    return true;
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
-    throw err;
+    await writeFileAtomic(candidate, content, { mode });
+    await link(candidate, path);
+  } finally {
+    await rm(candidate, { force: true }).catch(() => undefined);
   }
 }

--- a/src/codex-task/workspace.ts
+++ b/src/codex-task/workspace.ts
@@ -1,0 +1,127 @@
+import { mkdir, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { writeFileAtomic } from '../platform/atomic-write';
+
+export interface InitializeControllerWorkspaceOptions {
+  workspace: string;
+  force?: boolean;
+}
+
+export interface InitializeControllerWorkspaceResult {
+  workspace: string;
+  created: string[];
+  skipped: string[];
+}
+
+const AGENTS_CONTENT = `# 飞书 Codex 主控工作区
+
+本目录用于维护一个长期存在的飞书主控 task。
+
+## 职责
+
+- 普通飞书消息默认由当前主 task 处理。
+- 涉及具体代码仓库的实现、测试或 review，优先创建或恢复该仓库对应的 worker task。
+- task 管理必须使用 \`codex-task-controller\` Skill 和 Bridge 提供的 \`codex-task\` 命令。
+- 不直接修改 Codex rollout JSONL、SQLite 或 session index。
+- 不同时从 Bridge 和 Codex App 写入同一个 task。
+- 读取其他 task 时先读取元数据和摘要，仅在必要时读取完整 turns。
+- worker 完成后，将结果汇总回当前主 task。
+
+## 工作目录
+
+- 主 task 的 cwd 始终保持为本目录。
+- “切换项目”表示选择 worker 的目标项目，不修改主 task 的真实 cwd。
+- worker task 使用目标项目的真实绝对路径作为 cwd。
+`;
+
+const SKILL_CONTENT = `---
+name: codex-task-controller
+description: Use when the user asks to list, inspect, create, resume, or send work to persistent Codex tasks from the fixed Lark controller workspace.
+---
+
+# Codex Task Controller
+
+Use the local \`lark-channel-bridge codex-task\` control plane for every cross-task operation.
+
+## Boundaries
+
+1. Never edit Codex rollout JSONL, SQLite, or session index files directly.
+2. Use user-facing task handles such as \`T-A1B2C3\`; do not expose raw thread IDs unless diagnosing locally.
+3. Read task metadata before sending work.
+4. Do not send work when the target is already being written by Codex App.
+5. Never dispatch work back to the current controller task.
+6. Do not delete or archive tasks; this MVP intentionally has no destructive command.
+
+## Profile selection
+
+When \`LARK_CHANNEL_PROFILE\` is set, pass \`--profile "$LARK_CHANNEL_PROFILE"\`.
+Otherwise ask for the profile name instead of guessing when more than one profile exists.
+
+## Commands
+
+List registered worker tasks:
+
+\`\`\`bash
+lark-channel-bridge codex-task list --profile "$LARK_CHANNEL_PROFILE" --json
+\`\`\`
+
+Create an empty persistent worker task:
+
+\`\`\`bash
+lark-channel-bridge codex-task create --profile "$LARK_CHANNEL_PROFILE" --title "<title>" --cwd "<absolute-path>" --json
+\`\`\`
+
+Create a worker and immediately give it work:
+
+\`\`\`bash
+lark-channel-bridge codex-task create --profile "$LARK_CHANNEL_PROFILE" --title "<title>" --cwd "<absolute-path>" --message "<instruction>" --json
+\`\`\`
+
+Read a worker without resuming it:
+
+\`\`\`bash
+lark-channel-bridge codex-task read <handle> --profile "$LARK_CHANNEL_PROFILE" --json
+\`\`\`
+
+Send additional work and wait for the turn to finish:
+
+\`\`\`bash
+lark-channel-bridge codex-task send <handle> --profile "$LARK_CHANNEL_PROFILE" --message "<instruction>" --json
+\`\`\`
+
+After a command finishes, report the handle, title, cwd, model, status, and result. Keep long histories summarized unless the user asks for full detail.
+`;
+
+export async function initializeControllerWorkspace(
+  options: InitializeControllerWorkspaceOptions,
+): Promise<InitializeControllerWorkspaceResult> {
+  const workspace = options.workspace;
+  const files = [
+    { path: join(workspace, 'AGENTS.md'), content: AGENTS_CONTENT },
+    {
+      path: join(workspace, '.agents', 'skills', 'codex-task-controller', 'SKILL.md'),
+      content: SKILL_CONTENT,
+    },
+  ];
+  const result: InitializeControllerWorkspaceResult = { workspace, created: [], skipped: [] };
+  await mkdir(workspace, { recursive: true });
+  for (const file of files) {
+    if (!options.force && await exists(file.path)) {
+      result.skipped.push(file.path);
+      continue;
+    }
+    await writeFileAtomic(file.path, file.content, { mode: 0o644 });
+    result.created.push(file.path);
+  }
+  return result;
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await readFile(path);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw err;
+  }
+}

--- a/src/codex-task/workspace.ts
+++ b/src/codex-task/workspace.ts
@@ -53,51 +53,45 @@ Use the local \`lark-channel-bridge codex-task\` control plane for every cross-t
 5. Never dispatch work back to the current controller task.
 6. Do not delete or archive tasks; this MVP intentionally has no destructive command.
 
-## Profile selection
+## Profile and config selection
 
-When \`LARK_CHANNEL_PROFILE\` is set, pass \`--profile "$LARK_CHANNEL_PROFILE"\`.
-Otherwise ask for the profile name instead of guessing when more than one profile exists.
+Resolve two shell-neutral placeholders before running a command:
 
-Preserve the exact Bridge root config without reusing \`LARK_CHANNEL_CONFIG\`, which belongs to
-the lark-cli source projection:
+- \`<profile-option>\` is \`--profile "<profile-name>"\`. Use \`LARK_CHANNEL_PROFILE\` when it is set; otherwise ask instead of guessing when more than one profile exists.
+- \`<config-option>\` is empty unless \`LARK_CHANNEL_BRIDGE_CONFIG\` is set, in which case it is \`--config "<absolute-root-config-path>"\`.
 
-\`\`\`bash
-bridge_config_args=()
-if [[ -n "\${LARK_CHANNEL_BRIDGE_CONFIG:-}" ]]; then
-  bridge_config_args=(--config "$LARK_CHANNEL_BRIDGE_CONFIG")
-fi
-\`\`\`
+Do not reuse \`LARK_CHANNEL_CONFIG\`; it belongs to the lark-cli source projection. Substitute the placeholders as ordinary command arguments so the same examples work in Bash, PowerShell, and cmd.exe.
 
 ## Commands
 
 List registered worker tasks:
 
-\`\`\`bash
-lark-channel-bridge codex-task list "\${bridge_config_args[@]}" --profile "$LARK_CHANNEL_PROFILE" --json
+\`\`\`text
+lark-channel-bridge codex-task list <config-option> <profile-option> --json
 \`\`\`
 
-Create an empty persistent worker task:
+Reserve a pending worker handle. This does not create a Codex thread yet:
 
-\`\`\`bash
-lark-channel-bridge codex-task create "\${bridge_config_args[@]}" --profile "$LARK_CHANNEL_PROFILE" --title "<title>" --cwd "<absolute-path>" --json
+\`\`\`text
+lark-channel-bridge codex-task create <config-option> <profile-option> --title "<title>" --cwd "<absolute-path>" --json
 \`\`\`
 
-Create a worker and immediately give it work:
+Create a worker and materialize its durable thread with the first turn:
 
-\`\`\`bash
-lark-channel-bridge codex-task create "\${bridge_config_args[@]}" --profile "$LARK_CHANNEL_PROFILE" --title "<title>" --cwd "<absolute-path>" --message "<instruction>" --json
+\`\`\`text
+lark-channel-bridge codex-task create <config-option> <profile-option> --title "<title>" --cwd "<absolute-path>" --message "<instruction>" --json
 \`\`\`
 
-Read a worker without resuming it:
+Read a materialized worker without resuming it:
 
-\`\`\`bash
-lark-channel-bridge codex-task read <handle> "\${bridge_config_args[@]}" --profile "$LARK_CHANNEL_PROFILE" --json
+\`\`\`text
+lark-channel-bridge codex-task read <handle> <config-option> <profile-option> --json
 \`\`\`
 
-Send additional work and wait for the turn to finish:
+Send work and wait for the turn to finish. For a pending handle, this command creates the durable thread and starts the first turn in one App Server process:
 
-\`\`\`bash
-lark-channel-bridge codex-task send <handle> "\${bridge_config_args[@]}" --profile "$LARK_CHANNEL_PROFILE" --message "<instruction>" --json
+\`\`\`text
+lark-channel-bridge codex-task send <handle> <config-option> <profile-option> --message "<instruction>" --json
 \`\`\`
 
 After a command finishes, report the handle, title, cwd, model, status, and result. Keep long histories summarized unless the user asks for full detail.

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -216,11 +216,7 @@ export async function tryHandleCommand(ctx: CommandContext): Promise<boolean> {
   const cmd = parts[0] ?? '';
   const args = parts.slice(1).join(' ');
   const h = handlers[cmd];
-  if (!h) {
-    log.info('command', 'unknown', { cmd: cmd.slice(0, 64) });
-    await reply(ctx, '未知命令。使用 `/help` 查看可用命令。');
-    return true;
-  }
+  if (!h) return false;
   if (
     isAdminCommand(cmd) &&
     !canRunAdminCommand(ctx.controls.profileConfig, ctx.controls, ctx.msg.senderId).ok

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -4,7 +4,12 @@ import { homedir } from 'node:os';
 import { dirname, isAbsolute } from 'node:path';
 import type { LarkChannel, NormalizedMessage } from '@larksuite/channel';
 import { claudeCapability, codexCapability } from '../agent/capability';
-import { DEFAULT_MODEL, normalizeModelSelection, supportedModels } from '../agent/models';
+import {
+  DEFAULT_MODEL,
+  normalizeModelSelection,
+  resolveModelArg,
+  supportedModels,
+} from '../agent/models';
 import type { AgentAdapter } from '../agent/types';
 import type { ActiveRuns } from '../bot/active-runs';
 import {
@@ -79,6 +84,7 @@ import { RunRejected } from '../runtime/errors';
 import { validateAppCredentials } from '../utils/feishu-auth';
 import type { WorkspaceStore } from '../workspace/store';
 import { createBoundChat, defaultChatName } from '../bot/group';
+import { buildBridgeThreadName } from '../bot/thread-name';
 import { fetchKnownChats, type KnownChat } from '../bot/lark-info';
 import { hasStructuredLarkCliUserAuth } from '../lark-cli/identity-policy';
 
@@ -166,6 +172,7 @@ const handlers: Record<string, Handler> = {
   '/ws': handleWs,
   '/resume': handleResume,
   '/status': handleStatus,
+  '/model': handleModel,
   '/help': handleHelp,
   '/account': handleAccount,
   '/config': handleConfig,
@@ -209,7 +216,11 @@ export async function tryHandleCommand(ctx: CommandContext): Promise<boolean> {
   const cmd = parts[0] ?? '';
   const args = parts.slice(1).join(' ');
   const h = handlers[cmd];
-  if (!h) return false;
+  if (!h) {
+    log.info('command', 'unknown', { cmd: cmd.slice(0, 64) });
+    await reply(ctx, '未知命令。使用 `/help` 查看可用命令。');
+    return true;
+  }
   if (
     isAdminCommand(cmd) &&
     !canRunAdminCommand(ctx.controls.profileConfig, ctx.controls, ctx.msg.senderId).ok
@@ -803,9 +814,14 @@ async function handleStatus(_args: string, ctx: CommandContext): Promise<void> {
   const sess = ctx.sessions.getRaw(ctx.scope);
   const isCodex = ctx.controls.profileConfig.agentKind === 'codex';
   const catalogEntry =
-    isCodex && ctx.sessionCatalog && ctx.sessionCatalogIdentity
+    ctx.sessionCatalog && ctx.sessionCatalogIdentity
       ? ctx.sessionCatalog.activeFor(ctx.sessionCatalogIdentity)
       : undefined;
+  const requestedModel =
+    resolveModelArg(
+      ctx.controls.profileConfig.agentKind,
+      ctx.controls.profileConfig.preferences.model,
+    ) ?? 'default';
   const card = statusCard({
     profileName: ctx.controls.profile,
     cwd,
@@ -813,6 +829,8 @@ async function handleStatus(_args: string, ctx: CommandContext): Promise<void> {
     emptySessionText: isCodex ? '(未建立)' : undefined,
     sessionStale: !isCodex && Boolean(cwd && sess && sess.cwd !== cwd),
     agentName: ctx.agent.displayName,
+    requestedModel,
+    actualModel: catalogEntry?.model,
     runtimeAccess: runtimeAccessStatus(ctx.controls.profileConfig),
     larkCliStatus: await larkCliStatus(ctx),
     activeRun: Boolean(ctx.activeRuns.get(ctx.scope)),
@@ -824,6 +842,31 @@ async function handleStatus(_args: string, ctx: CommandContext): Promise<void> {
     chatMode: ctx.chatMode,
   });
   await ctx.channel.send(ctx.msg.chatId, { card }, commandReplyOptions(ctx));
+}
+
+async function handleModel(_args: string, ctx: CommandContext): Promise<void> {
+  const requested = resolveModelArg(
+    ctx.controls.profileConfig.agentKind,
+    ctx.controls.profileConfig.preferences.model,
+  );
+  const catalogEntry =
+    ctx.sessionCatalog && ctx.sessionCatalogIdentity
+      ? ctx.sessionCatalog.activeFor(ctx.sessionCatalogIdentity)
+      : undefined;
+  const configured = requested ? `\`${inlineCode(requested)}\`` : '跟随默认（未指定）';
+  const actual = catalogEntry?.model
+    ? `\`${inlineCode(catalogEntry.model)}\``
+    : catalogEntry
+      ? '当前 session 尚无实际模型记录，下一次普通消息后确认'
+      : '尚未建立 session，首次普通消息后确认';
+  await reply(
+    ctx,
+    ['🤖 **当前模型**', `- 配置：${configured}`, `- 最近实际：${actual}`].join('\n'),
+  );
+}
+
+function inlineCode(value: string): string {
+  return value.replace(/`/g, "'");
 }
 
 function formatOwnerState(ctx: CommandContext): string {
@@ -1172,6 +1215,7 @@ async function handleDoctor(args: string, ctx: CommandContext): Promise<void> {
     execution = await ctx.runExecutor.submit({
       scopeId: `${ctx.scope}:doctor`,
       policy,
+      threadName: buildBridgeThreadName('飞书诊断', 'agent echo check'),
       nowait: true,
       stopGraceMs: getAgentStopGraceMs(ctx.controls.cfg),
       observability: {

--- a/src/config/app-paths.ts
+++ b/src/config/app-paths.ts
@@ -14,6 +14,7 @@ export interface AppPaths {
   configFile: string;
   activeProfileFile: string;
   sessionsFile: string;
+  codexTasksFile: string;
   workspacesFile: string;
   secretsFile: string;
   keystoreSaltFile: string;
@@ -57,6 +58,7 @@ export function resolveAppPaths(opts: ResolveAppPathsOptions = {}): AppPaths {
     configFile: join(rootDir, 'config.json'),
     activeProfileFile: join(rootDir, 'active-profile'),
     sessionsFile: join(profileDir, 'sessions.json'),
+    codexTasksFile: join(profileDir, 'codex-tasks.json'),
     workspacesFile: join(profileDir, 'workspaces.json'),
     secretsFile: join(profileDir, 'secrets.enc'),
     keystoreSaltFile: join(profileDir, '.keystore.salt'),

--- a/src/config/profile-schema.ts
+++ b/src/config/profile-schema.ts
@@ -14,6 +14,7 @@ import {
 } from './permissions';
 
 export type AgentKind = 'claude' | 'codex';
+export type CodexTransport = 'exec' | 'app-server';
 export type SandboxMode = CodexSandboxMode;
 export type { AccessMode, PermissionConfig, PermissionSource };
 
@@ -40,6 +41,8 @@ export interface SandboxConfig {
 
 export interface CodexConfig {
   binaryPath: string;
+  /** Codex runtime transport. Omitted profiles retain the legacy `exec` behavior. */
+  transport?: CodexTransport;
   realpath?: string;
   version?: string;
   sha256?: string;
@@ -189,7 +192,7 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
     };
     sandbox?: Partial<SandboxConfig>;
     permissions?: Partial<PermissionConfig>;
-    codex?: CodexConfig & { flags?: unknown };
+    codex?: Omit<CodexConfig, 'transport'> & { transport?: unknown; flags?: unknown };
     attachments?: Partial<AttachmentConfig>;
     comments?: unknown;
     larkCli?: unknown;
@@ -323,9 +326,13 @@ function normalizeWorkspaces(input: {
   return defaultWorkspace ? { default: defaultWorkspace } : {};
 }
 
-function normalizeCodex(input: CodexConfig & { flags?: unknown }): CodexConfig {
+function normalizeCodex(
+  input: Omit<CodexConfig, 'transport'> & { transport?: unknown; flags?: unknown },
+): CodexConfig {
+  const transport = normalizeCodexTransport(input.transport);
   const codex: CodexConfig = {
     binaryPath: input.binaryPath,
+    ...(transport === 'app-server' ? { transport } : {}),
     ...(typeof input.realpath === 'string' ? { realpath: input.realpath } : {}),
     ...(typeof input.version === 'string' ? { version: input.version } : {}),
     ...(typeof input.sha256 === 'string' ? { sha256: input.sha256 } : {}),
@@ -337,6 +344,26 @@ function normalizeCodex(input: CodexConfig & { flags?: unknown }): CodexConfig {
     ignoreRules: input.ignoreRules !== false,
   };
   return codex;
+}
+
+function normalizeCodexTransport(value: unknown): CodexTransport {
+  if (value === undefined || value === 'exec') return 'exec';
+  if (value === 'app-server') return value;
+  throw new Error('codex.transport must be exec or app-server');
+}
+
+export function effectiveCodexTransport(
+  codex: Pick<CodexConfig, 'transport'> | undefined,
+): CodexTransport {
+  return codex?.transport ?? 'exec';
+}
+
+export function codexTransportFromString(
+  value: string | undefined,
+): CodexTransport | undefined {
+  if (value === undefined) return undefined;
+  if (value === 'exec' || value === 'app-server') return value;
+  throw new Error(`unsupported Codex transport: ${value}`);
 }
 
 function normalizeComments(_input: unknown): CommentConfig {

--- a/src/runtime/agent-runtime.ts
+++ b/src/runtime/agent-runtime.ts
@@ -1,4 +1,5 @@
 import { ClaudeAdapter } from '../agent/claude/adapter';
+import { CodexAppServerAdapter } from '../agent/codex/app-server-adapter';
 import { CodexAdapter } from '../agent/codex/adapter';
 import { AgentPreflightError, type AgentAvailability } from '../agent/preflight';
 import type { AgentAdapter } from '../agent/types';
@@ -38,7 +39,7 @@ export function createRuntimeAgent(
     if (!codex?.binaryPath) {
       throw new Error('codex profile requires codex.binaryPath');
     }
-    return new CodexAdapter({
+    const codexOptions = {
       binary: codex.binaryPath,
       profileStateDir: appPaths.profileDir,
       ...(codex.codexHome ? { codexHome: codex.codexHome } : {}),
@@ -47,7 +48,10 @@ export function createRuntimeAgent(
       ignoreRules: codex.ignoreRules !== false,
       sandbox: profileConfig.sandbox.defaultMode,
       larkChannel,
-    });
+    };
+    return codex.transport === 'app-server'
+      ? new CodexAppServerAdapter(codexOptions)
+      : new CodexAdapter(codexOptions);
   }
   return new ClaudeAdapter({ larkChannel });
 }

--- a/src/runtime/profile-runtime.ts
+++ b/src/runtime/profile-runtime.ts
@@ -29,8 +29,11 @@ import {
   writeActiveProfile,
 } from '../config/profile-store';
 import {
+  codexTransportFromString,
   createDefaultProfileConfig,
+  effectiveCodexTransport,
   type AgentKind,
+  type CodexTransport,
   type CreateDefaultProfileConfigInput,
   type ProfileConfig,
   type RootConfig,
@@ -56,6 +59,7 @@ export interface ResolveProfileRuntimeOptions {
   config?: string;
   profile?: string;
   agent?: string;
+  codexTransport?: string;
   workspace?: string;
   appId?: string;
   appSecret?: string;
@@ -102,6 +106,7 @@ export async function resolveProfileRuntime(
     await recoverLegacyLarkCliSourceOverlay(recoveryConfigFile);
   }
   const requestedAgent = agentKindFromString(opts.agent);
+  const requestedCodexTransport = codexTransportFromString(opts.codexTransport);
   const explicitProfile = opts.profile;
   const activeProfile = explicitProfile ?? (await readActiveProfile(rootDir));
   let profile = activeProfile ?? requestedAgent;
@@ -129,6 +134,9 @@ export async function resolveProfileRuntime(
 
   const migrationAgent = resolveBootstrapAgent(requestedAgent, profile);
   const needsMigration = await hasLegacyConfig(configPath);
+  if (needsMigration) {
+    assertCodexTransportAppliesToAgent(migrationAgent ?? 'claude', requestedCodexTransport);
+  }
   await migrateV1ToV2WithActiveBridgeHandling({
     rootDir: appPaths.rootDir,
     profile: appPaths.profile,
@@ -136,7 +144,7 @@ export async function resolveProfileRuntime(
     workspace: opts.workspace,
     ...(migrationAgent ? { agentKind: migrationAgent } : {}),
     ...(needsMigration && migrationAgent === 'codex'
-      ? { codex: await createBootstrapCodexConfig(undefined) }
+      ? { codex: await createBootstrapCodexConfig(undefined, requestedCodexTransport) }
       : {}),
   }, opts.handleActiveBridgeMigrationConflict);
 
@@ -153,6 +161,7 @@ export async function resolveProfileRuntime(
           rootConfig,
           profile,
           requestedAgent,
+          requestedCodexTransport,
           opts,
           appPaths,
           configPath,
@@ -161,6 +170,11 @@ export async function resolveProfileRuntime(
       throw new Error(`profile not found: ${profile}`);
     }
     assertRequestedAgentMatchesExistingProfile(profile, profileConfig, requestedAgent);
+    assertRequestedCodexTransportMatchesExistingProfile(
+      profile,
+      profileConfig,
+      requestedCodexTransport,
+    );
     const runtimeUpgrade = upgradeLegacyRuntimeDefaults(rootConfig, profile);
     if (runtimeUpgrade.changed) {
       rootConfig = runtimeUpgrade.rootConfig;
@@ -188,11 +202,18 @@ export async function resolveProfileRuntime(
   if (isComplete(existing)) {
     assertBootstrapAppMatchesExistingConfig(opts, profile, existing);
     const cfg = await maybeMigratePlaintextSecret(existing, configPath, appPaths);
+    const legacyAgent = requestedAgent ?? 'claude';
+    assertCodexTransportAppliesToAgent(legacyAgent, requestedCodexTransport);
     const profileConfig = createRuntimeProfileConfig({
-      agentKind: requestedAgent ?? 'claude',
+      agentKind: legacyAgent,
       accounts: cfg.accounts,
       preferences: cfg.preferences,
       secrets: cfg.secrets,
+      ...(legacyAgent === 'codex'
+        ? {
+            codex: await createBootstrapCodexConfig(undefined, requestedCodexTransport),
+          }
+        : {}),
     });
     profileConfig.workspaces.default = await resolveConvertedLegacyDefaultWorkspace(opts, appPaths);
     const root = createRootConfig(profile, profileConfig, cfg.secrets);
@@ -205,6 +226,7 @@ export async function resolveProfileRuntime(
     throw new Error('config not initialized');
   }
   const bootstrapAgent = resolveBootstrapAgent(requestedAgent, profile) ?? 'claude';
+  assertCodexTransportAppliesToAgent(bootstrapAgent, requestedCodexTransport);
   const workspace = opts.workspace;
   const fresh = await resolveBootstrapAppConfig(opts);
   const encrypted = await encryptedConfigForProfile(fresh, appPaths);
@@ -213,6 +235,7 @@ export async function resolveProfileRuntime(
     accounts: encrypted.accounts,
     preferences: encrypted.preferences,
     secrets: encrypted.secrets,
+    codexTransport: requestedCodexTransport,
     workspace,
     defaultWorkspace: appPaths.defaultWorkspaceDir,
     profileDir: appPaths.profileDir,
@@ -228,12 +251,22 @@ async function bootstrapProfileIntoExistingRoot(args: {
   rootConfig: RootConfig;
   profile: string;
   requestedAgent: AgentKind | undefined;
+  requestedCodexTransport: CodexTransport | undefined;
   opts: ResolveProfileRuntimeOptions;
   appPaths: AppPaths;
   configPath: string;
 }): Promise<ProfileRuntime> {
-  const { rootConfig, profile, requestedAgent, opts, appPaths, configPath } = args;
+  const {
+    rootConfig,
+    profile,
+    requestedAgent,
+    requestedCodexTransport,
+    opts,
+    appPaths,
+    configPath,
+  } = args;
   const bootstrapAgent = resolveBootstrapAgent(requestedAgent, profile) ?? 'claude';
+  assertCodexTransportAppliesToAgent(bootstrapAgent, requestedCodexTransport);
   const workspace = opts.workspace;
   const fresh = await resolveBootstrapAppConfig(opts);
   const encrypted = await encryptedConfigForProfile(fresh, appPaths);
@@ -242,6 +275,7 @@ async function bootstrapProfileIntoExistingRoot(args: {
     accounts: encrypted.accounts,
     preferences: encrypted.preferences,
     secrets: encrypted.secrets,
+    codexTransport: requestedCodexTransport,
     workspace,
     defaultWorkspace: appPaths.defaultWorkspaceDir,
     profileDir: appPaths.profileDir,
@@ -503,6 +537,30 @@ function assertRequestedAgentMatchesExistingProfile(
       `Profile names are labels; to use the existing ${profileConfig.agentKind} profile, omit --agent. ` +
       `To recreate it as ${requestedAgent}, remove profile ${profile} first.`,
   );
+}
+
+function assertRequestedCodexTransportMatchesExistingProfile(
+  profile: string,
+  profileConfig: ProfileConfig,
+  requestedTransport: CodexTransport | undefined,
+): void {
+  if (!requestedTransport) return;
+  assertCodexTransportAppliesToAgent(profileConfig.agentKind, requestedTransport);
+  const configuredTransport = effectiveCodexTransport(profileConfig.codex);
+  if (configuredTransport === requestedTransport) return;
+  throw new Error(
+    `profile ${profile} already uses Codex transport ${configuredTransport}, ` +
+      `but this command requested --codex-transport ${requestedTransport}. ` +
+      'Update the persisted profile config and restart the profile to change transports.',
+  );
+}
+
+function assertCodexTransportAppliesToAgent(
+  agentKind: AgentKind,
+  requestedTransport: CodexTransport | undefined,
+): void {
+  if (!requestedTransport || agentKind === 'codex') return;
+  throw new Error('--codex-transport can only be used with a Codex profile');
 }
 
 function assertBootstrapAppMatchesExistingConfig(

--- a/src/runtime/run-executor.ts
+++ b/src/runtime/run-executor.ts
@@ -18,6 +18,7 @@ export interface RunExecutorDeps {
 export interface SubmitRunInput {
   scopeId: string;
   policy: RunPolicyAllow;
+  threadName?: string;
   sessionId?: string;
   threadId?: string;
   model?: string;
@@ -96,6 +97,7 @@ export class RunExecutor {
     const runOptions = {
       runId,
       prompt: input.policy.prompt,
+      threadName: input.threadName,
       cwd: input.policy.cwdRealpath,
       sessionId: input.sessionId,
       threadId: input.threadId,
@@ -115,6 +117,7 @@ export class RunExecutor {
       throw new SpawnFailed('agent prepare failed', err, 'agent-prepare-failed');
     }
     if (this.activeRuns.newRunsPaused()) {
+      this.agent.discardPreparedRun?.(runOptions);
       release();
       releaseScope();
       throw new RunRejected(

--- a/src/session/catalog.ts
+++ b/src/session/catalog.ts
@@ -21,6 +21,7 @@ export interface SessionCatalogEntry extends SessionCatalogIdentity {
   updatedAt: number;
   sessionId?: string;
   threadId?: string;
+  model?: string;
   lastSummary?: string;
 }
 
@@ -28,6 +29,7 @@ export interface UpsertSessionCatalogInput extends SessionCatalogIdentity {
   now?: number;
   sessionId?: string;
   threadId?: string;
+  model?: string;
   lastSummary?: string;
 }
 
@@ -102,6 +104,9 @@ export class SessionCatalog {
   upsertActive(input: UpsertSessionCatalogInput): SessionCatalogEntry {
     assertAgentIdentity(input);
     const key = sessionCatalogKey(input);
+    const previous = this.data.get(key);
+    const previousModel = sameConversation(previous, input) ? previous?.model : undefined;
+    const model = input.model ?? previousModel;
     const entry: SessionCatalogEntry = {
       key,
       scopeId: input.scopeId,
@@ -112,6 +117,7 @@ export class SessionCatalog {
       updatedAt: input.now ?? Date.now(),
       ...(input.sessionId ? { sessionId: input.sessionId } : {}),
       ...(input.threadId ? { threadId: input.threadId } : {}),
+      ...(model ? { model } : {}),
       ...(input.lastSummary ? { lastSummary: input.lastSummary } : {}),
     };
     this.data.set(key, entry);
@@ -232,8 +238,18 @@ function normalizeEntry(input: unknown): SessionCatalogEntry | undefined {
     updatedAt: raw.updatedAt,
     ...(typeof raw.sessionId === 'string' ? { sessionId: raw.sessionId } : {}),
     ...(typeof raw.threadId === 'string' ? { threadId: raw.threadId } : {}),
+    ...(typeof raw.model === 'string' ? { model: raw.model } : {}),
     ...(typeof raw.lastSummary === 'string' ? { lastSummary: raw.lastSummary } : {}),
   };
+}
+
+function sameConversation(
+  entry: SessionCatalogEntry | undefined,
+  input: UpsertSessionCatalogInput,
+): boolean {
+  if (!entry) return false;
+  if (input.agentId === 'claude') return entry.sessionId === input.sessionId;
+  return entry.threadId === input.threadId;
 }
 
 function matchesIdentity(entry: SessionCatalogEntry, input: SessionCatalogIdentity): boolean {

--- a/tests/integration/bot/bot-at-bot-context.test.ts
+++ b/tests/integration/bot/bot-at-bot-context.test.ts
@@ -111,6 +111,7 @@ describe('sender identity in bridge_context', () => {
       { openId: 'ou_bot', name: 'Bridge', isBot: true },
       { openId: 'ou_human', name: '张三', isBot: false },
     ]);
+    expect(h.agent.runOptions[0]?.threadName).toBe('飞书 · @Bridge 部署完成，请验证');
   });
 
   it('marks a human sender via raw sender_type', async () => {

--- a/tests/integration/cli/codex-task-init.test.ts
+++ b/tests/integration/cli/codex-task-init.test.ts
@@ -48,12 +48,29 @@ describe('codex-task init command', () => {
       /does not use Codex App Server transport/,
     );
   });
+
+  it('uses an explicit custom Bridge config instead of the default config.json', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'codex-task-init-custom-root-'));
+    const workspace = await mkdtemp(join(tmpdir(), 'codex-task-init-custom-workspace-'));
+    cleanup.push(rootDir, workspace);
+    const customConfig = join(rootDir, 'bridge.custom.json');
+    await writeCodexProfile(rootDir, workspace, 'app-server', customConfig);
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await runCodexTaskInit({ config: customConfig, profile: 'codex', json: true });
+
+    expect(await readFile(join(workspace, 'AGENTS.md'), 'utf8')).toContain('飞书 Codex 主控工作区');
+    await expect(readFile(resolveAppPaths({ rootDir }).configFile, 'utf8')).rejects.toMatchObject({
+      code: 'ENOENT',
+    });
+  });
 });
 
 async function writeCodexProfile(
   rootDir: string,
   workspace: string,
   transport: CodexTransport,
+  configPath = resolveAppPaths({ rootDir }).configFile,
 ): Promise<void> {
   const profile = createDefaultProfileConfig({
     agentKind: 'codex',
@@ -66,5 +83,5 @@ async function writeCodexProfile(
   });
   profile.workspaces.default = workspace;
   const root = createRootConfig('codex', profile);
-  await saveRootConfig(root, resolveAppPaths({ rootDir }).configFile);
+  await saveRootConfig(root, configPath);
 }

--- a/tests/integration/cli/codex-task-init.test.ts
+++ b/tests/integration/cli/codex-task-init.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, readFile, realpath, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { runCodexTaskInit } from '../../../src/cli/commands/codex-task';
+import { resolveAppPaths } from '../../../src/config/app-paths';
+import {
+  createDefaultProfileConfig,
+  type CodexTransport,
+} from '../../../src/config/profile-schema';
+import { createRootConfig, saveRootConfig } from '../../../src/config/profile-store';
+
+describe('codex-task init command', () => {
+  const cleanup: string[] = [];
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+  });
+
+  it('installs controller guidance into the configured profile workspace', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'codex-task-init-root-'));
+    const workspace = await mkdtemp(join(tmpdir(), 'codex-task-init-workspace-'));
+    cleanup.push(rootDir, workspace);
+    await writeCodexProfile(rootDir, workspace, 'app-server');
+    const output = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    await runCodexTaskInit({ rootDir, profile: 'codex', json: true });
+
+    expect(output).toHaveBeenCalledOnce();
+    expect(JSON.parse(String(output.mock.calls[0]?.[0]))).toMatchObject({
+      workspace: await realpath(workspace),
+    });
+    expect(await readFile(join(workspace, 'AGENTS.md'), 'utf8')).toContain('飞书 Codex 主控工作区');
+    expect(await readFile(
+      join(workspace, '.agents', 'skills', 'codex-task-controller', 'SKILL.md'),
+      'utf8',
+    )).toContain('lark-channel-bridge codex-task');
+  });
+
+  it('rejects Codex profiles that do not use app-server transport', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'codex-task-init-root-'));
+    const workspace = await mkdtemp(join(tmpdir(), 'codex-task-init-workspace-'));
+    cleanup.push(rootDir, workspace);
+    await writeCodexProfile(rootDir, workspace, 'exec');
+
+    await expect(runCodexTaskInit({ rootDir, profile: 'codex' })).rejects.toThrow(
+      /does not use Codex App Server transport/,
+    );
+  });
+});
+
+async function writeCodexProfile(
+  rootDir: string,
+  workspace: string,
+  transport: CodexTransport,
+): Promise<void> {
+  const profile = createDefaultProfileConfig({
+    agentKind: 'codex',
+    accounts: { app: { id: 'cli_test', secret: 'test-secret', tenant: 'feishu' } },
+    codex: {
+      binaryPath: 'codex',
+      transport,
+      inheritCodexHome: true,
+    },
+  });
+  profile.workspaces.default = workspace;
+  const root = createRootConfig('codex', profile);
+  await saveRootConfig(root, resolveAppPaths({ rootDir }).configFile);
+}

--- a/tests/integration/cli/first-run-profile.test.ts
+++ b/tests/integration/cli/first-run-profile.test.ts
@@ -31,6 +31,7 @@ describe('first-run profile bootstrap', () => {
       accounts: { app: { id: 'cli_codex', secret: '${APP_SECRET}', tenant: 'feishu' } },
       workspace,
       codexBinaryPath: codex,
+      codexTransport: 'app-server',
       profileDir,
     });
 
@@ -39,6 +40,7 @@ describe('first-run profile bootstrap', () => {
     expect(profile.workspaces).toEqual({ default: workspaceRealpath });
     expect(profile.codex).toMatchObject({
       binaryPath: codex,
+      transport: 'app-server',
       inheritCodexHome: true,
     });
     expect(profile.codex?.realpath).toBeUndefined();
@@ -67,6 +69,17 @@ describe('first-run profile bootstrap', () => {
 
     const defaultWorkspaceRealpath = await realpath(defaultWorkspace);
     expect(profile.workspaces.default).toBe(defaultWorkspaceRealpath);
+    expect(profile.codex).not.toHaveProperty('transport');
+  });
+
+  it('rejects Codex transport configuration for a Claude profile', async () => {
+    await expect(
+      createBootstrapProfileConfig({
+        agentKind: 'claude',
+        accounts: { app: { id: 'cli_claude', secret: '${APP_SECRET}', tenant: 'feishu' } },
+        codexTransport: 'app-server',
+      }),
+    ).rejects.toThrow(/Codex profile/);
   });
 
   it('reports missing Codex bootstrap binaries as agent preflight diagnostics', async () => {

--- a/tests/integration/cli/profile-create.test.ts
+++ b/tests/integration/cli/profile-create.test.ts
@@ -78,6 +78,7 @@ describe('profile create command', () => {
       await runProfileCreate('codex-dev', {
         rootDir: root,
         agent: 'codex',
+        codexTransport: 'app-server',
         workspace,
         appId: 'cli_codex_dev',
         appSecret: 'manual-secret',
@@ -94,6 +95,7 @@ describe('profile create command', () => {
     const configPath = join(root, 'config.json');
     const saved = JSON.parse(await readFile(configPath, 'utf8'));
     expect(saved.profiles['codex-dev']?.agentKind).toBe('codex');
+    expect(saved.profiles['codex-dev']?.codex?.transport).toBe('app-server');
     expect(saved.profiles['codex-dev']).not.toHaveProperty('sandbox');
 
     const loaded = await loadRootConfig(configPath);
@@ -115,6 +117,23 @@ describe('profile create command', () => {
         appSecret: 'manual-secret',
       }),
     ).rejects.toThrow(/profile already exists/);
+  });
+
+  it('rejects --codex-transport when creating a Claude profile', async () => {
+    const root = await makeRoot();
+    await writeProfiles(root, 'codex-dev', ['codex-dev']);
+
+    await expect(
+      runProfileCreate('claude-app-server', {
+        rootDir: root,
+        agent: 'claude',
+        codexTransport: 'app-server',
+        appId: 'cli_claude_app_server',
+        appSecret: 'manual-secret',
+        tenant: 'feishu',
+      }),
+    ).rejects.toThrow(/only be used with a Codex profile/);
+    expect(auth.validateAppCredentials).not.toHaveBeenCalled();
   });
 
   it('explains how to recover when an existing profile has the wrong agent', async () => {

--- a/tests/integration/cli/start-codex-legacy-config.test.ts
+++ b/tests/integration/cli/start-codex-legacy-config.test.ts
@@ -55,9 +55,55 @@ describe('Codex startup compatibility with legacy binary metadata', () => {
       }),
     ).resolves.toBeUndefined();
   });
+
+  it('treats an older Codex profile as exec and rejects an explicit transport mismatch', async () => {
+    const h = await createLegacyCodexConfig({ codexMetadata: {} });
+
+    await expect(
+      resolveProfileRuntime({
+        config: h.configPath,
+        profile: 'codex',
+        codexTransport: 'app-server',
+        allowBootstrap: false,
+      }),
+    ).rejects.toThrow(/already uses Codex transport exec/);
+    await expect(
+      resolveProfileRuntime({
+        config: h.configPath,
+        profile: 'codex',
+        codexTransport: 'exec',
+        allowBootstrap: false,
+      }),
+    ).resolves.toMatchObject({ profile: 'codex' });
+  });
+
+  it('accepts a matching persisted app-server transport and rejects exec', async () => {
+    const h = await createLegacyCodexConfig({
+      codexMetadata: {},
+      transport: 'app-server',
+    });
+
+    await expect(
+      resolveProfileRuntime({
+        config: h.configPath,
+        profile: 'codex',
+        codexTransport: 'app-server',
+        allowBootstrap: false,
+      }),
+    ).resolves.toMatchObject({ profile: 'codex' });
+    await expect(
+      resolveProfileRuntime({
+        config: h.configPath,
+        profile: 'codex',
+        codexTransport: 'exec',
+        allowBootstrap: false,
+      }),
+    ).rejects.toThrow(/already uses Codex transport app-server/);
+  });
 });
 
 async function createLegacyCodexConfig(options: {
+  transport?: 'app-server';
   codexMetadata: {
     realpath?: string;
     version?: string;
@@ -110,6 +156,7 @@ async function createLegacyCodexConfig(options: {
     secrets,
     codex: {
       binaryPath: codex,
+      ...(options.transport ? { transport: options.transport } : {}),
       ...options.codexMetadata,
     },
   });

--- a/tests/integration/commands/claude-commands.test.ts
+++ b/tests/integration/commands/claude-commands.test.ts
@@ -32,12 +32,16 @@ describe('Claude slash command visible behavior', () => {
     await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
   });
 
-  it('consumes unknown slash commands without invoking the agent', async () => {
+  it.each([
+    '/xxx keep this as a prompt',
+    '/review inspect the current changes',
+    '/Volumes/External/project review recent changes',
+    '/Users/example/project review recent changes',
+  ])('lets non-Bridge slash-prefixed input fall through to the agent: %s', async (content) => {
     const h = await createHarness();
 
-    await expect(h.run('/xxx keep this as a prompt')).resolves.toBe(true);
-    expect(lastMarkdown(h.channel)).toContain('未知命令');
-    expect(lastMarkdown(h.channel)).toContain('/help');
+    await expect(h.run(content)).resolves.toBe(false);
+    expect(h.channel.sent).toHaveLength(0);
     expect(h.agent.runOptions).toHaveLength(0);
   });
 

--- a/tests/integration/commands/claude-commands.test.ts
+++ b/tests/integration/commands/claude-commands.test.ts
@@ -32,11 +32,13 @@ describe('Claude slash command visible behavior', () => {
     await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
   });
 
-  it('lets unknown slash commands fall through as ordinary agent messages', async () => {
+  it('consumes unknown slash commands without invoking the agent', async () => {
     const h = await createHarness();
 
-    await expect(h.run('/xxx keep this as a prompt')).resolves.toBe(false);
-    expect(h.channel.sent).toEqual([]);
+    await expect(h.run('/xxx keep this as a prompt')).resolves.toBe(true);
+    expect(lastMarkdown(h.channel)).toContain('未知命令');
+    expect(lastMarkdown(h.channel)).toContain('/help');
+    expect(h.agent.runOptions).toHaveLength(0);
   });
 
   it('handles /new and /reset by clearing session state', async () => {
@@ -148,9 +150,21 @@ describe('Claude slash command visible behavior', () => {
     expect(lastContent(h.channel)).toHaveProperty('card');
     const help = JSON.stringify(lastContent(h.channel));
     expect(help).toContain('Fake Agent');
+    expect(help).toContain('/model');
     expect(help).toContain('lark-cli 身份策略');
     expect(help).not.toContain('/lark');
     expect(help).not.toContain('交给 Claude');
+  });
+
+  it('handles /model passively without starting an agent turn', async () => {
+    const h = await createHarness();
+
+    await expect(h.run('/model')).resolves.toBe(true);
+
+    expect(lastMarkdown(h.channel)).toContain('当前模型');
+    expect(lastMarkdown(h.channel)).toContain('跟随默认');
+    expect(lastMarkdown(h.channel)).toContain('尚未建立 session');
+    expect(h.agent.runOptions).toHaveLength(0);
   });
 
   it('reports lark-cli user-ready for structured user records', async () => {

--- a/tests/integration/commands/resume-command.test.ts
+++ b/tests/integration/commands/resume-command.test.ts
@@ -245,16 +245,40 @@ describe('agent-aware resume commands', () => {
     let status = JSON.stringify(lastContent(h.channel));
     expect(status).toContain('**session**');
     expect(status).toContain('未建立');
+    expect(status).toContain('requested=default');
+    expect(status).toContain('actual=unconfirmed');
     expect(status).not.toContain('**thread**');
     expect(status).not.toContain('**conversation**');
 
-    h.catalog.upsertActive({ ...h.identity, threadId: 'thread-current', now: 1000 });
+    h.catalog.upsertActive({
+      ...h.identity,
+      threadId: 'thread-current',
+      model: 'gpt-5.6-luna',
+      now: 1000,
+    });
     await expect(h.run('/status')).resolves.toBe(true);
 
     status = JSON.stringify(lastContent(h.channel));
     expect(status).toContain('**session**');
     expect(status).toContain('thread-c');
+    expect(status).toContain('gpt-5.6-luna');
     expect(status).not.toContain('未建立');
+  });
+
+  it('reports the recorded Codex model without starting an agent prompt', async () => {
+    const h = await createHarness('codex');
+    h.catalog.upsertActive({
+      ...h.identity,
+      threadId: 'thread-current',
+      model: 'gpt-5.6-luna',
+      now: 1000,
+    });
+
+    await expect(h.run('/model')).resolves.toBe(true);
+
+    const output = lastMarkdown(h.channel);
+    expect(output).toContain('配置：跟随默认');
+    expect(output).toContain('最近实际：`gpt-5.6-luna`');
   });
 
   it('does not list local history from home when no workspace is bound', async () => {

--- a/tests/integration/comments/comment-run-flow.test.ts
+++ b/tests/integration/comments/comment-run-flow.test.ts
@@ -57,6 +57,7 @@ describe('comment run flow', () => {
     expect(h.agent.runOptions).toHaveLength(1);
     const opts = h.agent.runOptions[0]!;
     await expect(realpath(h.tmp.workspace)).resolves.toBe(opts.cwd);
+    expect(opts.threadName).toBe('飞书评论 · @bot question');
     expect(opts.prompt).toContain('file_token：doc-token');
     expect(opts.prompt).toContain(
       'lark-cli docs +fetch --api-version v2 --doc doc-token --doc-format markdown',

--- a/tests/integration/config/profile-migration.test.ts
+++ b/tests/integration/config/profile-migration.test.ts
@@ -393,6 +393,7 @@ describe('profile v2 migration', () => {
         config: join(root, 'config.json'),
         profile: 'codex',
         agent: 'codex',
+        codexTransport: 'app-server',
       });
     } finally {
       if (oldCodexBin === undefined) {
@@ -407,6 +408,7 @@ describe('profile v2 migration', () => {
     expect(next.profiles.codex?.agentKind).toBe('codex');
     expect(next.profiles.codex?.codex).toMatchObject({
       binaryPath: codex,
+      transport: 'app-server',
     });
     expect(next.profiles.codex?.codex?.realpath).toBeUndefined();
     expect(next.profiles.codex?.codex?.version).toBeUndefined();
@@ -416,6 +418,14 @@ describe('profile v2 migration', () => {
       maxAccess: 'full',
     });
     expect(next.profiles.codex).not.toHaveProperty('sandbox');
+
+    await expect(
+      runMigrate({
+        config: join(root, 'config.json'),
+        profile: 'codex',
+        codexTransport: 'exec',
+      }),
+    ).rejects.toThrow(/already uses Codex transport app-server/);
   });
 });
 

--- a/tests/integration/session/resume.test.ts
+++ b/tests/integration/session/resume.test.ts
@@ -134,7 +134,12 @@ describe('agent-aware run-flow resume', () => {
       sessionCatalog: claude.catalog,
       capability: claudeCapability(claude.profileConfig),
       policy: claudeRun.policy,
-      event: { type: 'system', sessionId: 'sess-recorded', cwd: claudeRun.cwdRealpath },
+      event: {
+        type: 'system',
+        sessionId: 'sess-recorded',
+        cwd: claudeRun.cwdRealpath,
+        model: 'claude-test',
+      },
     });
 
     expect(
@@ -144,7 +149,7 @@ describe('agent-aware run-flow resume', () => {
         cwdRealpath: claudeRun.cwdRealpath,
         policyFingerprint: claudeRun.policy.policyFingerprint,
       }),
-    ).toMatchObject({ sessionId: 'sess-recorded' });
+    ).toMatchObject({ sessionId: 'sess-recorded', model: 'claude-test' });
     expect(claude.sessions.resumeFor('chat-1', claudeRun.cwdRealpath)).toBe('sess-recorded');
 
     const codex = await createHarness('codex');
@@ -159,7 +164,7 @@ describe('agent-aware run-flow resume', () => {
       sessionCatalog: codex.catalog,
       capability: codexCapability(codex.profileConfig),
       policy: codexRun.policy,
-      event: { type: 'system', threadId: 'thread-recorded' },
+      event: { type: 'system', threadId: 'thread-recorded', model: 'gpt-test' },
     });
 
     expect(
@@ -169,7 +174,7 @@ describe('agent-aware run-flow resume', () => {
         cwdRealpath: codexRun.cwdRealpath,
         policyFingerprint: codexRun.policy.policyFingerprint,
       }),
-    ).toMatchObject({ threadId: 'thread-recorded' });
+    ).toMatchObject({ threadId: 'thread-recorded', model: 'gpt-test' });
     expect(codex.sessions.getRaw('chat-1')).toBeUndefined();
   });
 });

--- a/tests/process/codex-app-server-adapter.test.ts
+++ b/tests/process/codex-app-server-adapter.test.ts
@@ -101,6 +101,7 @@ describe('CodexAppServerAdapter process contract', () => {
       LARK_CHANNEL_PROFILE: 'codex-app-server',
       LARK_CHANNEL_HOME: join(fake.dir, 'channel-home'),
       LARK_CHANNEL_CONFIG: join(fake.dir, 'config.json'),
+      LARK_CHANNEL_BRIDGE_CONFIG: join(fake.dir, 'config.json'),
       LARKSUITE_CLI_CONFIG_DIR: join(fake.dir, 'lark-cli'),
       CODEX_HOME: '/outer/codex-home',
       APP_SECRET: 'inherited-secret',
@@ -108,6 +109,7 @@ describe('CodexAppServerAdapter process contract', () => {
     expect(record.messages.map((message) => message.method).filter(Boolean)).toEqual([
       'initialize',
       'initialized',
+      'config/read',
       'thread/start',
       'thread/name/set',
       'turn/start',
@@ -215,6 +217,118 @@ describe('CodexAppServerAdapter process contract', () => {
       id: 'approval-1',
       result: { decision: 'decline' },
     });
+  });
+
+  it('answers currentTime/read with whole Unix seconds', async () => {
+    const fake = await createFakeAppServer({ currentTimeRequest: true });
+    cleanup.push(fake.dir);
+    const before = Math.floor(Date.now() / 1000);
+    const run = await prepareAndRun(new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+    }), {
+      runId: 'run-current-time',
+      prompt: 'time',
+      cwd: await realpath(fake.dir),
+    });
+
+    expect((await collect(run.events)).at(-1)).toMatchObject({ type: 'done' });
+    expect(await run.waitForExit(1000)).toBe(true);
+    const after = Math.floor(Date.now() / 1000);
+    const response = (await readRecord(fake.recordPath)).messages.find(
+      (message) => message.id === 'current-time-1' && message.result,
+    );
+    const currentTimeAt = (response?.result as { currentTimeAt?: unknown } | undefined)?.currentTimeAt;
+    expect(typeof currentTimeAt).toBe('number');
+    if (typeof currentTimeAt !== 'number') throw new Error('missing numeric currentTimeAt');
+    expect(Number.isInteger(currentTimeAt)).toBe(true);
+    expect(currentTimeAt).toBeGreaterThanOrEqual(before);
+    expect(currentTimeAt).toBeLessThanOrEqual(after);
+  });
+
+  it.each(['applyPatchApproval', 'execCommandApproval'] as const)(
+    'uses the official ReviewDecision wire schema for %s',
+    async (legacyApprovalMethod) => {
+      const fake = await createFakeAppServer({ legacyApprovalMethod });
+      cleanup.push(fake.dir);
+      const run = await prepareAndRun(new CodexAppServerAdapter({
+        binary: fake.path,
+        profileStateDir: fake.dir,
+      }), {
+        runId: `run-${legacyApprovalMethod}`,
+        prompt: 'legacy approval',
+        cwd: await realpath(fake.dir),
+      });
+
+      await collect(run.events);
+      expect(await run.waitForExit(1000)).toBe(true);
+      expect((await readRecord(fake.recordPath)).messages).toContainEqual({
+        id: 'legacy-approval-1',
+        result: { decision: 'denied' },
+      });
+    },
+  );
+
+  it('filters lean feature flags using the binary feature inventory', async () => {
+    const fake = await createFakeAppServer({ supportedFeatures: ['apps', 'hooks'] });
+    cleanup.push(fake.dir);
+    const adapter = new CodexAppServerAdapter({ binary: fake.path, profileStateDir: fake.dir });
+    expect((await adapter.checkAvailability()).ok).toBe(true);
+    const run = await prepareAndRun(adapter, {
+      runId: 'run-old-feature-set',
+      prompt: 'compatible',
+      cwd: await realpath(fake.dir),
+    });
+
+    await collect(run.events);
+    expect(await run.waitForExit(1000)).toBe(true);
+    expect(disabledFeatures((await readRecord(fake.recordPath)).argv)).toEqual(['apps', 'hooks']);
+  });
+
+  it('rejects an unparseable feature inventory during availability checks', async () => {
+    const fake = await createFakeAppServer({ featureListOutput: 'not a feature inventory\n' });
+    cleanup.push(fake.dir);
+    const adapter = new CodexAppServerAdapter({ binary: fake.path, profileStateDir: fake.dir });
+
+    await expect(adapter.checkAvailability()).resolves.toMatchObject({
+      ok: false,
+      diagnostic: { args: ['features', 'list'] },
+    });
+  });
+
+  it('checks feature availability with the same profile-local Codex home used by runs', async () => {
+    const fake = await createFakeAppServer({ requireProfileCodexHome: true });
+    cleanup.push(fake.dir);
+    const adapter = new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+      inheritCodexHome: false,
+    });
+
+    await expect(adapter.checkAvailability()).resolves.toMatchObject({ ok: true });
+  });
+
+  it('rejects an MCP server added between the probe and the actual app-server', async () => {
+    const fake = await createFakeAppServer({ addMcpAfterProbe: true });
+    cleanup.push(fake.dir);
+    const run = await prepareAndRun(new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+    }), {
+      runId: 'run-mcp-race',
+      prompt: 'must stay lean',
+      cwd: await realpath(fake.dir),
+    });
+
+    expect(await collect(run.events)).toEqual([
+      expect.objectContaining({ type: 'error', message: expect.stringContaining('late-mcp') }),
+    ]);
+    expect(await run.waitForExit(1000)).toBe(true);
+    const record = await readRecord(fake.recordPath);
+    expect(record.messages.some(
+      (message) => message.method === 'thread/start',
+    )).toBe(false);
+    expect(record.mcpStarts).toEqual([]);
   });
 
   it('buffers turn notifications that arrive before the turn/start response', async () => {
@@ -380,10 +494,16 @@ async function prepareAndRun(
 
 async function createFakeAppServer(options: {
   approvalRequest?: boolean;
+  addMcpAfterProbe?: boolean;
+  currentTimeRequest?: boolean;
+  featureListOutput?: string;
   holdTurn?: boolean;
+  legacyApprovalMethod?: 'applyPatchApproval' | 'execCommandApproval';
   failMethod?: string;
   malformedAfterInitialize?: boolean;
   notificationsBeforeTurnResponse?: boolean;
+  requireProfileCodexHome?: boolean;
+  supportedFeatures?: string[];
 } = {}): Promise<FakeAppServer> {
   const dir = await mkdtemp(join(tmpdir(), 'codex-app-server-adapter-test-'));
   const path = join(dir, 'fake-codex.mjs');
@@ -394,7 +514,37 @@ import { writeFileSync } from 'node:fs';
 
 const options = ${JSON.stringify(options)};
 const recordPath = ${JSON.stringify(recordPath)};
+const supportedFeatures = options.supportedFeatures ?? [
+  'apps', 'enable_mcp_apps', 'plugins', 'remote_plugin', 'plugin_sharing',
+  'skill_mcp_dependency_install', 'tool_call_mcp_elicitation', 'tool_suggest',
+  'browser_use', 'browser_use_external', 'browser_use_full_cdp_access',
+  'in_app_browser', 'computer_use', 'request_permissions_tool', 'hooks'
+];
+if (process.argv[2] === 'features' && process.argv[3] === 'list') {
+  if (options.requireProfileCodexHome && process.env.CODEX_HOME !== ${JSON.stringify(join(dir, 'codex-home'))}) {
+    process.stderr.write('feature inventory used the wrong CODEX_HOME\\n');
+    process.exit(3);
+  }
+  process.stdout.write(
+    options.featureListOutput
+      ?? supportedFeatures.map((name) => name + ' stable true').join('\\n') + '\\n'
+  );
+  process.exit(0);
+}
+if (process.argv.includes('--help')) {
+  process.stdout.write('fake codex app-server help\\n');
+  process.exit(0);
+}
+const requestedDisabledFeatures = process.argv.slice(2).flatMap(
+  (arg, index, argv) => arg === '--disable' ? [argv[index + 1]] : []
+);
+const unknownFeature = requestedDisabledFeatures.find((name) => !supportedFeatures.includes(name));
+if (unknownFeature) {
+  process.stderr.write('Unknown feature flag: ' + unknownFeature + '\\n');
+  process.exit(1);
+}
 const messages = [];
+const mcpStarts = [];
 let threadId = 'thread-fresh';
 let turnId = 'turn-1';
 let completed = false;
@@ -411,11 +561,13 @@ function persist() {
         LARK_CHANNEL_PROFILE: process.env.LARK_CHANNEL_PROFILE,
         LARK_CHANNEL_HOME: process.env.LARK_CHANNEL_HOME,
         LARK_CHANNEL_CONFIG: process.env.LARK_CHANNEL_CONFIG,
+        LARK_CHANNEL_BRIDGE_CONFIG: process.env.LARK_CHANNEL_BRIDGE_CONFIG,
         LARKSUITE_CLI_CONFIG_DIR: process.env.LARKSUITE_CLI_CONFIG_DIR,
         CODEX_HOME: process.env.CODEX_HOME,
         APP_SECRET: process.env.APP_SECRET,
       },
       messages,
+      mcpStarts,
     }, null, 2));
   } catch {
     // The test may already have removed its temp directory after collecting
@@ -493,20 +645,25 @@ rl.on('line', (line) => {
     process.stderr.write('initialized arrived before initialize response\\n');
     process.exit(2);
   } else if (message.method === 'config/read') {
+    const disabled = !configProbe && process.argv.some((arg) => arg.startsWith('mcp_servers={'));
     send({ id: message.id, result: { config: { mcp_servers: {
       'fake-stdio': {
-        enabled: true,
+        enabled: !disabled,
         command: 'unsafe-mcp-command',
         args: ['--token', 'fake-secret-value'],
         env: { SECRET: 'fake-secret-value' }
       },
       'fake-http': {
-        enabled: true,
+        enabled: !disabled,
         url: 'https://mcp.example.invalid',
         bearer_token_env_var: 'FAKE_MCP_TOKEN'
-      }
+      },
+      ...(options.addMcpAfterProbe && !configProbe ? {
+        'late-mcp': { enabled: true, command: 'late-unsafe-command' }
+      } : {})
     } } } });
   } else if (message.method === 'thread/start' || message.method === 'thread/resume') {
+    if (options.addMcpAfterProbe) mcpStarts.push('late-mcp');
     threadId = message.params.threadId ?? 'thread-fresh';
     send({ id: message.id, result: {
       thread: { id: threadId }, cwd: message.params.cwd,
@@ -524,6 +681,12 @@ rl.on('line', (line) => {
       send({ id: 'approval-1', method: 'item/commandExecution/requestApproval', params: {
         threadId, turnId, itemId: 'cmd-approval'
       }});
+    } else if (options.currentTimeRequest) {
+      send({ id: 'current-time-1', method: 'currentTime/read', params: { threadId } });
+    } else if (options.legacyApprovalMethod) {
+      send({ id: 'legacy-approval-1', method: options.legacyApprovalMethod, params: {
+        conversationId: threadId, callId: 'legacy-call-1'
+      }});
     } else if (!options.holdTurn) {
       finish('completed');
     }
@@ -531,6 +694,11 @@ rl.on('line', (line) => {
     send({ id: message.id, result: {} });
     finish('interrupted');
   } else if (message.id === 'approval-1' && message.result) {
+    finish('completed');
+  } else if (
+    (message.id === 'current-time-1' || message.id === 'legacy-approval-1')
+    && (message.result || message.error)
+  ) {
     finish('completed');
   }
 });
@@ -554,6 +722,7 @@ interface FakeRecord {
   argv: string[];
   cwd: string;
   env: Record<string, string | undefined>;
+  mcpStarts: string[];
   messages: Array<{
     id?: number | string;
     method?: string;
@@ -570,6 +739,10 @@ function messageByMethod(record: FakeRecord, method: string) {
   const message = record.messages.find((candidate) => candidate.method === method);
   if (!message?.params) throw new Error(`missing recorded method: ${method}`);
   return { ...message, params: message.params };
+}
+
+function disabledFeatures(args: string[]): string[] {
+  return args.flatMap((arg, index) => arg === '--disable' ? [args[index + 1] ?? ''] : []);
 }
 
 async function waitForRecordedMethod(path: string, method: string): Promise<void> {

--- a/tests/process/codex-app-server-adapter.test.ts
+++ b/tests/process/codex-app-server-adapter.test.ts
@@ -1,0 +1,586 @@
+import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CodexAppServerAdapter } from '../../src/agent/codex/app-server-adapter.js';
+import type { AgentEvent, AgentRun, AgentRunOptions } from '../../src/agent/types.js';
+
+interface FakeAppServer {
+  path: string;
+  dir: string;
+  recordPath: string;
+}
+
+describe('CodexAppServerAdapter process contract', () => {
+  const cleanup: string[] = [];
+  const oldCodexHome = process.env.CODEX_HOME;
+  const oldAppSecret = process.env.APP_SECRET;
+
+  afterEach(async () => {
+    if (oldCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = oldCodexHome;
+    if (oldAppSecret === undefined) delete process.env.APP_SECRET;
+    else process.env.APP_SECRET = oldAppSecret;
+    await Promise.all(
+      cleanup.splice(0).map((dir) =>
+        rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 25 }),
+      ),
+    );
+  });
+
+  it('runs the initialize -> thread/start -> turn/start handshake and translates events', async () => {
+    process.env.CODEX_HOME = '/outer/codex-home';
+    process.env.APP_SECRET = 'inherited-secret';
+    const fake = await createFakeAppServer();
+    cleanup.push(fake.dir);
+    const cwd = await realpath(fake.dir);
+    const adapter = new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+      sandbox: 'read-only',
+      larkChannel: {
+        profile: 'codex-app-server',
+        rootDir: join(fake.dir, 'channel-home'),
+        configPath: join(fake.dir, 'config.json'),
+        larkCliConfigDir: join(fake.dir, 'lark-cli'),
+      },
+    });
+    adapter.setBotIdentity({ openId: 'ou_bot', name: 'Bridge Bot' });
+
+    const run = await prepareAndRun(adapter, {
+      runId: 'run-fresh',
+      prompt: 'hello from lark',
+      threadName: '飞书 · hello from lark',
+      cwd,
+    });
+
+    expect(run.runId).toBe('run-fresh');
+    expect(await collect(run.events)).toEqual([
+      { type: 'system', threadId: 'thread-fresh', cwd, model: 'fake-model' },
+      { type: 'thinking', delta: 'checking' },
+      {
+        type: 'tool_use',
+        id: 'cmd-1',
+        name: 'Bash',
+        input: { command: 'pwd', cwd, commandActions: [] },
+      },
+      { type: 'tool_result', id: 'cmd-1', output: `${cwd}\n`, isError: false },
+      { type: 'final_text', content: 'hello user' },
+      {
+        type: 'usage',
+        inputTokens: 12,
+        outputTokens: 3,
+        cachedInputTokens: 4,
+        reasoningOutputTokens: 1,
+      },
+      { type: 'done', threadId: 'thread-fresh', terminationReason: 'normal' },
+    ]);
+    expect(await run.waitForExit(1000)).toBe(true);
+
+    const record = await readRecord(fake.recordPath);
+    expect(record.argv.slice(0, 3)).toEqual(['app-server', '--listen', 'stdio://']);
+    expect(record.argv).toContain('notify=[]');
+    expect(record.argv).toContain('include_apps_instructions=false');
+    expect(record.argv).toContain('apps');
+    expect(record.argv).toContain('plugins');
+    expect(record.argv).toContain('browser_use');
+    expect(record.argv).toContain('computer_use');
+    const mcpOverride = record.argv.find((arg) => arg.startsWith('mcp_servers={'));
+    expect(mcpOverride).toContain(
+      '"fake-http"={enabled=false,url="http://127.0.0.1"}',
+    );
+    expect(mcpOverride).toContain(
+      '"fake-stdio"={enabled=false,command="disabled-by-lark-channel-bridge"}',
+    );
+    expect(record.argv.join('\n')).not.toContain('unsafe-mcp-command');
+    expect(record.argv.join('\n')).not.toContain('https://mcp.example.invalid');
+    expect(record.argv.join('\n')).not.toContain('fake-secret-value');
+    expect(await realpath(record.cwd)).toBe(cwd);
+    expect(record.env).toMatchObject({
+      LARK_CHANNEL: '1',
+      LARK_CHANNEL_PROFILE: 'codex-app-server',
+      LARK_CHANNEL_HOME: join(fake.dir, 'channel-home'),
+      LARK_CHANNEL_CONFIG: join(fake.dir, 'config.json'),
+      LARKSUITE_CLI_CONFIG_DIR: join(fake.dir, 'lark-cli'),
+      CODEX_HOME: '/outer/codex-home',
+      APP_SECRET: 'inherited-secret',
+    });
+    expect(record.messages.map((message) => message.method).filter(Boolean)).toEqual([
+      'initialize',
+      'initialized',
+      'thread/start',
+      'thread/name/set',
+      'turn/start',
+    ]);
+
+    const threadStart = messageByMethod(record, 'thread/start');
+    expect(threadStart.params).toMatchObject({
+      cwd,
+      approvalPolicy: 'never',
+      sandbox: 'read-only',
+      serviceName: 'lark-channel-bridge',
+      threadSource: 'user',
+      ephemeral: false,
+    });
+    expect(threadStart.params.developerInstructions).toContain('lark-channel-bridge 运行约定');
+    expect(threadStart.params.developerInstructions).toContain('ou_bot');
+    expect(JSON.stringify(threadStart)).not.toContain('hello from lark');
+    expect(messageByMethod(record, 'thread/name/set').params).toEqual({
+      threadId: 'thread-fresh',
+      name: '飞书 · hello from lark',
+    });
+
+    const turnStart = messageByMethod(record, 'turn/start');
+    expect(turnStart.params).toMatchObject({
+      threadId: 'thread-fresh',
+      cwd,
+      approvalPolicy: 'never',
+      input: [{ type: 'text', text: 'hello from lark' }],
+    });
+  });
+
+  it('resumes a thread and passes model, sandbox, and local images in protocol params', async () => {
+    const fake = await createFakeAppServer();
+    cleanup.push(fake.dir);
+    const cwd = await realpath(fake.dir);
+    const image = join(cwd, 'image.png');
+
+    const adapter = new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+      sandbox: 'danger-full-access',
+    });
+    const run = await prepareAndRun(adapter, {
+      runId: 'run-resume',
+      prompt: 'continue',
+      cwd,
+      threadId: 'thread-old',
+      model: 'gpt-test',
+      images: [image],
+      sandbox: 'workspace-write',
+    });
+
+    const events = await collect(run.events);
+    expect(await run.waitForExit(1000)).toBe(true);
+    expect(events.at(0)).toEqual({
+      type: 'system',
+      threadId: 'thread-old',
+      cwd,
+      model: 'gpt-test',
+    });
+    const record = await readRecord(fake.recordPath);
+    expect(record.messages.some((message) => message.method === 'thread/start')).toBe(false);
+    expect(record.messages.some((message) => message.method === 'thread/name/set')).toBe(false);
+    expect(messageByMethod(record, 'thread/resume').params).toMatchObject({
+      threadId: 'thread-old',
+      cwd,
+      model: 'gpt-test',
+      sandbox: 'workspace-write',
+      approvalPolicy: 'never',
+    });
+    expect(messageByMethod(record, 'turn/start').params).toMatchObject({
+      threadId: 'thread-old',
+      model: 'gpt-test',
+      input: [
+        { type: 'text', text: 'continue' },
+        { type: 'localImage', path: image },
+      ],
+    });
+    expect(record.argv).not.toContain('continue');
+    expect(record.argv).not.toContain(image);
+  });
+
+  it('declines unexpected approval requests under approvalPolicy never', async () => {
+    const fake = await createFakeAppServer({ approvalRequest: true });
+    cleanup.push(fake.dir);
+
+    const adapter = new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+    });
+    const run = await prepareAndRun(adapter, {
+      runId: 'run-approval',
+      prompt: 'approval',
+      cwd: await realpath(fake.dir),
+    });
+
+    expect((await collect(run.events)).at(-1)).toEqual({
+      type: 'done',
+      threadId: 'thread-fresh',
+      terminationReason: 'normal',
+    });
+    expect(await run.waitForExit(1000)).toBe(true);
+    const record = await readRecord(fake.recordPath);
+    expect(record.messages).toContainEqual({
+      id: 'approval-1',
+      result: { decision: 'decline' },
+    });
+  });
+
+  it('buffers turn notifications that arrive before the turn/start response', async () => {
+    const fake = await createFakeAppServer({ notificationsBeforeTurnResponse: true });
+    cleanup.push(fake.dir);
+    const cwd = await realpath(fake.dir);
+    const adapter = new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+    });
+    const run = await prepareAndRun(adapter, {
+      runId: 'run-race',
+      prompt: 'race',
+      cwd,
+    });
+
+    const events = await collect(run.events);
+    expect(await run.waitForExit(1000)).toBe(true);
+    expect(events.at(0)).toMatchObject({ type: 'system', threadId: 'thread-fresh' });
+    expect(events.filter((event) => event.type === 'done')).toEqual([
+      { type: 'done', threadId: 'thread-fresh', terminationReason: 'normal' },
+    ]);
+    expect(events.filter((event) => event.type === 'final_text')).toEqual([
+      { type: 'final_text', content: 'hello user' },
+    ]);
+    expect(events.filter((event) => event.type === 'usage')).toHaveLength(1);
+  });
+
+  it('interrupts an active turn before terminating its temporary app-server', async () => {
+    const fake = await createFakeAppServer({ holdTurn: true });
+    cleanup.push(fake.dir);
+    const adapter = new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+      stopGraceMs: 100,
+    });
+    const run = await prepareAndRun(adapter, {
+      runId: 'run-stop',
+      prompt: 'stop',
+      cwd: await realpath(fake.dir),
+    });
+    const iterator = run.events[Symbol.asyncIterator]();
+
+    expect(await iterator.next()).toMatchObject({
+      done: false,
+      value: { type: 'system', threadId: 'thread-fresh' },
+    });
+    await waitForRecordedMethod(fake.recordPath, 'turn/start');
+    expect(await run.waitForExit(10)).toBe(false);
+    await run.stop();
+    expect(await iterator.next()).toEqual({
+      done: false,
+      value: { type: 'done', threadId: 'thread-fresh', terminationReason: 'interrupted' },
+    });
+    expect(await run.waitForExit(1000)).toBe(true);
+    const record = await readRecord(fake.recordPath);
+    expect(messageByMethod(record, 'turn/interrupt').params).toEqual({
+      threadId: 'thread-fresh',
+      turnId: 'turn-1',
+    });
+    await iterator.return?.();
+  });
+
+  it('surfaces RPC rejection as a terminal error', async () => {
+    const rejected = await createFakeAppServer({ failMethod: 'thread/start' });
+    cleanup.push(rejected.dir);
+    const rejectedAdapter = new CodexAppServerAdapter({
+      binary: rejected.path,
+      profileStateDir: rejected.dir,
+    });
+    const rejectedRun = await prepareAndRun(rejectedAdapter, {
+      runId: 'run-rejected',
+      prompt: 'fail',
+      cwd: await realpath(rejected.dir),
+    });
+    expect(await collect(rejectedRun.events)).toEqual([
+      {
+        type: 'error',
+        message: 'codex app-server protocol error: fake rejected thread/start',
+        terminationReason: 'failed',
+      },
+    ]);
+    expect(await rejectedRun.waitForExit(1000)).toBe(true);
+  });
+
+  it('surfaces malformed protocol as a terminal error', async () => {
+    const malformed = await createFakeAppServer({ malformedAfterInitialize: true });
+    cleanup.push(malformed.dir);
+    const malformedAdapter = new CodexAppServerAdapter({
+      binary: malformed.path,
+      profileStateDir: malformed.dir,
+    });
+    const malformedRun = await prepareAndRun(malformedAdapter, {
+      runId: 'run-malformed',
+      prompt: 'fail',
+      cwd: await realpath(malformed.dir),
+    });
+    expect(await collect(malformedRun.events)).toEqual([
+      {
+        type: 'error',
+        message: 'codex app-server protocol error: codex app-server emitted malformed JSON',
+        terminationReason: 'failed',
+      },
+    ]);
+    expect(await malformedRun.waitForExit(1000)).toBe(true);
+  });
+
+  it('surfaces a missing app-server binary during preparation', async () => {
+    const missing = join(tmpdir(), `missing-codex-app-server-${Date.now()}`);
+    const adapter = new CodexAppServerAdapter({
+      binary: missing,
+      profileStateDir: tmpdir(),
+    });
+    await expect(
+      adapter.prepareRun({ runId: 'run-missing', prompt: 'hi', cwd: tmpdir() }),
+    ).rejects.toMatchObject({ code: 'agent-prepare-failed' });
+  });
+
+  it('uses a profile-local Codex home only when inheritance is disabled', async () => {
+    process.env.CODEX_HOME = '/outer/codex-home';
+    const fake = await createFakeAppServer();
+    cleanup.push(fake.dir);
+
+    const adapter = new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+      inheritCodexHome: false,
+    });
+    const run = await prepareAndRun(adapter, {
+      runId: 'run-home',
+      prompt: 'home',
+      cwd: await realpath(fake.dir),
+    });
+
+    await collect(run.events);
+    expect(await run.waitForExit(1000)).toBe(true);
+    expect((await readRecord(fake.recordPath)).env.CODEX_HOME).toBe(join(fake.dir, 'codex-home'));
+  });
+
+  it('requires cwd before spawning', () => {
+    expect(() =>
+      new CodexAppServerAdapter({ binary: 'unused', profileStateDir: tmpdir() }).run({
+        runId: 'run-no-cwd',
+        prompt: 'hi',
+      }),
+    ).toThrow(/cwd is required/);
+  });
+});
+
+async function collect(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const out: AgentEvent[] = [];
+  for await (const event of events) out.push(event);
+  return out;
+}
+
+async function prepareAndRun(
+  adapter: CodexAppServerAdapter,
+  options: AgentRunOptions,
+): Promise<AgentRun> {
+  await adapter.prepareRun(options);
+  return adapter.run(options);
+}
+
+async function createFakeAppServer(options: {
+  approvalRequest?: boolean;
+  holdTurn?: boolean;
+  failMethod?: string;
+  malformedAfterInitialize?: boolean;
+  notificationsBeforeTurnResponse?: boolean;
+} = {}): Promise<FakeAppServer> {
+  const dir = await mkdtemp(join(tmpdir(), 'codex-app-server-adapter-test-'));
+  const path = join(dir, 'fake-codex.mjs');
+  const recordPath = join(dir, 'record.json');
+  const script = `#!/usr/bin/env node
+import { createInterface } from 'node:readline';
+import { writeFileSync } from 'node:fs';
+
+const options = ${JSON.stringify(options)};
+const recordPath = ${JSON.stringify(recordPath)};
+const messages = [];
+let threadId = 'thread-fresh';
+let turnId = 'turn-1';
+let completed = false;
+let initializeReplied = false;
+let configProbe = false;
+
+function persist() {
+  try {
+    writeFileSync(recordPath, JSON.stringify({
+      argv: process.argv.slice(2),
+      cwd: process.cwd(),
+      env: {
+        LARK_CHANNEL: process.env.LARK_CHANNEL,
+        LARK_CHANNEL_PROFILE: process.env.LARK_CHANNEL_PROFILE,
+        LARK_CHANNEL_HOME: process.env.LARK_CHANNEL_HOME,
+        LARK_CHANNEL_CONFIG: process.env.LARK_CHANNEL_CONFIG,
+        LARKSUITE_CLI_CONFIG_DIR: process.env.LARKSUITE_CLI_CONFIG_DIR,
+        CODEX_HOME: process.env.CODEX_HOME,
+        APP_SECRET: process.env.APP_SECRET,
+      },
+      messages,
+    }, null, 2));
+  } catch {
+    // The test may already have removed its temp directory after collecting
+    // the terminal event; late process-exit persistence is best-effort.
+  }
+}
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + '\\n');
+}
+
+function finish(status = 'completed') {
+  if (completed) return;
+  completed = true;
+  if (status === 'completed') {
+    send({ method: 'item/reasoning/summaryTextDelta', params: {
+      threadId, turnId, itemId: 'reason-1', summaryIndex: 0, delta: 'checking'
+    }});
+    send({ method: 'item/started', params: {
+      threadId, turnId, startedAtMs: Date.now(), item: {
+        id: 'cmd-1', type: 'commandExecution', command: 'pwd', cwd: process.cwd(),
+        commandActions: [], status: 'inProgress'
+      }
+    }});
+    send({ method: 'item/completed', params: {
+      threadId, turnId, completedAtMs: Date.now(), item: {
+        id: 'cmd-1', type: 'commandExecution', command: 'pwd', cwd: process.cwd(),
+        commandActions: [], status: 'completed', aggregatedOutput: process.cwd() + '\\n', exitCode: 0
+      }
+    }});
+    send({ method: 'item/started', params: {
+      threadId, turnId, startedAtMs: Date.now(),
+      item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer', text: '' }
+    }});
+    send({ method: 'item/agentMessage/delta', params: {
+      threadId, turnId, itemId: 'msg-1', delta: 'hello user'
+    }});
+    send({ method: 'item/completed', params: {
+      threadId, turnId, completedAtMs: Date.now(),
+      item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer', text: 'hello user' }
+    }});
+    send({ method: 'thread/tokenUsage/updated', params: {
+      threadId, turnId, tokenUsage: {
+        last: { inputTokens: 12, outputTokens: 3, cachedInputTokens: 4, reasoningOutputTokens: 1, totalTokens: 15 },
+        total: { inputTokens: 120, outputTokens: 30, cachedInputTokens: 40, reasoningOutputTokens: 10, totalTokens: 150 }
+      }
+    }});
+  }
+  send({ method: 'turn/completed', params: {
+    threadId, turn: { id: turnId, status, items: [] }
+  }});
+}
+
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+rl.on('line', (line) => {
+  if (!line.trim()) return;
+  const message = JSON.parse(line);
+  messages.push(message);
+  persist();
+  if (message.method && options.failMethod === message.method) {
+    send({ id: message.id, error: { code: -32000, message: 'fake rejected ' + message.method } });
+    return;
+  }
+  if (message.method === 'initialize') {
+    configProbe = message.params?.clientInfo?.name === 'lark-channel-bridge-config-probe';
+    setTimeout(() => {
+      initializeReplied = true;
+      send({ id: message.id, result: {
+        userAgent: 'fake-codex', codexHome: process.env.CODEX_HOME ?? '',
+        platformFamily: 'unix', platformOs: 'macos'
+      }});
+      if (options.malformedAfterInitialize && !configProbe) process.stdout.write('{bad json\\n');
+    }, 10);
+  } else if (message.method === 'initialized' && !initializeReplied) {
+    process.stderr.write('initialized arrived before initialize response\\n');
+    process.exit(2);
+  } else if (message.method === 'config/read') {
+    send({ id: message.id, result: { config: { mcp_servers: {
+      'fake-stdio': {
+        enabled: true,
+        command: 'unsafe-mcp-command',
+        args: ['--token', 'fake-secret-value'],
+        env: { SECRET: 'fake-secret-value' }
+      },
+      'fake-http': {
+        enabled: true,
+        url: 'https://mcp.example.invalid',
+        bearer_token_env_var: 'FAKE_MCP_TOKEN'
+      }
+    } } } });
+  } else if (message.method === 'thread/start' || message.method === 'thread/resume') {
+    threadId = message.params.threadId ?? 'thread-fresh';
+    send({ id: message.id, result: {
+      thread: { id: threadId }, cwd: message.params.cwd,
+      model: message.params.model ?? 'fake-model', modelProvider: 'openai',
+      approvalPolicy: 'never', approvalsReviewer: 'user', sandbox: {}
+    }});
+  } else if (message.method === 'thread/name/set') {
+    send({ id: message.id, result: {} });
+  } else if (message.method === 'turn/start') {
+    if (options.notificationsBeforeTurnResponse) finish('completed');
+    send({ id: message.id, result: { turn: { id: turnId, status: 'inProgress', items: [] } } });
+    if (options.notificationsBeforeTurnResponse) {
+      // Notifications were intentionally sent first to exercise client buffering.
+    } else if (options.approvalRequest) {
+      send({ id: 'approval-1', method: 'item/commandExecution/requestApproval', params: {
+        threadId, turnId, itemId: 'cmd-approval'
+      }});
+    } else if (!options.holdTurn) {
+      finish('completed');
+    }
+  } else if (message.method === 'turn/interrupt') {
+    send({ id: message.id, result: {} });
+    finish('interrupted');
+  } else if (message.id === 'approval-1' && message.result) {
+    finish('completed');
+  }
+});
+
+process.stdin.on('end', () => {
+  persist();
+  setTimeout(() => process.exit(0), 5);
+});
+process.on('SIGTERM', () => {
+  persist();
+  process.exit(0);
+});
+process.on('exit', persist);
+`;
+  await writeFile(path, script, 'utf8');
+  await chmod(path, 0o755);
+  return { path, dir, recordPath };
+}
+
+interface FakeRecord {
+  argv: string[];
+  cwd: string;
+  env: Record<string, string | undefined>;
+  messages: Array<{
+    id?: number | string;
+    method?: string;
+    params?: Record<string, unknown>;
+    result?: unknown;
+  }>;
+}
+
+async function readRecord(path: string): Promise<FakeRecord> {
+  return JSON.parse(await readFile(path, 'utf8')) as FakeRecord;
+}
+
+function messageByMethod(record: FakeRecord, method: string) {
+  const message = record.messages.find((candidate) => candidate.method === method);
+  if (!message?.params) throw new Error(`missing recorded method: ${method}`);
+  return { ...message, params: message.params };
+}
+
+async function waitForRecordedMethod(path: string, method: string): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    try {
+      if ((await readRecord(path)).messages.some((message) => message.method === method)) return;
+    } catch {
+      // The fake may not have persisted its first request yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for ${method}`);
+}

--- a/tests/process/codex-app-server-adapter.test.ts
+++ b/tests/process/codex-app-server-adapter.test.ts
@@ -111,10 +111,13 @@ describe('CodexAppServerAdapter process contract', () => {
       'initialized',
       'config/read',
       'thread/start',
-      'thread/name/set',
       'turn/start',
+      'thread/name/set',
     ]);
 
+    expect(messageByMethod(record, 'initialize').params.capabilities).toEqual({
+      experimentalApi: true,
+    });
     const threadStart = messageByMethod(record, 'thread/start');
     expect(threadStart.params).toMatchObject({
       cwd,
@@ -151,6 +154,9 @@ describe('CodexAppServerAdapter process contract', () => {
       binary: fake.path,
       profileStateDir: fake.dir,
       sandbox: 'danger-full-access',
+      onThreadCandidate: async () => {
+        throw new Error('resume must not report a fresh thread candidate');
+      },
     });
     const run = await prepareAndRun(adapter, {
       runId: 'run-resume',
@@ -179,6 +185,7 @@ describe('CodexAppServerAdapter process contract', () => {
       model: 'gpt-test',
       sandbox: 'workspace-write',
       approvalPolicy: 'never',
+      excludeTurns: true,
     });
     expect(messageByMethod(record, 'turn/start').params).toMatchObject({
       threadId: 'thread-old',
@@ -219,6 +226,131 @@ describe('CodexAppServerAdapter process contract', () => {
     });
   });
 
+  it('treats thread naming as best-effort after the first turn starts', async () => {
+    const fake = await createFakeAppServer({ failMethod: 'thread/name/set' });
+    cleanup.push(fake.dir);
+    const run = await prepareAndRun(new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+    }), {
+      runId: 'run-name-failure',
+      prompt: 'continue without a display name',
+      cwd: await realpath(fake.dir),
+    });
+
+    expect((await collect(run.events)).at(-1)).toEqual({
+      type: 'done',
+      threadId: 'thread-fresh',
+      terminationReason: 'normal',
+    });
+    expect(await run.waitForExit(1000)).toBe(true);
+    const methods = (await readRecord(fake.recordPath)).messages
+      .map((message) => message.method)
+      .filter(Boolean);
+    expect(methods.indexOf('turn/start')).toBeLessThan(methods.indexOf('thread/name/set'));
+  });
+
+  it('awaits fresh thread candidate reconciliation before turn/start', async () => {
+    const fake = await createFakeAppServer();
+    cleanup.push(fake.dir);
+    const candidates: string[] = [];
+    const run = await prepareAndRun(new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+      onThreadCandidate: async (threadId) => {
+        candidates.push(threadId);
+        throw new Error('candidate reconciliation failed');
+      },
+    }), {
+      runId: 'run-candidate-failure',
+      prompt: 'must not start',
+      cwd: await realpath(fake.dir),
+    });
+
+    expect(await collect(run.events)).toEqual([{
+      type: 'error',
+      message: 'codex app-server protocol error: candidate reconciliation failed',
+      terminationReason: 'failed',
+    }]);
+    expect(await run.waitForExit(1000)).toBe(true);
+    expect(candidates).toEqual(['thread-fresh']);
+    const record = await readRecord(fake.recordPath);
+    expect(record.messages.some((message) => message.method === 'thread/start')).toBe(true);
+    expect(record.messages.some((message) => message.method === 'turn/start')).toBe(false);
+  });
+
+  it('returns protocol-complete MCP elicitation declines', async () => {
+    const fake = await createFakeAppServer({ mcpElicitationRequest: true });
+    cleanup.push(fake.dir);
+    const run = await prepareAndRun(new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+    }), {
+      runId: 'run-mcp-elicitation',
+      prompt: 'decline MCP input',
+      cwd: await realpath(fake.dir),
+    });
+
+    await collect(run.events);
+    expect(await run.waitForExit(1000)).toBe(true);
+    expect((await readRecord(fake.recordPath)).messages).toContainEqual({
+      id: 'mcp-elicitation-1',
+      result: { action: 'decline', content: null },
+    });
+  });
+
+  it('keeps current resume usage that arrives before turn/start while filtering history', async () => {
+    const fake = await createFakeAppServer({
+      historicalUsageOnResume: true,
+      notificationsBeforeTurnResponse: true,
+    });
+    cleanup.push(fake.dir);
+    const run = await prepareAndRun(new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+    }), {
+      runId: 'run-resume-current-usage',
+      prompt: 'new turn',
+      cwd: await realpath(fake.dir),
+      threadId: 'thread-old',
+    });
+
+    const events = await collect(run.events);
+    expect(await run.waitForExit(1000)).toBe(true);
+    expect(events.filter((event) => event.type === 'usage')).toEqual([{
+      type: 'usage',
+      inputTokens: 12,
+      outputTokens: 3,
+      cachedInputTokens: 4,
+      reasoningOutputTokens: 1,
+    }]);
+  });
+
+  it('does not attribute legacy resume usage without a turn id to the current turn', async () => {
+    const fake = await createFakeAppServer({
+      historicalUsageOnResume: true,
+      historicalUsageWithoutTurnId: true,
+      suppressCurrentUsage: true,
+    });
+    cleanup.push(fake.dir);
+    const run = await prepareAndRun(new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+    }), {
+      runId: 'run-resume-usage',
+      prompt: 'new turn',
+      cwd: await realpath(fake.dir),
+      threadId: 'thread-old',
+    });
+
+    const events = await collect(run.events);
+    expect(await run.waitForExit(1000)).toBe(true);
+    expect(events.filter((event) => event.type === 'usage')).toEqual([]);
+    expect(messageByMethod(await readRecord(fake.recordPath), 'thread/resume').params).toMatchObject({
+      excludeTurns: true,
+    });
+  });
+
   it('answers currentTime/read with whole Unix seconds', async () => {
     const fake = await createFakeAppServer({ currentTimeRequest: true });
     cleanup.push(fake.dir);
@@ -248,7 +380,7 @@ describe('CodexAppServerAdapter process contract', () => {
 
   it.each(['applyPatchApproval', 'execCommandApproval'] as const)(
     'uses the official ReviewDecision wire schema for %s',
-    async (legacyApprovalMethod) => {
+    async (legacyApprovalMethod: 'applyPatchApproval' | 'execCommandApproval') => {
       const fake = await createFakeAppServer({ legacyApprovalMethod });
       cleanup.push(fake.dir);
       const run = await prepareAndRun(new CodexAppServerAdapter({
@@ -355,6 +487,44 @@ describe('CodexAppServerAdapter process contract', () => {
       { type: 'final_text', content: 'hello user' },
     ]);
     expect(events.filter((event) => event.type === 'usage')).toHaveLength(1);
+  });
+
+  it('reports matching raw run activity even when no display event is produced', async () => {
+    const fake = await createFakeAppServer({
+      activityOnlyNotifications: true,
+      holdTurn: true,
+    });
+    cleanup.push(fake.dir);
+    let activityCount = 0;
+    let resolveActivity!: () => void;
+    const activity = new Promise<void>((resolve) => {
+      resolveActivity = resolve;
+    });
+    const run = await prepareAndRun(new CodexAppServerAdapter({
+      binary: fake.path,
+      profileStateDir: fake.dir,
+      stopGraceMs: 100,
+      onActivity: () => {
+        activityCount++;
+        resolveActivity();
+      },
+    }), {
+      runId: 'run-raw-activity',
+      prompt: 'stay active',
+      cwd: await realpath(fake.dir),
+    });
+    const iterator = run.events[Symbol.asyncIterator]();
+
+    expect(await iterator.next()).toMatchObject({
+      done: false,
+      value: { type: 'system', threadId: 'thread-fresh' },
+    });
+    await waitForPromise(activity, 'matching raw activity');
+    expect(activityCount).toBe(1);
+
+    await run.stop();
+    expect(await run.waitForExit(1000)).toBe(true);
+    await iterator.return?.();
   });
 
   it('interrupts an active turn before terminating its temporary app-server', async () => {
@@ -493,6 +663,7 @@ async function prepareAndRun(
 }
 
 async function createFakeAppServer(options: {
+  activityOnlyNotifications?: boolean;
   approvalRequest?: boolean;
   addMcpAfterProbe?: boolean;
   currentTimeRequest?: boolean;
@@ -501,7 +672,11 @@ async function createFakeAppServer(options: {
   legacyApprovalMethod?: 'applyPatchApproval' | 'execCommandApproval';
   failMethod?: string;
   malformedAfterInitialize?: boolean;
+  mcpElicitationRequest?: boolean;
   notificationsBeforeTurnResponse?: boolean;
+  historicalUsageOnResume?: boolean;
+  historicalUsageWithoutTurnId?: boolean;
+  suppressCurrentUsage?: boolean;
   requireProfileCodexHome?: boolean;
   supportedFeatures?: string[];
 } = {}): Promise<FakeAppServer> {
@@ -548,6 +723,7 @@ const mcpStarts = [];
 let threadId = 'thread-fresh';
 let turnId = 'turn-1';
 let completed = false;
+let turnStarted = false;
 let initializeReplied = false;
 let configProbe = false;
 
@@ -609,12 +785,14 @@ function finish(status = 'completed') {
       threadId, turnId, completedAtMs: Date.now(),
       item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer', text: 'hello user' }
     }});
-    send({ method: 'thread/tokenUsage/updated', params: {
-      threadId, turnId, tokenUsage: {
-        last: { inputTokens: 12, outputTokens: 3, cachedInputTokens: 4, reasoningOutputTokens: 1, totalTokens: 15 },
-        total: { inputTokens: 120, outputTokens: 30, cachedInputTokens: 40, reasoningOutputTokens: 10, totalTokens: 150 }
-      }
-    }});
+    if (!options.suppressCurrentUsage) {
+      send({ method: 'thread/tokenUsage/updated', params: {
+        threadId, turnId, tokenUsage: {
+          last: { inputTokens: 12, outputTokens: 3, cachedInputTokens: 4, reasoningOutputTokens: 1, totalTokens: 15 },
+          total: { inputTokens: 120, outputTokens: 30, cachedInputTokens: 40, reasoningOutputTokens: 10, totalTokens: 150 }
+        }
+      }});
+    }
   }
   send({ method: 'turn/completed', params: {
     threadId, turn: { id: turnId, status, items: [] }
@@ -670,19 +848,45 @@ rl.on('line', (line) => {
       model: message.params.model ?? 'fake-model', modelProvider: 'openai',
       approvalPolicy: 'never', approvalsReviewer: 'user', sandbox: {}
     }});
+    if (message.method === 'thread/resume' && options.historicalUsageOnResume) {
+      send({ method: 'thread/tokenUsage/updated', params: {
+        threadId,
+        ...(options.historicalUsageWithoutTurnId ? {} : { turnId: 'turn-historical' }),
+        tokenUsage: {
+          last: { inputTokens: 999, outputTokens: 999, totalTokens: 1998 },
+          total: { inputTokens: 999, outputTokens: 999, totalTokens: 1998 }
+        }
+      }});
+    }
   } else if (message.method === 'thread/name/set') {
+    if (!turnStarted) {
+      send({ id: message.id, error: { code: -32600, message: 'no rollout found for thread id' } });
+      return;
+    }
     send({ id: message.id, result: {} });
   } else if (message.method === 'turn/start') {
+    turnStarted = true;
     if (options.notificationsBeforeTurnResponse) finish('completed');
     send({ id: message.id, result: { turn: { id: turnId, status: 'inProgress', items: [] } } });
     if (options.notificationsBeforeTurnResponse) {
       // Notifications were intentionally sent first to exercise client buffering.
+    } else if (options.activityOnlyNotifications) {
+      send({ method: 'item/reasoning/textDelta', params: {
+        threadId, turnId: 'turn-other', itemId: 'reason-other', delta: 'ignore me'
+      }});
+      send({ method: 'item/reasoning/textDelta', params: {
+        threadId, turnId, itemId: 'reason-1', delta: 'still working'
+      }});
     } else if (options.approvalRequest) {
       send({ id: 'approval-1', method: 'item/commandExecution/requestApproval', params: {
         threadId, turnId, itemId: 'cmd-approval'
       }});
     } else if (options.currentTimeRequest) {
       send({ id: 'current-time-1', method: 'currentTime/read', params: { threadId } });
+    } else if (options.mcpElicitationRequest) {
+      send({ id: 'mcp-elicitation-1', method: 'mcpServer/elicitation/request', params: {
+        threadId, turnId, serverName: 'fake-mcp', message: 'need input'
+      }});
     } else if (options.legacyApprovalMethod) {
       send({ id: 'legacy-approval-1', method: options.legacyApprovalMethod, params: {
         conversationId: threadId, callId: 'legacy-call-1'
@@ -693,7 +897,10 @@ rl.on('line', (line) => {
   } else if (message.method === 'turn/interrupt') {
     send({ id: message.id, result: {} });
     finish('interrupted');
-  } else if (message.id === 'approval-1' && message.result) {
+  } else if (
+    (message.id === 'approval-1' || message.id === 'mcp-elicitation-1')
+    && message.result
+  ) {
     finish('completed');
   } else if (
     (message.id === 'current-time-1' || message.id === 'legacy-approval-1')
@@ -756,4 +963,18 @@ async function waitForRecordedMethod(path: string, method: string): Promise<void
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   throw new Error(`timed out waiting for ${method}`);
+}
+
+async function waitForPromise(promise: Promise<unknown>, label: string): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(`timed out waiting for ${label}`)), 2000);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
 }

--- a/tests/process/codex-app-server-process.test.ts
+++ b/tests/process/codex-app-server-process.test.ts
@@ -1,0 +1,201 @@
+import { chmod, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  APP_SERVER_PROCESS_GROUP_ENABLED,
+  readAppServerFeatureInventory,
+  terminateAndReapChild,
+} from '../../src/agent/codex/app-server-process';
+import { writeFileAtomic } from '../../src/platform/atomic-write';
+import { spawnProcess } from '../../src/platform/spawn';
+
+describe('Codex App Server process probes', () => {
+  const cleanup: string[] = [];
+  const childPids: number[] = [];
+  const processGroupPids: number[] = [];
+
+  afterEach(async () => {
+    for (const pid of processGroupPids.splice(0)) {
+      try {
+        process.kill(-pid, 'SIGKILL');
+      } catch {
+        // Already reaped by the code under test, or process groups are unavailable.
+      }
+    }
+    for (const pid of childPids.splice(0)) {
+      try {
+        process.kill(pid, 'SIGKILL');
+      } catch {
+        // Already reaped by the code under test.
+      }
+    }
+    await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+  });
+
+  it('reports a hung feature probe timeout independently of process startup', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'codex-feature-probe-timeout-'));
+    cleanup.push(dir);
+    const binary = join(dir, 'fake-codex.mjs');
+    await writeFileAtomic(binary, `#!/usr/bin/env node
+process.on('SIGTERM', () => {});
+setInterval(() => {}, 1000);
+`, { mode: 0o755 });
+    await chmod(binary, 0o755);
+
+    await expect(readAppServerFeatureInventory({
+      binary,
+      cwd: dir,
+      env: process.env,
+      featureListTimeoutMs: 100,
+      shutdownGraceMs: 100,
+    })).rejects.toThrow(/codex features list timed out after 100ms/);
+  });
+
+  it('reaps a started wrapper and its POSIX process group after escalation', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'codex-feature-probe-reap-'));
+    cleanup.push(dir);
+    const wrapper = join(dir, 'wrapper.mjs');
+    const readyFile = join(dir, 'ready.json');
+    await writeFileAtomic(wrapper, `
+import { spawn } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+const grandchild = spawn(process.execPath, ['-e', ${JSON.stringify(
+  "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+)}], { stdio: 'ignore' });
+grandchild.once('spawn', () => {
+  writeFileSync(${JSON.stringify(readyFile)}, JSON.stringify({
+    wrapperPid: process.pid,
+    grandchildPid: grandchild.pid,
+  }));
+});
+process.on('SIGTERM', () => {});
+setInterval(() => {}, 1000);
+`);
+
+    const child = spawnProcess(process.execPath, [wrapper], {
+      cwd: dir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: APP_SERVER_PROCESS_GROUP_ENABLED,
+    });
+    if (!child.pid) throw new Error('wrapper spawn returned no pid');
+    childPids.push(child.pid);
+    if (APP_SERVER_PROCESS_GROUP_ENABLED) processGroupPids.push(child.pid);
+    child.stdout?.resume();
+    child.stderr?.resume();
+    const closed = new Promise<void>((resolve) => child.once('close', () => resolve()));
+    const ready = await waitForReadyFile(readyFile);
+    childPids.push(ready.grandchildPid);
+
+    expect(ready.wrapperPid).toBe(child.pid);
+    expect(isProcessAlive(ready.wrapperPid)).toBe(true);
+    expect(isProcessAlive(ready.grandchildPid)).toBe(true);
+
+    await expect(terminateAndReapChild(child, closed, {
+      eofGraceMs: 0,
+      terminateGraceMs: 100,
+      killGraceMs: 1000,
+    })).resolves.toBe(true);
+
+    await waitForProcessExit(ready.wrapperPid);
+    expect(isProcessAlive(ready.wrapperPid)).toBe(false);
+    if (APP_SERVER_PROCESS_GROUP_ENABLED) {
+      await waitForProcessExit(ready.grandchildPid);
+      expect(isProcessAlive(ready.grandchildPid)).toBe(false);
+    }
+    // Windows intentionally guarantees only direct-child termination; the
+    // afterEach PID cleanup owns any surviving wrapper grandchild there.
+  });
+
+  it.skipIf(!APP_SERVER_PROCESS_GROUP_ENABLED)(
+    'reaps a surviving POSIX process group after the direct child closes early',
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'codex-feature-probe-early-close-'));
+      cleanup.push(dir);
+      const wrapper = join(dir, 'wrapper.mjs');
+      const readyFile = join(dir, 'ready.json');
+      await writeFileAtomic(wrapper, `
+import { spawn } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+const grandchild = spawn(process.execPath, ['-e', ${JSON.stringify(
+  "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000);",
+)}], { stdio: 'ignore' });
+grandchild.once('spawn', () => {
+  writeFileSync(${JSON.stringify(readyFile)}, JSON.stringify({
+    wrapperPid: process.pid,
+    grandchildPid: grandchild.pid,
+  }));
+  process.exit(0);
+});
+`);
+
+      const child = spawnProcess(process.execPath, [wrapper], {
+        cwd: dir,
+        stdio: ['ignore', 'pipe', 'pipe'],
+        detached: true,
+      });
+      if (!child.pid) throw new Error('wrapper spawn returned no pid');
+      childPids.push(child.pid);
+      processGroupPids.push(child.pid);
+      child.stdout?.resume();
+      child.stderr?.resume();
+      const closed = new Promise<void>((resolve) => child.once('close', () => resolve()));
+      const ready = await waitForReadyFile(readyFile);
+      childPids.push(ready.grandchildPid);
+
+      await closed;
+      expect(isProcessAlive(ready.wrapperPid)).toBe(false);
+      expect(isProcessAlive(ready.grandchildPid)).toBe(true);
+
+      await expect(terminateAndReapChild(child, closed, {
+        eofGraceMs: 0,
+        terminateGraceMs: 100,
+        killGraceMs: 1000,
+      })).resolves.toBe(true);
+
+      await waitForProcessExit(ready.grandchildPid);
+      expect(isProcessAlive(ready.grandchildPid)).toBe(false);
+    },
+  );
+});
+
+async function waitForReadyFile(
+  path: string,
+): Promise<{ wrapperPid: number; grandchildPid: number }> {
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    try {
+      const parsed = JSON.parse(await readFile(path, 'utf8')) as {
+        wrapperPid?: unknown;
+        grandchildPid?: unknown;
+      };
+      if (typeof parsed.wrapperPid === 'number' && typeof parsed.grandchildPid === 'number') {
+        return { wrapperPid: parsed.wrapperPid, grandchildPid: parsed.grandchildPid };
+      }
+    } catch {
+      // The wrapper has not completed its startup handshake yet.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error('timed out waiting for wrapper startup handshake');
+}
+
+async function waitForProcessExit(pid: number): Promise<void> {
+  const deadline = Date.now() + 2000;
+  while (Date.now() < deadline) {
+    if (!isProcessAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`process ${pid} did not exit`);
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}

--- a/tests/process/codex-task-controller.test.ts
+++ b/tests/process/codex-task-controller.test.ts
@@ -26,6 +26,11 @@ describe('CodexTaskController process contract', () => {
       profileStateDir: fake.dir,
       registry,
       sandbox: 'workspace-write',
+      larkChannel: {
+        rootDir: fake.dir,
+        configPath: join(fake.dir, 'bridge.custom.json'),
+        larkCliSourceConfigFile: join(fake.dir, 'lark-cli-source', 'config.json'),
+      },
     });
 
     const created = await controller.create({
@@ -57,33 +62,252 @@ describe('CodexTaskController process contract', () => {
 
     const invocations = JSON.parse(await readFile(fake.invocations, 'utf8')) as string[][];
     expect(invocations.length).toBeGreaterThanOrEqual(6);
-    expect(invocations.every((argv) => argv.slice(0, 3).join(' ') === 'app-server --listen stdio://')).toBe(true);
+    expect(invocations.some((argv) => argv.slice(0, 2).join(' ') === 'features list')).toBe(true);
+    expect(invocations
+      .filter((argv) => argv[0] !== 'features')
+      .every((argv) => argv.slice(0, 3).join(' ') === 'app-server --listen stdio://')).toBe(true);
     expect(invocations.some((argv) => argv.includes('apps') && argv.includes('computer_use'))).toBe(true);
+    const environments = JSON.parse(await readFile(fake.environments, 'utf8')) as Array<Record<string, string>>;
+    expect(environments).not.toHaveLength(0);
+    expect(environments.every((env) => (
+      env.LARK_CHANNEL_BRIDGE_CONFIG === join(fake.dir, 'bridge.custom.json')
+      && env.LARK_CHANNEL_CONFIG === join(fake.dir, 'lark-cli-source', 'config.json')
+    ))).toBe(true);
     const persisted = JSON.parse(await readFile(fake.state, 'utf8')) as Record<string, unknown>;
     expect(persisted.resumeDeveloperInstructions).toContain('persistent Codex worker task');
     expect(persisted.resumeDeveloperInstructions).not.toContain('lark-channel-bridge 运行约定');
   });
+
+  it('does not persist the observed runtime model unless the caller explicitly overrides it', async () => {
+    const fake = await createFakeAppServer();
+    cleanup.push(fake.dir);
+    const registry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-D3FA17',
+    );
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry,
+      sandbox: 'workspace-write',
+    });
+
+    const created = await controller.create({ title: 'Default model', cwd: fake.dir });
+    expect('output' in created).toBe(false);
+    if ('output' in created) throw new Error('unexpected execution result');
+    expect(created.model).toBeUndefined();
+
+    const sent = await controller.send(created.handle, { message: 'use profile default' });
+    expect(sent.task.model).toBeUndefined();
+    expect((await registry.get(created.handle))?.model).toBeUndefined();
+
+    const pinned = await controller.send(created.handle, {
+      message: 'pin the next model',
+      model: 'gpt-pinned',
+    });
+    expect(pinned.task.model).toBe('gpt-pinned');
+    expect((await registry.get(created.handle))?.model).toBe('gpt-pinned');
+  });
+
+  it('keeps a failed thread naming operation discoverable in the registry', async () => {
+    const fake = await createFakeAppServer({ failThreadName: true });
+    cleanup.push(fake.dir);
+    const registry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-FA17ED',
+    );
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry,
+      sandbox: 'workspace-write',
+    });
+
+    await expect(controller.create({ title: 'Recoverable worker', cwd: fake.dir })).rejects.toThrow(
+      /T-FA17ED/,
+    );
+    const recovered = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry: new CodexTaskRegistry(join(fake.dir, 'codex-tasks.json')),
+      sandbox: 'workspace-write',
+    });
+    await expect(recovered.list()).resolves.toEqual([
+      expect.objectContaining({
+        handle: 'T-FA17ED',
+        threadId: 'thread-worker',
+        status: 'failed',
+      }),
+    ]);
+  });
+
+  it('records the durable thread id when registry import fails after thread creation', async () => {
+    const fake = await createFakeAppServer();
+    cleanup.push(fake.dir);
+    const baseRegistry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-1A2B3C',
+    );
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry: new FailImportRegistry(baseRegistry),
+      sandbox: 'workspace-write',
+    });
+
+    await expect(controller.create({ title: 'Import recovery', cwd: fake.dir })).rejects.toThrow(
+      /T-1A2B3C.*thread-worker/,
+    );
+    await expect(baseRegistry.get('T-1A2B3C')).resolves.toMatchObject({
+      status: 'reconcile',
+      threadId: 'thread-worker',
+      reconciliation: {
+        desiredStatus: 'failed',
+        threadId: 'thread-worker',
+        error: 'simulated thread import failure',
+      },
+    });
+  });
+
+  it('returns a completed turn with an explicit sync warning when final registry persistence fails', async () => {
+    const fake = await createFakeAppServer();
+    cleanup.push(fake.dir);
+    const baseRegistry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-5A17ED',
+    );
+    const registry = new FailCompletedUpdateRegistry(baseRegistry);
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry,
+      sandbox: 'workspace-write',
+    });
+    const created = await controller.create({ title: 'Durable send', cwd: fake.dir });
+    if ('output' in created) throw new Error('unexpected execution result');
+
+    await expect(controller.send(created.handle, { message: 'do not retry me' })).resolves.toMatchObject({
+      task: { handle: created.handle, status: 'completed' },
+      output: 'worker-ok: do not retry me',
+      terminationReason: 'normal',
+      registrySync: 'pending',
+      registryError: 'simulated completed update failure',
+    });
+    await expect(baseRegistry.get(created.handle)).resolves.toMatchObject({
+      status: 'reconcile',
+      threadId: 'thread-worker',
+      reconciliation: {
+        desiredStatus: 'completed',
+        lastTurnId: 'turn-1',
+        lastResult: 'worker-ok: do not retry me',
+      },
+    });
+    const recovered = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry: new CodexTaskRegistry(join(fake.dir, 'codex-tasks.json')),
+      sandbox: 'workspace-write',
+    });
+    await expect(recovered.list()).resolves.toEqual([
+      expect.objectContaining({
+        status: 'completed',
+        lastTurnId: 'turn-1',
+        lastResult: 'worker-ok: do not retry me',
+      }),
+    ]);
+  });
 });
 
-async function createFakeAppServer(): Promise<{
+class FailCompletedUpdateRegistry extends CodexTaskRegistry {
+  constructor(private readonly delegate: CodexTaskRegistry) {
+    super('/unused');
+  }
+
+  override list() {
+    return this.delegate.list();
+  }
+
+  override get(handle: string) {
+    return this.delegate.get(handle);
+  }
+
+  override reserve(input: Parameters<CodexTaskRegistry['reserve']>[0]) {
+    return this.delegate.reserve(input);
+  }
+
+  override importThread(handle: string, threadId: string) {
+    return this.delegate.importThread(handle, threadId);
+  }
+
+  override markReconcile(
+    handle: string,
+    input: Parameters<CodexTaskRegistry['markReconcile']>[1],
+  ) {
+    return this.delegate.markReconcile(handle, input);
+  }
+
+  override reconcile(handle?: string) {
+    return this.delegate.reconcile(handle);
+  }
+
+  override register(input: Parameters<CodexTaskRegistry['register']>[0]) {
+    return this.delegate.register(input);
+  }
+
+  override update(
+    handle: string,
+    input: Parameters<CodexTaskRegistry['update']>[1],
+  ): ReturnType<CodexTaskRegistry['update']> {
+    if (input.status === 'completed') {
+      return Promise.reject(new Error('simulated completed update failure'));
+    }
+    return this.delegate.update(handle, input);
+  }
+}
+
+class FailImportRegistry extends FailCompletedUpdateRegistry {
+  override importThread(): ReturnType<CodexTaskRegistry['importThread']> {
+    return Promise.reject(new Error('simulated thread import failure'));
+  }
+}
+
+async function createFakeAppServer(options: { failThreadName?: boolean } = {}): Promise<{
   dir: string;
   binary: string;
   invocations: string;
+  environments: string;
   state: string;
 }> {
   const dir = await mkdtemp(join(tmpdir(), 'codex-task-controller-'));
   const binary = join(dir, 'fake-codex.mjs');
   const state = join(dir, 'state.json');
   const invocations = join(dir, 'invocations.json');
+  const environments = join(dir, 'environments.json');
   const source = `#!/usr/bin/env node
 import { createInterface } from 'node:readline';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
 const statePath = ${JSON.stringify(state)};
 const invocationsPath = ${JSON.stringify(invocations)};
+const environmentsPath = ${JSON.stringify(environments)};
+const failThreadName = ${JSON.stringify(options.failThreadName === true)};
 const invocations = existsSync(invocationsPath) ? JSON.parse(readFileSync(invocationsPath, 'utf8')) : [];
 invocations.push(process.argv.slice(2));
 writeFileSync(invocationsPath, JSON.stringify(invocations));
+const environments = existsSync(environmentsPath) ? JSON.parse(readFileSync(environmentsPath, 'utf8')) : [];
+environments.push({
+  LARK_CHANNEL_BRIDGE_CONFIG: process.env.LARK_CHANNEL_BRIDGE_CONFIG,
+  LARK_CHANNEL_CONFIG: process.env.LARK_CHANNEL_CONFIG
+});
+writeFileSync(environmentsPath, JSON.stringify(environments));
+if (process.argv[2] === 'features' && process.argv[3] === 'list') {
+  process.stdout.write('apps stable true\\ncomputer_use stable true\\n');
+  process.exit(0);
+}
 
 let initialized = false;
 let loadedThread;
@@ -122,6 +346,10 @@ rl.on('line', (line) => {
     return;
   }
   if (message.method === 'thread/name/set') {
+    if (failThreadName) {
+      send({ id: message.id, error: { code: -32000, message: 'simulated thread/name/set failure' } });
+      return;
+    }
     const current = load() ?? { id: message.params.threadId, cwd: process.cwd(), turns: [] };
     save({ ...current, name: message.params.name });
     send({ id: message.id, result: {} });
@@ -187,5 +415,5 @@ rl.on('close', () => process.exit(0));
 `;
   await writeFileAtomic(binary, source, { mode: 0o755 });
   await chmod(binary, 0o755);
-  return { dir, binary, invocations, state };
+  return { dir, binary, invocations, environments, state };
 }

--- a/tests/process/codex-task-controller.test.ts
+++ b/tests/process/codex-task-controller.test.ts
@@ -1,0 +1,191 @@
+import { chmod, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CodexTaskController, finalAgentMessages } from '../../src/codex-task/controller';
+import { CodexTaskRegistry } from '../../src/codex-task/registry';
+import { writeFileAtomic } from '../../src/platform/atomic-write';
+
+describe('CodexTaskController process contract', () => {
+  const cleanup: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+  });
+
+  it('creates, names, resumes, reads, and records a persistent worker task', async () => {
+    const fake = await createFakeAppServer();
+    cleanup.push(fake.dir);
+    const registry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-A1B2C3',
+    );
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry,
+      sandbox: 'workspace-write',
+    });
+
+    const created = await controller.create({
+      title: 'Worker task',
+      cwd: fake.dir,
+      model: 'gpt-test',
+    });
+    expect('output' in created).toBe(false);
+    if ('output' in created) throw new Error('unexpected execution result');
+    expect(created).toMatchObject({
+      handle: 'T-A1B2C3',
+      title: 'Worker task',
+      cwd: fake.dir,
+      model: 'gpt-test',
+      status: 'idle',
+    });
+
+    const sent = await controller.send(created.handle, { message: 'check status' });
+    expect(sent).toMatchObject({
+      task: { handle: 'T-A1B2C3', status: 'completed' },
+      output: 'worker-ok: check status',
+      terminationReason: 'normal',
+    });
+
+    const read = await controller.read(created.handle);
+    expect(read.thread).toMatchObject({ id: 'thread-worker', name: 'Worker task' });
+    expect(finalAgentMessages(read.thread)).toEqual(['worker-ok: check status']);
+    expect(await controller.list()).toEqual([sent.task]);
+
+    const invocations = JSON.parse(await readFile(fake.invocations, 'utf8')) as string[][];
+    expect(invocations.length).toBeGreaterThanOrEqual(6);
+    expect(invocations.every((argv) => argv.slice(0, 3).join(' ') === 'app-server --listen stdio://')).toBe(true);
+    expect(invocations.some((argv) => argv.includes('apps') && argv.includes('computer_use'))).toBe(true);
+    const persisted = JSON.parse(await readFile(fake.state, 'utf8')) as Record<string, unknown>;
+    expect(persisted.resumeDeveloperInstructions).toContain('persistent Codex worker task');
+    expect(persisted.resumeDeveloperInstructions).not.toContain('lark-channel-bridge 运行约定');
+  });
+});
+
+async function createFakeAppServer(): Promise<{
+  dir: string;
+  binary: string;
+  invocations: string;
+  state: string;
+}> {
+  const dir = await mkdtemp(join(tmpdir(), 'codex-task-controller-'));
+  const binary = join(dir, 'fake-codex.mjs');
+  const state = join(dir, 'state.json');
+  const invocations = join(dir, 'invocations.json');
+  const source = `#!/usr/bin/env node
+import { createInterface } from 'node:readline';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+const statePath = ${JSON.stringify(state)};
+const invocationsPath = ${JSON.stringify(invocations)};
+const invocations = existsSync(invocationsPath) ? JSON.parse(readFileSync(invocationsPath, 'utf8')) : [];
+invocations.push(process.argv.slice(2));
+writeFileSync(invocationsPath, JSON.stringify(invocations));
+
+let initialized = false;
+let loadedThread;
+let turnCounter = 0;
+const load = () => existsSync(statePath) ? JSON.parse(readFileSync(statePath, 'utf8')) : undefined;
+const save = (value) => writeFileSync(statePath, JSON.stringify(value));
+const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+
+rl.on('line', (line) => {
+  if (!line.trim()) return;
+  const message = JSON.parse(line);
+  if (message.method === 'initialize') {
+    initialized = true;
+    send({ id: message.id, result: { userAgent: 'fake', codexHome: process.env.CODEX_HOME ?? '' } });
+    return;
+  }
+  if (message.method === 'initialized') return;
+  if (!initialized) {
+    send({ id: message.id, error: { code: -32000, message: 'not initialized' } });
+    return;
+  }
+  if (message.method === 'config/read') {
+    send({ id: message.id, result: { config: { mcp_servers: {} } } });
+    return;
+  }
+  if (message.method === 'thread/start') {
+    loadedThread = 'thread-worker';
+    send({ id: message.id, result: {
+      thread: { id: loadedThread, sessionId: loadedThread, ephemeral: false },
+      cwd: message.params.cwd,
+      model: message.params.model ?? 'fake-default',
+      modelProvider: 'fake'
+    }});
+    send({ method: 'thread/started', params: { thread: { id: loadedThread } } });
+    return;
+  }
+  if (message.method === 'thread/name/set') {
+    const current = load() ?? { id: message.params.threadId, cwd: process.cwd(), turns: [] };
+    save({ ...current, name: message.params.name });
+    send({ id: message.id, result: {} });
+    return;
+  }
+  if (message.method === 'thread/resume') {
+    const current = load();
+    if (!current || current.id !== message.params.threadId) {
+      send({ id: message.id, error: { code: -32000, message: 'thread not found' } });
+      return;
+    }
+    loadedThread = current.id;
+    save({ ...current, resumeDeveloperInstructions: message.params.developerInstructions });
+    send({ id: message.id, result: {
+      thread: current,
+      cwd: message.params.cwd,
+      model: message.params.model ?? 'gpt-test',
+      modelProvider: 'fake'
+    }});
+    return;
+  }
+  if (message.method === 'thread/read') {
+    const current = load();
+    send({ id: message.id, result: { thread: message.params.includeTurns
+      ? { ...current, status: { type: 'notLoaded' } }
+      : { id: current.id, name: current.name, cwd: current.cwd, status: { type: 'notLoaded' } }
+    }});
+    return;
+  }
+  if (message.method === 'turn/start') {
+    if (loadedThread !== message.params.threadId) {
+      send({ id: message.id, error: { code: -32000, message: 'thread not loaded' } });
+      return;
+    }
+    const turnId = 'turn-' + (++turnCounter);
+    const text = 'worker-ok: ' + message.params.input[0].text;
+    send({ id: message.id, result: { turn: { id: turnId, status: 'inProgress', items: [] } } });
+    setTimeout(() => {
+      send({ method: 'item/started', params: {
+        threadId: loadedThread, turnId, item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer', text: '' }
+      }});
+      send({ method: 'item/agentMessage/delta', params: {
+        threadId: loadedThread, turnId, itemId: 'msg-1', delta: text
+      }});
+      send({ method: 'item/completed', params: {
+        threadId: loadedThread, turnId,
+        item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer', text }
+      }});
+      const current = load();
+      save({ ...current, turns: [...(current.turns ?? []), {
+        id: turnId, status: 'completed', items: [{ id: 'msg-1', type: 'agentMessage', text }]
+      }] });
+      send({ method: 'turn/completed', params: {
+        threadId: loadedThread, turn: { id: turnId, status: 'completed', items: [] }
+      }});
+    }, 10);
+    return;
+  }
+  send({ id: message.id, error: { code: -32601, message: 'unsupported ' + message.method } });
+});
+
+rl.on('close', () => process.exit(0));
+`;
+  await writeFileAtomic(binary, source, { mode: 0o755 });
+  await chmod(binary, 0o755);
+  return { dir, binary, invocations, state };
+}

--- a/tests/process/codex-task-controller.test.ts
+++ b/tests/process/codex-task-controller.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { CodexTaskController, finalAgentMessages } from '../../src/codex-task/controller';
-import { CodexTaskRegistry } from '../../src/codex-task/registry';
+import { CodexTaskBusyError, CodexTaskRegistry } from '../../src/codex-task/registry';
 import { writeFileAtomic } from '../../src/platform/atomic-write';
 
 describe('CodexTaskController process contract', () => {
@@ -45,8 +45,10 @@ describe('CodexTaskController process contract', () => {
       title: 'Worker task',
       cwd: fake.dir,
       model: 'gpt-test',
-      status: 'idle',
+      status: 'pending',
     });
+    expect(created.threadId).toBeUndefined();
+    await expect(controller.read(created.handle)).rejects.toThrow(/pending.*first message/i);
 
     const sent = await controller.send(created.handle, { message: 'check status' });
     expect(sent).toMatchObject({
@@ -74,8 +76,62 @@ describe('CodexTaskController process contract', () => {
       && env.LARK_CHANNEL_CONFIG === join(fake.dir, 'lark-cli-source', 'config.json')
     ))).toBe(true);
     const persisted = JSON.parse(await readFile(fake.state, 'utf8')) as Record<string, unknown>;
-    expect(persisted.resumeDeveloperInstructions).toContain('persistent Codex worker task');
-    expect(persisted.resumeDeveloperInstructions).not.toContain('lark-channel-bridge 运行约定');
+    expect(persisted.startDeveloperInstructions).toContain('persistent Codex worker task');
+    expect(persisted.startDeveloperInstructions).not.toContain('lark-channel-bridge 运行约定');
+  });
+
+  it('materializes create --message in the same App Server lifecycle', async () => {
+    const fake = await createFakeAppServer();
+    cleanup.push(fake.dir);
+    const registry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-C0DE01',
+    );
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry,
+      sandbox: 'workspace-write',
+    });
+
+    const created = await controller.create({
+      title: 'Immediate worker',
+      cwd: fake.dir,
+      message: 'bootstrap',
+    });
+    if (!('output' in created)) throw new Error('expected execution result');
+    expect(created).toMatchObject({
+      task: { handle: 'T-C0DE01', threadId: 'thread-worker', status: 'completed' },
+      output: 'worker-ok: bootstrap',
+      terminationReason: 'normal',
+    });
+    await expect(controller.read(created.task.handle)).resolves.toMatchObject({
+      thread: { id: 'thread-worker', name: 'Immediate worker' },
+    });
+  });
+
+  it('includes the reserved handle when create --message fails', async () => {
+    const fake = await createFakeAppServer({ rejectTurnStart: true });
+    cleanup.push(fake.dir);
+    const registry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-BAD001',
+    );
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry,
+      sandbox: 'workspace-write',
+    });
+
+    await expect(controller.create({
+      title: 'Failed immediate worker',
+      cwd: fake.dir,
+      message: 'bootstrap',
+    })).rejects.toThrow(/T-BAD001.*first turn/i);
+    await expect(registry.get('T-BAD001')).resolves.toMatchObject({ status: 'failed' });
   });
 
   it('does not persist the observed runtime model unless the caller explicitly overrides it', async () => {
@@ -110,7 +166,7 @@ describe('CodexTaskController process contract', () => {
     expect((await registry.get(created.handle))?.model).toBe('gpt-pinned');
   });
 
-  it('keeps a failed thread naming operation discoverable in the registry', async () => {
+  it('keeps a successfully materialized task usable when thread naming fails', async () => {
     const fake = await createFakeAppServer({ failThreadName: true });
     cleanup.push(fake.dir);
     const registry = new CodexTaskRegistry(
@@ -125,22 +181,14 @@ describe('CodexTaskController process contract', () => {
       sandbox: 'workspace-write',
     });
 
-    await expect(controller.create({ title: 'Recoverable worker', cwd: fake.dir })).rejects.toThrow(
-      /T-FA17ED/,
-    );
-    const recovered = new CodexTaskController({
-      binary: fake.binary,
-      profileStateDir: fake.dir,
-      registry: new CodexTaskRegistry(join(fake.dir, 'codex-tasks.json')),
-      sandbox: 'workspace-write',
+    const created = await controller.create({ title: 'Recoverable worker', cwd: fake.dir });
+    if ('output' in created) throw new Error('unexpected execution result');
+    const sent = await controller.send(created.handle, { message: 'materialize me' });
+    expect(sent).toMatchObject({
+      task: { handle: 'T-FA17ED', threadId: 'thread-worker', status: 'completed' },
+      output: 'worker-ok: materialize me',
     });
-    await expect(recovered.list()).resolves.toEqual([
-      expect.objectContaining({
-        handle: 'T-FA17ED',
-        threadId: 'thread-worker',
-        status: 'failed',
-      }),
-    ]);
+    await expect(controller.list()).resolves.toEqual([sent.task]);
   });
 
   it('records the durable thread id when registry import fails after thread creation', async () => {
@@ -158,8 +206,10 @@ describe('CodexTaskController process contract', () => {
       sandbox: 'workspace-write',
     });
 
-    await expect(controller.create({ title: 'Import recovery', cwd: fake.dir })).rejects.toThrow(
-      /T-1A2B3C.*thread-worker/,
+    const created = await controller.create({ title: 'Import recovery', cwd: fake.dir });
+    if ('output' in created) throw new Error('unexpected execution result');
+    await expect(controller.send(created.handle, { message: 'materialize' })).rejects.toThrow(
+      /simulated thread import failure/,
     );
     await expect(baseRegistry.get('T-1A2B3C')).resolves.toMatchObject({
       status: 'reconcile',
@@ -169,6 +219,95 @@ describe('CodexTaskController process contract', () => {
         threadId: 'thread-worker',
         error: 'simulated thread import failure',
       },
+    });
+  });
+
+  it('recovers a durable candidate but fails closed when the first-turn outcome is ambiguous', async () => {
+    const fake = await createFakeAppServer({ dropTurnStartResponse: true });
+    cleanup.push(fake.dir);
+    const registry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-A8B190',
+    );
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry,
+      sandbox: 'workspace-write',
+    });
+    const created = await controller.create({ title: 'Ambiguous worker', cwd: fake.dir });
+    if ('output' in created) throw new Error('unexpected execution result');
+
+    await expect(controller.send(created.handle, { message: 'run exactly once' })).rejects.toThrow();
+    await expect(registry.get(created.handle)).resolves.toMatchObject({
+      status: 'failed',
+      candidateThreadId: 'thread-worker',
+    });
+
+    await expect(controller.send(created.handle, { message: 'must not run yet' })).rejects.toThrow(
+      /outcome.*ambiguous/i,
+    );
+    await expect(registry.get(created.handle)).resolves.toMatchObject({
+      status: 'failed',
+      threadId: 'thread-worker',
+    });
+    await expect(registry.get(created.handle)).resolves.not.toHaveProperty('candidateThreadId');
+    const persisted = JSON.parse(await readFile(fake.state, 'utf8')) as { turns?: unknown[] };
+    expect(persisted.turns).toHaveLength(1);
+    expect(JSON.stringify(persisted)).not.toContain('must not run yet');
+  });
+
+  it('clears an explicitly missing candidate before retrying materialization', async () => {
+    const fake = await createFakeAppServer();
+    cleanup.push(fake.dir);
+    const registry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-CA11D0',
+    );
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry,
+      sandbox: 'workspace-write',
+    });
+    const created = await registry.reserve({ title: 'Missing candidate', cwd: fake.dir });
+    await registry.update(created.handle, { status: 'failed' });
+    await registry.setThreadCandidate(created.handle, 'thread-missing');
+
+    await expect(controller.send(created.handle, { message: 'safe retry' })).resolves.toMatchObject({
+      task: { status: 'completed', threadId: 'thread-worker' },
+      output: 'worker-ok: safe retry',
+    });
+    await expect(registry.get(created.handle)).resolves.not.toHaveProperty('candidateThreadId');
+  });
+
+  it('keeps a candidate and fails closed on a non-not-found read error', async () => {
+    const fake = await createFakeAppServer({
+      threadReadError: { code: -32600, message: 'temporary registry backend failure' },
+    });
+    cleanup.push(fake.dir);
+    const registry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-CA11D1',
+    );
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry,
+      sandbox: 'workspace-write',
+    });
+    const created = await registry.reserve({ title: 'Unreadable candidate', cwd: fake.dir });
+    await registry.update(created.handle, { status: 'failed' });
+    await registry.setThreadCandidate(created.handle, 'thread-unknown');
+
+    await expect(controller.send(created.handle, { message: 'do not duplicate' })).rejects.toThrow(
+      /unresolved thread candidate/i,
+    );
+    await expect(registry.get(created.handle)).resolves.toMatchObject({
+      candidateThreadId: 'thread-unknown',
     });
   });
 
@@ -220,11 +359,131 @@ describe('CodexTaskController process contract', () => {
       }),
     ]);
   });
+
+  it('marks a silent turn as timeout and releases the task execution lock', async () => {
+    const fake = await createFakeAppServer({ neverComplete: true });
+    cleanup.push(fake.dir);
+    const registry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-71AE00',
+    );
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry,
+      sandbox: 'workspace-write',
+      turnIdleTimeoutMs: 100,
+      stopGraceMs: 50,
+    });
+    const created = await controller.create({ title: 'Silent worker', cwd: fake.dir });
+    if ('output' in created) throw new Error('unexpected execution result');
+
+    await expect(controller.send(created.handle, { message: 'stay silent' })).resolves.toMatchObject({
+      task: { status: 'timeout', threadId: 'thread-worker' },
+      terminationReason: 'timeout',
+    });
+    await expect(controller.send(created.handle, { message: 'try again' })).resolves.toMatchObject({
+      task: { status: 'timeout' },
+      terminationReason: 'timeout',
+    });
+  });
+
+  it('keeps an active turn alive when raw command progress continues', async () => {
+    const fake = await createFakeAppServer({ turnDelayMs: 300, progressEveryMs: 25 });
+    cleanup.push(fake.dir);
+    const registry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-AC7100',
+    );
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry,
+      sandbox: 'workspace-write',
+      turnIdleTimeoutMs: 100,
+      stopGraceMs: 50,
+    });
+    const created = await controller.create({ title: 'Active worker', cwd: fake.dir });
+    if ('output' in created) throw new Error('unexpected execution result');
+
+    await expect(controller.send(created.handle, { message: 'long build' })).resolves.toMatchObject({
+      task: { status: 'completed' },
+      terminationReason: 'normal',
+      output: 'worker-ok: long build',
+    });
+  });
+
+  it('uses AbortSignal to interrupt a turn and release the execution lock', async () => {
+    const fake = await createFakeAppServer({ turnDelayMs: 1_000 });
+    cleanup.push(fake.dir);
+    const registry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-AB0710',
+    );
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry,
+      sandbox: 'workspace-write',
+      turnIdleTimeoutMs: 2_000,
+      stopGraceMs: 50,
+    });
+    const created = await controller.create({ title: 'Abortable worker', cwd: fake.dir });
+    if ('output' in created) throw new Error('unexpected execution result');
+    const abort = new AbortController();
+    const sent = controller.send(created.handle, {
+      message: 'wait for cancellation',
+      signal: abort.signal,
+    });
+    await waitForTaskThread(registry, created.handle);
+    abort.abort();
+
+    await expect(sent).resolves.toMatchObject({
+      task: { status: 'interrupted', threadId: 'thread-worker' },
+      terminationReason: 'interrupted',
+    });
+    await expect(registry.withTaskLock(created.handle, async () => 'released')).resolves.toBe('released');
+  });
+
+  it('rejects a concurrent send with a domain error instead of using stale task state', async () => {
+    const fake = await createFakeAppServer({ turnDelayMs: 200 });
+    cleanup.push(fake.dir);
+    const registry = new CodexTaskRegistry(
+      join(fake.dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-B05E00',
+    );
+    const controller = new CodexTaskController({
+      binary: fake.binary,
+      profileStateDir: fake.dir,
+      registry,
+      sandbox: 'workspace-write',
+    });
+    const created = await controller.create({ title: 'Busy worker', cwd: fake.dir });
+    if ('output' in created) throw new Error('unexpected execution result');
+
+    const first = controller.send(created.handle, { message: 'first', model: 'gpt-first' });
+    await waitForTaskStatus(registry, created.handle, 'running');
+    const second = controller.send(created.handle, { message: 'second', model: 'gpt-stale' });
+    await expect(second).rejects.toBeInstanceOf(CodexTaskBusyError);
+    await expect(first).resolves.toMatchObject({
+      task: { status: 'completed', model: 'gpt-first' },
+      output: 'worker-ok: first',
+    });
+    await expect(registry.get(created.handle)).resolves.toMatchObject({ model: 'gpt-first' });
+  });
 });
 
 class FailCompletedUpdateRegistry extends CodexTaskRegistry {
   constructor(private readonly delegate: CodexTaskRegistry) {
     super('/unused');
+  }
+
+  override withTaskLock<T>(handle: string, fn: () => Promise<T>) {
+    return this.delegate.withTaskLock(handle, fn);
   }
 
   override list() {
@@ -241,6 +500,14 @@ class FailCompletedUpdateRegistry extends CodexTaskRegistry {
 
   override importThread(handle: string, threadId: string) {
     return this.delegate.importThread(handle, threadId);
+  }
+
+  override setThreadCandidate(handle: string, threadId: string) {
+    return this.delegate.setThreadCandidate(handle, threadId);
+  }
+
+  override clearThreadCandidate(handle: string, threadId: string) {
+    return this.delegate.clearThreadCandidate(handle, threadId);
   }
 
   override markReconcile(
@@ -275,7 +542,15 @@ class FailImportRegistry extends FailCompletedUpdateRegistry {
   }
 }
 
-async function createFakeAppServer(options: { failThreadName?: boolean } = {}): Promise<{
+async function createFakeAppServer(options: {
+  dropTurnStartResponse?: boolean;
+  failThreadName?: boolean;
+  neverComplete?: boolean;
+  progressEveryMs?: number;
+  rejectTurnStart?: boolean;
+  threadReadError?: { code: number; message: string };
+  turnDelayMs?: number;
+} = {}): Promise<{
   dir: string;
   binary: string;
   invocations: string;
@@ -294,7 +569,13 @@ import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 const statePath = ${JSON.stringify(state)};
 const invocationsPath = ${JSON.stringify(invocations)};
 const environmentsPath = ${JSON.stringify(environments)};
+const dropTurnStartResponse = ${JSON.stringify(options.dropTurnStartResponse === true)};
 const failThreadName = ${JSON.stringify(options.failThreadName === true)};
+const neverComplete = ${JSON.stringify(options.neverComplete === true)};
+const progressEveryMs = ${JSON.stringify(options.progressEveryMs ?? 0)};
+const rejectTurnStart = ${JSON.stringify(options.rejectTurnStart === true)};
+const threadReadError = ${JSON.stringify(options.threadReadError)};
+const turnDelayMs = ${JSON.stringify(options.turnDelayMs ?? 10)};
 const invocations = existsSync(invocationsPath) ? JSON.parse(readFileSync(invocationsPath, 'utf8')) : [];
 invocations.push(process.argv.slice(2));
 writeFileSync(invocationsPath, JSON.stringify(invocations));
@@ -311,7 +592,9 @@ if (process.argv[2] === 'features' && process.argv[3] === 'list') {
 
 let initialized = false;
 let loadedThread;
-let turnCounter = 0;
+let loadedCwd;
+let loadedModel;
+let loadedDeveloperInstructions;
 const load = () => existsSync(statePath) ? JSON.parse(readFileSync(statePath, 'utf8')) : undefined;
 const save = (value) => writeFileSync(statePath, JSON.stringify(value));
 const send = (value) => process.stdout.write(JSON.stringify(value) + '\\n');
@@ -336,6 +619,9 @@ rl.on('line', (line) => {
   }
   if (message.method === 'thread/start') {
     loadedThread = 'thread-worker';
+    loadedCwd = message.params.cwd;
+    loadedModel = message.params.model;
+    loadedDeveloperInstructions = message.params.developerInstructions;
     send({ id: message.id, result: {
       thread: { id: loadedThread, sessionId: loadedThread, ephemeral: false },
       cwd: message.params.cwd,
@@ -346,6 +632,10 @@ rl.on('line', (line) => {
     return;
   }
   if (message.method === 'thread/name/set') {
+    if (!load()) {
+      send({ id: message.id, error: { code: -32600, message: 'no rollout found for thread id' } });
+      return;
+    }
     if (failThreadName) {
       send({ id: message.id, error: { code: -32000, message: 'simulated thread/name/set failure' } });
       return;
@@ -362,7 +652,14 @@ rl.on('line', (line) => {
       return;
     }
     loadedThread = current.id;
-    save({ ...current, resumeDeveloperInstructions: message.params.developerInstructions });
+    loadedCwd = message.params.cwd;
+    loadedModel = message.params.model;
+    loadedDeveloperInstructions = message.params.developerInstructions;
+    save({
+      ...current,
+      resumeDeveloperInstructions: message.params.developerInstructions,
+      resumeExcludeTurns: message.params.excludeTurns,
+    });
     send({ id: message.id, result: {
       thread: current,
       cwd: message.params.cwd,
@@ -372,7 +669,18 @@ rl.on('line', (line) => {
     return;
   }
   if (message.method === 'thread/read') {
+    if (threadReadError) {
+      send({ id: message.id, error: threadReadError });
+      return;
+    }
     const current = load();
+    if (!current || current.id !== message.params.threadId) {
+      send({
+        id: message.id,
+        error: { code: -32600, message: 'thread not loaded: ' + message.params.threadId }
+      });
+      return;
+    }
     send({ id: message.id, result: { thread: message.params.includeTurns
       ? { ...current, status: { type: 'notLoaded' } }
       : { id: current.id, name: current.name, cwd: current.cwd, status: { type: 'notLoaded' } }
@@ -384,10 +692,38 @@ rl.on('line', (line) => {
       send({ id: message.id, error: { code: -32000, message: 'thread not loaded' } });
       return;
     }
-    const turnId = 'turn-' + (++turnCounter);
+    const existing = load();
+    const current = existing ?? {
+      id: loadedThread,
+      cwd: loadedCwd ?? process.cwd(),
+      model: loadedModel,
+      startDeveloperInstructions: loadedDeveloperInstructions,
+      turns: [],
+    };
+    const turnId = 'turn-' + ((current.turns?.length ?? 0) + 1);
     const text = 'worker-ok: ' + message.params.input[0].text;
+    if (rejectTurnStart) {
+      send({ id: message.id, error: { code: -32000, message: 'simulated turn/start rejection' } });
+      return;
+    }
+    // The fake models Codex durability: thread/start alone is in-memory; the
+    // first turn/start materializes the thread before naming or process exit.
+    save(current);
+    if (dropTurnStartResponse) {
+      save({ ...current, turns: [...(current.turns ?? []), {
+        id: turnId, status: 'completed', items: [{ id: 'msg-1', type: 'agentMessage', text }]
+      }] });
+      process.exit(1);
+    }
     send({ id: message.id, result: { turn: { id: turnId, status: 'inProgress', items: [] } } });
+    if (neverComplete) return;
+    const progressTimer = progressEveryMs > 0 ? setInterval(() => {
+      send({ method: 'item/commandExecution/outputDelta', params: {
+        threadId: loadedThread, turnId, itemId: 'command-1', delta: 'still working'
+      }});
+    }, progressEveryMs) : undefined;
     setTimeout(() => {
+      if (progressTimer) clearInterval(progressTimer);
       send({ method: 'item/started', params: {
         threadId: loadedThread, turnId, item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer', text: '' }
       }});
@@ -398,14 +734,21 @@ rl.on('line', (line) => {
         threadId: loadedThread, turnId,
         item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer', text }
       }});
-      const current = load();
-      save({ ...current, turns: [...(current.turns ?? []), {
+      const persisted = load();
+      save({ ...persisted, turns: [...(persisted.turns ?? []), {
         id: turnId, status: 'completed', items: [{ id: 'msg-1', type: 'agentMessage', text }]
       }] });
       send({ method: 'turn/completed', params: {
         threadId: loadedThread, turn: { id: turnId, status: 'completed', items: [] }
       }});
-    }, 10);
+    }, turnDelayMs);
+    return;
+  }
+  if (message.method === 'turn/interrupt') {
+    send({ id: message.id, result: {} });
+    send({ method: 'turn/completed', params: {
+      threadId: loadedThread, turn: { id: message.params.turnId, status: 'interrupted', items: [] }
+    }});
     return;
   }
   send({ id: message.id, error: { code: -32601, message: 'unsupported ' + message.method } });
@@ -416,4 +759,26 @@ rl.on('close', () => process.exit(0));
   await writeFileAtomic(binary, source, { mode: 0o755 });
   await chmod(binary, 0o755);
   return { dir, binary, invocations, environments, state };
+}
+
+async function waitForTaskStatus(
+  registry: CodexTaskRegistry,
+  handle: string,
+  status: string,
+): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if ((await registry.get(handle))?.status === status) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for ${handle} to reach ${status}`);
+}
+
+async function waitForTaskThread(registry: CodexTaskRegistry, handle: string): Promise<void> {
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    if ((await registry.get(handle))?.threadId) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`timed out waiting for ${handle} to import its thread`);
 }

--- a/tests/unit/agent/codex-app-server-jsonrpc.test.ts
+++ b/tests/unit/agent/codex-app-server-jsonrpc.test.ts
@@ -33,6 +33,7 @@ describe('CodexAppServerJsonRpc', () => {
 
     await expect(rejected).rejects.toMatchObject({
       name: 'CodexAppServerRpcError',
+      method: 'thread/resume',
       message: 'thread not found',
       code: -32000,
       data: { stale: true },

--- a/tests/unit/agent/codex-app-server-jsonrpc.test.ts
+++ b/tests/unit/agent/codex-app-server-jsonrpc.test.ts
@@ -1,0 +1,452 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CodexAppServerEventTranslator,
+  CodexAppServerJsonRpc,
+  CodexAppServerRpcError,
+} from '../../../src/agent/codex/app-server-jsonrpc.js';
+
+describe('CodexAppServerJsonRpc', () => {
+  it('correlates out-of-order responses by request id', async () => {
+    const writes: unknown[] = [];
+    const rpc = new CodexAppServerJsonRpc(async (message) => {
+      writes.push(message);
+    });
+
+    const first = rpc.request('initialize', { capabilities: null });
+    const second = rpc.request('thread/start', { cwd: '/repo' });
+
+    expect(writes).toEqual([
+      { method: 'initialize', id: 1, params: { capabilities: null } },
+      { method: 'thread/start', id: 2, params: { cwd: '/repo' } },
+    ]);
+    expect(rpc.receive({ id: 2, result: { thread: { id: 'thread-1' } } })).toBeUndefined();
+    expect(rpc.receive({ id: 1, result: { userAgent: 'codex' } })).toBeUndefined();
+
+    await expect(first).resolves.toEqual({ userAgent: 'codex' });
+    await expect(second).resolves.toEqual({ thread: { id: 'thread-1' } });
+  });
+
+  it('surfaces request errors with their code and rejects pending work on close', async () => {
+    const rpc = new CodexAppServerJsonRpc(async () => undefined);
+    const rejected = rpc.request('thread/resume', { threadId: 'missing' });
+    rpc.receive({ id: 1, error: { code: -32000, message: 'thread not found', data: { stale: true } } });
+
+    await expect(rejected).rejects.toMatchObject({
+      name: 'CodexAppServerRpcError',
+      message: 'thread not found',
+      code: -32000,
+      data: { stale: true },
+    } satisfies Partial<CodexAppServerRpcError>);
+
+    const pending = rpc.request('turn/start', {});
+    rpc.fail(new Error('connection lost'));
+    await expect(pending).rejects.toThrow('connection lost');
+    await expect(rpc.request('thread/start', {})).rejects.toThrow('connection lost');
+  });
+
+  it('classifies notifications and server requests without a jsonrpc field', () => {
+    const rpc = new CodexAppServerJsonRpc(async () => undefined);
+
+    expect(rpc.receive({ method: 'turn/started', params: { threadId: 't' } })).toEqual({
+      kind: 'notification',
+      method: 'turn/started',
+      params: { threadId: 't' },
+    });
+    expect(
+      rpc.receive({ id: 'server-1', method: 'item/commandExecution/requestApproval', params: {} }),
+    ).toEqual({
+      kind: 'request',
+      id: 'server-1',
+      method: 'item/commandExecution/requestApproval',
+      params: {},
+    });
+  });
+
+  it('rejects malformed messages and unknown response ids', () => {
+    const rpc = new CodexAppServerJsonRpc(async () => undefined);
+
+    expect(() => rpc.receive('bad')).toThrow(/non-object/);
+    expect(() => rpc.receive({ value: 1 })).toThrow(/neither method nor request id/);
+    expect(() => rpc.receive({ id: 99, result: {} })).toThrow(/unknown response id/);
+  });
+});
+
+describe('CodexAppServerEventTranslator', () => {
+  it('maps streamed text, reasoning, commands, usage, and a completed turn', () => {
+    const translator = new CodexAppServerEventTranslator();
+    translator.setContext('thread-1', 'turn-1');
+
+    expect(
+      translator.translate('item/started', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: { id: 'reason-1', type: 'reasoning', summary: [], content: [] },
+      }),
+    ).toEqual([]);
+    expect(
+      translator.translate('item/reasoning/summaryTextDelta', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'reason-1',
+        summaryIndex: 0,
+        delta: 'checking',
+      }),
+    ).toEqual([{ type: 'thinking', delta: 'checking' }]);
+
+    expect(
+      translator.translate('item/started', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          id: 'cmd-1',
+          type: 'commandExecution',
+          command: 'pwd',
+          cwd: '/repo',
+          commandActions: [],
+          status: 'inProgress',
+        },
+      }),
+    ).toEqual([
+      {
+        type: 'tool_use',
+        id: 'cmd-1',
+        name: 'Bash',
+        input: { command: 'pwd', cwd: '/repo', commandActions: [] },
+      },
+    ]);
+    expect(
+      translator.translate('item/completed', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          id: 'cmd-1',
+          type: 'commandExecution',
+          command: 'pwd',
+          cwd: '/repo',
+          commandActions: [],
+          status: 'completed',
+          aggregatedOutput: '/repo\n',
+          exitCode: 0,
+        },
+      }),
+    ).toEqual([
+      { type: 'tool_result', id: 'cmd-1', output: '/repo\n', isError: false },
+    ]);
+
+    translator.translate('item/started', {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer', text: '' },
+    });
+    expect(
+      translator.translate('item/agentMessage/delta', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'msg-1',
+        delta: 'done',
+      }),
+    ).toEqual([]);
+    expect(
+      translator.translate('item/completed', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: { id: 'msg-1', type: 'agentMessage', phase: 'final_answer', text: 'done!' },
+      }),
+    ).toEqual([]);
+
+    expect(
+      translator.translate('thread/tokenUsage/updated', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        tokenUsage: {
+          last: {
+            inputTokens: 10,
+            outputTokens: 4,
+            cachedInputTokens: 3,
+            reasoningOutputTokens: 2,
+            totalTokens: 14,
+          },
+          total: {
+            inputTokens: 999,
+            outputTokens: 999,
+            cachedInputTokens: 999,
+            reasoningOutputTokens: 999,
+            totalTokens: 1998,
+          },
+        },
+      }),
+    ).toEqual([]);
+    expect(
+      translator.translate('turn/completed', {
+        threadId: 'thread-1',
+        turn: { id: 'turn-1', status: 'completed', items: [] },
+      }),
+    ).toEqual([
+      { type: 'final_text', content: 'done!' },
+      {
+        type: 'usage',
+        inputTokens: 10,
+        outputTokens: 4,
+        cachedInputTokens: 3,
+        reasoningOutputTokens: 2,
+      },
+      { type: 'done', threadId: 'thread-1', terminationReason: 'normal' },
+    ]);
+    expect(translator.translate('turn/completed', {})).toEqual([]);
+    expect(translator.finish()).toEqual([]);
+  });
+
+  it('uses completed agent messages when no deltas were emitted', () => {
+    const translator = new CodexAppServerEventTranslator();
+    translator.setContext('thread-1', 'turn-1');
+
+    expect(
+      translator.translate('item/completed', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: { id: 'msg-1', type: 'agentMessage', text: 'whole answer' },
+      }),
+    ).toEqual([]);
+    expect(
+      translator.translate('turn/completed', {
+        threadId: 'thread-1',
+        turn: { id: 'turn-1', status: 'completed', items: [] },
+      }),
+    ).toEqual([
+      { type: 'final_text', content: 'whole answer' },
+      { type: 'done', threadId: 'thread-1', terminationReason: 'normal' },
+    ]);
+  });
+
+  it('does not promote unphased progress text before a tool into the final answer', () => {
+    const translator = new CodexAppServerEventTranslator();
+    translator.setContext('thread-1', 'turn-1');
+
+    expect(
+      translator.translate('item/completed', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: { id: 'msg-progress', type: 'agentMessage', text: 'I will inspect this.' },
+      }),
+    ).toEqual([]);
+    expect(
+      translator.translate('item/started', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          id: 'cmd-after-progress',
+          type: 'commandExecution',
+          command: 'pwd',
+          cwd: '/repo',
+          commandActions: [],
+          status: 'inProgress',
+        },
+      }),
+    ).toEqual([
+      { type: 'text', delta: 'I will inspect this.' },
+      {
+        type: 'tool_use',
+        id: 'cmd-after-progress',
+        name: 'Bash',
+        input: { command: 'pwd', cwd: '/repo', commandActions: [] },
+      },
+    ]);
+    expect(
+      translator.translate('turn/completed', {
+        threadId: 'thread-1',
+        turn: { id: 'turn-1', status: 'completed', items: [] },
+      }),
+    ).toEqual([
+      { type: 'done', threadId: 'thread-1', terminationReason: 'normal' },
+    ]);
+  });
+
+  it('streams commentary but buffers the final answer until turn completion', () => {
+    const translator = new CodexAppServerEventTranslator();
+    translator.setContext('thread-1', 'turn-1');
+
+    translator.translate('item/started', {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      item: { id: 'commentary-1', type: 'agentMessage', phase: 'commentary', text: '' },
+    });
+    expect(
+      translator.translate('item/agentMessage/delta', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'commentary-1',
+        delta: 'I am checking',
+      }),
+    ).toEqual([{ type: 'text', delta: 'I am checking' }]);
+    expect(
+      translator.translate('item/completed', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          id: 'commentary-1',
+          type: 'agentMessage',
+          phase: 'commentary',
+          text: 'I am checking now.',
+        },
+      }),
+    ).toEqual([{ type: 'text', delta: ' now.' }]);
+
+    translator.translate('item/started', {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      item: { id: 'final-1', type: 'agentMessage', phase: 'final_answer', text: '' },
+    });
+    expect(
+      translator.translate('item/agentMessage/delta', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'final-1',
+        delta: 'Final result.',
+      }),
+    ).toEqual([]);
+    translator.translate('item/completed', {
+      threadId: 'thread-1',
+      turnId: 'turn-1',
+      item: {
+        id: 'final-1',
+        type: 'agentMessage',
+        phase: 'final_answer',
+        text: 'Final result.',
+      },
+    });
+    expect(
+      translator.translate('turn/completed', {
+        threadId: 'thread-1',
+        turn: { id: 'turn-1', status: 'completed', items: [] },
+      }),
+    ).toEqual([
+      { type: 'final_text', content: 'Final result.' },
+      { type: 'done', threadId: 'thread-1', terminationReason: 'normal' },
+    ]);
+  });
+
+  it('shows reasoning summaries but never forwards raw reasoning text', () => {
+    const translator = new CodexAppServerEventTranslator();
+    translator.setContext('thread-1', 'turn-1');
+
+    expect(
+      translator.translate('item/reasoning/summaryTextDelta', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'reason-1',
+        summaryIndex: 0,
+        delta: 'Safe summary',
+      }),
+    ).toEqual([{ type: 'thinking', delta: 'Safe summary' }]);
+    expect(
+      translator.translate('item/reasoning/textDelta', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        itemId: 'reason-1',
+        contentIndex: 0,
+        delta: 'raw reasoning',
+      }),
+    ).toEqual([]);
+  });
+
+  it('maps late tool completion into a complete tool pair', () => {
+    const translator = new CodexAppServerEventTranslator();
+    translator.setContext('thread-1', 'turn-1');
+
+    expect(
+      translator.translate('item/completed', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        item: {
+          id: 'file-1',
+          type: 'fileChange',
+          changes: [{ path: '/repo/a.ts', kind: 'update' }],
+          status: 'failed',
+        },
+      }),
+    ).toEqual([
+      {
+        type: 'tool_use',
+        id: 'file-1',
+        name: 'FileChange',
+        input: { changes: [{ path: '/repo/a.ts', kind: 'update' }] },
+      },
+      {
+        type: 'tool_result',
+        id: 'file-1',
+        output: JSON.stringify({
+          status: 'failed',
+          changes: [{ path: '/repo/a.ts', kind: 'update' }],
+        }),
+        isError: true,
+      },
+    ]);
+    expect(translator.protocolDrift()).toMatchObject({ anomalies: 1 });
+  });
+
+  it('keeps retryable errors non-terminal and uses the final failed turn as authority', () => {
+    const translator = new CodexAppServerEventTranslator();
+    translator.setContext('thread-1', 'turn-1');
+
+    expect(
+      translator.translate('error', {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        error: { message: 'retrying' },
+        willRetry: true,
+      }),
+    ).toEqual([]);
+    expect(translator.terminalEmitted()).toBe(false);
+    expect(
+      translator.translate('turn/completed', {
+        threadId: 'thread-1',
+        turn: {
+          id: 'turn-1',
+          status: 'failed',
+          items: [],
+          error: { message: 'model stopped' },
+        },
+      }),
+    ).toEqual([
+      { type: 'error', message: 'model stopped', terminationReason: 'failed' },
+    ]);
+    expect(translator.finish()).toEqual([]);
+  });
+
+  it('maps interruption and local stop to one terminal event', () => {
+    const notified = new CodexAppServerEventTranslator();
+    notified.setContext('thread-stop', 'turn-stop');
+    expect(
+      notified.translate('turn/completed', {
+        threadId: 'thread-stop',
+        turn: { id: 'turn-stop', status: 'interrupted', items: [] },
+      }),
+    ).toEqual([
+      { type: 'done', threadId: 'thread-stop', terminationReason: 'interrupted' },
+    ]);
+    expect(notified.finish('interrupted')).toEqual([]);
+
+    const local = new CodexAppServerEventTranslator();
+    local.setContext('thread-stop', 'turn-stop');
+    expect(local.finish('interrupted')).toEqual([
+      { type: 'done', threadId: 'thread-stop', terminationReason: 'interrupted' },
+    ]);
+    expect(local.finish('interrupted')).toEqual([]);
+  });
+
+  it('ignores other turns and tracks additive protocol drift', () => {
+    const translator = new CodexAppServerEventTranslator();
+    translator.setContext('thread-1', 'turn-1');
+
+    expect(
+      translator.translate('item/agentMessage/delta', {
+        threadId: 'thread-2',
+        turnId: 'turn-2',
+        itemId: 'msg',
+        delta: 'wrong run',
+      }),
+    ).toEqual([]);
+    expect(translator.translate('future/notification', { value: 1 })).toEqual([]);
+    expect(translator.protocolDrift()).toEqual({ unknownEvents: 1, anomalies: 1 });
+  });
+});

--- a/tests/unit/agent/codex-app-server-lean.test.ts
+++ b/tests/unit/agent/codex-app-server-lean.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { buildLeanAppServerArgs } from '../../../src/agent/codex/app-server-lean.js';
+
+describe('buildLeanAppServerArgs', () => {
+  it('disables MCP, Apps, plugins, browser/computer-use, permissions, and hooks locally', () => {
+    const args = buildLeanAppServerArgs({
+      mcp_servers: {
+        'z.http': {
+          url: 'https://secret.example.invalid/mcp',
+          http_headers: { Authorization: 'Bearer fake-secret' },
+        },
+        'a"stdio\\server': {
+          command: '/private/original-command',
+          args: ['--token', 'fake-secret'],
+          env: { TOKEN: 'fake-secret' },
+        },
+      },
+    });
+
+    expect(args.slice(0, 3)).toEqual(['app-server', '--listen', 'stdio://']);
+    expect(args).toContain('notify=[]');
+    expect(args).toContain('include_apps_instructions=false');
+    for (const feature of [
+      'apps',
+      'enable_mcp_apps',
+      'plugins',
+      'remote_plugin',
+      'plugin_sharing',
+      'skill_mcp_dependency_install',
+      'tool_call_mcp_elicitation',
+      'tool_suggest',
+      'browser_use',
+      'browser_use_external',
+      'browser_use_full_cdp_access',
+      'in_app_browser',
+      'computer_use',
+      'request_permissions_tool',
+      'hooks',
+    ]) {
+      expect(hasDisabledFeature(args, feature)).toBe(true);
+    }
+    expect(hasDisabledFeature(args, 'memories')).toBe(false);
+
+    const override = args.find((arg) => arg.startsWith('mcp_servers={'));
+    expect(override).toBe(
+      'mcp_servers={"a\\"stdio\\\\server"={enabled=false,command="disabled-by-lark-channel-bridge"},"z.http"={enabled=false,url="http://127.0.0.1"}}',
+    );
+    const serialized = args.join('\n');
+    expect(serialized).not.toContain('/private/original-command');
+    expect(serialized).not.toContain('secret.example.invalid');
+    expect(serialized).not.toContain('fake-secret');
+  });
+
+  it('omits an MCP override when the effective inventory is empty or damaged', () => {
+    expect(buildLeanAppServerArgs().some((arg) => arg.startsWith('mcp_servers={'))).toBe(false);
+    expect(
+      buildLeanAppServerArgs({ mcp_servers: [] }).some((arg) =>
+        arg.startsWith('mcp_servers={'),
+      ),
+    ).toBe(false);
+  });
+});
+
+function hasDisabledFeature(args: string[], feature: string): boolean {
+  return args.some((arg, index) => arg === '--disable' && args[index + 1] === feature);
+}

--- a/tests/unit/agent/codex-app-server-lean.test.ts
+++ b/tests/unit/agent/codex-app-server-lean.test.ts
@@ -4,6 +4,23 @@ import { buildLeanAppServerArgs } from '../../../src/agent/codex/app-server-lean
 describe('buildLeanAppServerArgs', () => {
   it('disables MCP, Apps, plugins, browser/computer-use, permissions, and hooks locally', () => {
     const args = buildLeanAppServerArgs({
+      features: [
+        'apps',
+        'enable_mcp_apps',
+        'plugins',
+        'remote_plugin',
+        'plugin_sharing',
+        'skill_mcp_dependency_install',
+        'tool_call_mcp_elicitation',
+        'tool_suggest',
+        'browser_use',
+        'browser_use_external',
+        'browser_use_full_cdp_access',
+        'in_app_browser',
+        'computer_use',
+        'request_permissions_tool',
+        'hooks',
+      ],
       mcp_servers: {
         'z.http': {
           url: 'https://secret.example.invalid/mcp',
@@ -59,8 +76,18 @@ describe('buildLeanAppServerArgs', () => {
       ),
     ).toBe(false);
   });
+
+  it('only disables feature flags reported by the running Codex binary', () => {
+    const args = buildLeanAppServerArgs({ features: ['apps', 'hooks', 'unrelated_feature'] });
+
+    expect(disabledFeatures(args)).toEqual(['apps', 'hooks']);
+  });
 });
 
 function hasDisabledFeature(args: string[], feature: string): boolean {
   return args.some((arg, index) => arg === '--disable' && args[index + 1] === feature);
+}
+
+function disabledFeatures(args: string[]): string[] {
+  return args.flatMap((arg, index) => arg === '--disable' ? [args[index + 1] ?? ''] : []);
 }

--- a/tests/unit/agent/codex-prepare-run.test.ts
+++ b/tests/unit/agent/codex-prepare-run.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
+import { CodexAppServerAdapter } from '../../../src/agent/codex/app-server-adapter.js';
 import { CodexAdapter } from '../../../src/agent/codex/adapter.js';
 import { writeVersionExecutable } from '../../helpers/fake-executable.js';
 
@@ -34,6 +35,42 @@ describe('CodexAdapter prepareRun', () => {
         code: 'agent-binary-not-found',
         agentId: 'codex',
         agentName: 'Codex CLI',
+      },
+    });
+  });
+});
+
+describe('CodexAppServerAdapter availability', () => {
+  afterEach(async () => {
+    await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+  });
+
+  it('checks that the configured binary exposes the app-server subcommand', async () => {
+    const binary = await writeCodexBinary('Run the app server');
+    const adapter = new CodexAppServerAdapter({
+      binary,
+      profileStateDir: join(tmpdir(), 'codex-app-server-profile'),
+    });
+
+    await expect(adapter.checkAvailability()).resolves.toMatchObject({
+      ok: true,
+      version: 'Run the app server',
+    });
+  });
+
+  it('includes app-server help args in a missing-binary diagnostic', async () => {
+    const adapter = new CodexAppServerAdapter({
+      binary: join(tmpdir(), 'missing-codex-app-server'),
+      profileStateDir: join(tmpdir(), 'codex-app-server-profile'),
+    });
+
+    await expect(adapter.checkAvailability()).resolves.toMatchObject({
+      ok: false,
+      diagnostic: {
+        code: 'agent-binary-not-found',
+        agentId: 'codex',
+        agentName: 'Codex App Server',
+        args: ['app-server', '--help'],
       },
     });
   });

--- a/tests/unit/agent/codex-prepare-run.test.ts
+++ b/tests/unit/agent/codex-prepare-run.test.ts
@@ -46,7 +46,7 @@ describe('CodexAppServerAdapter availability', () => {
   });
 
   it('checks that the configured binary exposes the app-server subcommand', async () => {
-    const binary = await writeCodexBinary('Run the app server');
+    const binary = await writeCodexBinary('Run the app server\napps stable true');
     const adapter = new CodexAppServerAdapter({
       binary,
       profileStateDir: join(tmpdir(), 'codex-app-server-profile'),

--- a/tests/unit/bot/thread-name.test.ts
+++ b/tests/unit/bot/thread-name.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { buildBridgeThreadName } from '../../../src/bot/thread-name.js';
+
+describe('buildBridgeThreadName', () => {
+  it('collapses whitespace and keeps the visible user text', () => {
+    expect(buildBridgeThreadName('飞书', '  帮我\n\n检查   这个项目  ')).toBe(
+      '飞书 · 帮我 检查 这个项目',
+    );
+  });
+
+  it('uses a readable fallback and truncates by Unicode characters', () => {
+    expect(buildBridgeThreadName('飞书评论', '   ')).toBe('飞书评论 · 新会话');
+    const title = buildBridgeThreadName('飞书', '测'.repeat(200));
+    expect(Array.from(title)).toHaveLength(96);
+    expect(title.endsWith('…')).toBe(true);
+  });
+});

--- a/tests/unit/cli/codex-task-execution.test.ts
+++ b/tests/unit/cli/codex-task-execution.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({ send: vi.fn() }));
+
+vi.mock('../../../src/codex-task/context', () => ({
+  resolveCodexTaskContext: vi.fn(async () => ({
+    controller: { send: mocks.send },
+  })),
+}));
+
+import { runCodexTaskSend } from '../../../src/cli/commands/codex-task';
+
+describe('codex-task execution CLI contract', () => {
+  let originalExitCode: typeof process.exitCode;
+
+  beforeEach(() => {
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    mocks.send.mockReset();
+    vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it('prints timeout as incomplete and sets a non-zero exit code', async () => {
+    mocks.send.mockResolvedValue(executionResult('timeout'));
+
+    await runCodexTaskSend('T-A1B2C3', { message: 'long task' });
+
+    expect(process.exitCode).toBe(1);
+    const output = vi.mocked(console.log).mock.calls.flat().map(String).join('\n');
+    expect(output).toContain('✗ T-A1B2C3 Worker');
+    expect(output).not.toContain('✓ T-A1B2C3 Worker');
+  });
+
+  it('keeps durable and candidate thread ids out of JSON output', async () => {
+    const result = executionResult('normal');
+    Object.assign(result.task, {
+      threadId: 'thread-durable',
+      candidateThreadId: 'thread-private-candidate',
+    });
+    mocks.send.mockResolvedValue(result);
+
+    await runCodexTaskSend('T-A1B2C3', { message: 'inspect output', json: true });
+
+    const payload = JSON.parse(String(vi.mocked(console.log).mock.calls[0]?.[0])) as {
+      task: Record<string, unknown>;
+    };
+    expect(payload.task).not.toHaveProperty('threadId');
+    expect(payload.task).not.toHaveProperty('candidateThreadId');
+  });
+
+  it('maps SIGINT to AbortSignal, cleans listeners, and preserves exit 130', async () => {
+    const originalListeners = new Set(process.listeners('SIGINT'));
+    mocks.send.mockImplementation(async (
+      _handle: string,
+      input: { signal?: AbortSignal },
+    ) => {
+      expect(input.signal).toBeDefined();
+      const handler = process.listeners('SIGINT').find((listener) => !originalListeners.has(listener));
+      expect(handler).toBeDefined();
+      handler!('SIGINT');
+      expect(input.signal?.aborted).toBe(true);
+      return executionResult('interrupted');
+    });
+
+    await runCodexTaskSend('T-A1B2C3', { message: 'interrupt me' });
+
+    expect(process.exitCode).toBe(130);
+    expect(process.listeners('SIGINT')).toEqual([...originalListeners]);
+  });
+});
+
+function executionResult(terminationReason: 'normal' | 'interrupted' | 'timeout') {
+  return {
+    task: {
+      handle: 'T-A1B2C3',
+      title: 'Worker',
+      cwd: '/tmp/worker',
+      status: terminationReason === 'normal' ? 'completed' : terminationReason,
+      createdAt: '2026-08-01T00:00:00.000Z',
+      updatedAt: '2026-08-01T00:00:01.000Z',
+    },
+    output: '',
+    terminationReason,
+    registrySync: 'synced' as const,
+  };
+}

--- a/tests/unit/cli/codex-task-read.test.ts
+++ b/tests/unit/cli/codex-task-read.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { runCodexTaskRead } from '../../../src/cli/commands/codex-task';
+
+describe('codex-task read CLI validation', () => {
+  it.each(['', '0', '51', '1.5', '5messages'])(
+    'rejects a non-integer or out-of-range --limit before resolving profile state: %j',
+    async (limit) => {
+      await expect(runCodexTaskRead('T-A1B2C3', {
+        rootDir: '/profile-state-must-not-be-read',
+        limit,
+      })).rejects.toThrow('--limit must be an integer between 1 and 50');
+    },
+  );
+});

--- a/tests/unit/cli/index-registration.test.ts
+++ b/tests/unit/cli/index-registration.test.ts
@@ -16,4 +16,21 @@ describe('CLI command registration', () => {
     const appSecretOptions = source.match(/--app-secret <secret>/g) ?? [];
     expect(appSecretOptions.length).toBeGreaterThanOrEqual(3);
   });
+
+  it('registers Codex transport for every profile bootstrap entry point', async () => {
+    const source = await readFile(join(process.cwd(), 'src', 'cli', 'index.ts'), 'utf8');
+
+    const transportOptions = source.match(/--codex-transport <transport>/g) ?? [];
+    expect(transportOptions).toHaveLength(4);
+    expect(source).toContain('exec or app-server; default exec');
+  });
+
+  it('registers the controller workspace Codex task command group', async () => {
+    const source = await readFile(join(process.cwd(), 'src', 'cli', 'index.ts'), 'utf8');
+
+    expect(source).toMatch(/\.command\(['"]codex-task['"]\)/);
+    for (const subcommand of ['init', 'list', 'create', 'read <handle>', 'send <handle>']) {
+      expect(source).toContain(`.command('${subcommand}')`);
+    }
+  });
 });

--- a/tests/unit/cli/index-registration.test.ts
+++ b/tests/unit/cli/index-registration.test.ts
@@ -32,5 +32,6 @@ describe('CLI command registration', () => {
     for (const subcommand of ['init', 'list', 'create', 'read <handle>', 'send <handle>']) {
       expect(source).toContain(`.command('${subcommand}')`);
     }
+    expect(source.match(/\.option\('-c, --config <path>'/g)).toHaveLength(7);
   });
 });

--- a/tests/unit/cli/service-profile.test.ts
+++ b/tests/unit/cli/service-profile.test.ts
@@ -104,6 +104,10 @@ describe('profile-aware service commands', () => {
         },
         agentKind: 'codex',
       },
+      profileConfig: {
+        agentKind: 'codex',
+        codex: { binaryPath: '/opt/homebrew/bin/codex', transport: 'app-server' },
+      },
     });
     mocks.checkRuntimeLock.mockResolvedValue({ locked: false });
     mocks.readActiveProfile.mockResolvedValue('codex-dev');
@@ -132,13 +136,18 @@ describe('profile-aware service commands', () => {
         }),
       ]);
 
-    await runServiceStart({ profile: 'codex-dev', skipCheckLarkCli: true });
+    await runServiceStart({
+      profile: 'codex-dev',
+      codexTransport: 'app-server',
+      skipCheckLarkCli: true,
+    });
 
     // Classic per-profile service pins `run --profile <profile>`.
     expect(mocks.getServiceAdapter).toHaveBeenCalledWith('codex-dev', ['run', '--profile', 'codex-dev']);
     expect(mocks.resolveProfileRuntime).toHaveBeenNthCalledWith(1, expect.objectContaining({
       profile: 'codex-dev',
       agent: undefined,
+      codexTransport: 'app-server',
       workspace: undefined,
       appId: undefined,
       appSecret: undefined,
@@ -163,6 +172,10 @@ describe('profile-aware service commands', () => {
         },
         agentKind: 'codex',
       }),
+      profileConfig: expect.objectContaining({
+        agentKind: 'codex',
+        codex: expect.objectContaining({ transport: 'app-server' }),
+      }),
       appPaths: expect.objectContaining({
         profile: 'codex-dev',
         rootDir: '/tmp/lark-channel-home',
@@ -180,7 +193,7 @@ describe('profile-aware service commands', () => {
     expect(mocks.adapter.install).toHaveBeenCalled();
     expect(mocks.adapter.start).toHaveBeenCalled();
     expect(lines).toContain(
-      '✓ 已启动  bot: Codex Bot (cli_codex)  agent: Codex CLI (codex)  进程: p1',
+      '✓ 已启动  bot: Codex Bot (cli_codex)  agent: Codex App Server (codex)  进程: p1',
     );
   });
 

--- a/tests/unit/cli/start-agent-factory.test.ts
+++ b/tests/unit/cli/start-agent-factory.test.ts
@@ -60,6 +60,20 @@ describe('start runtime agent factory', () => {
     expect(agent.displayName).toBe('Codex CLI');
   });
 
+  it('selects the App Server adapter only for an explicit Codex transport', () => {
+    const profile = createDefaultProfileConfig({
+      agentKind: 'codex',
+      accounts: appAccount(),
+      codex: { binaryPath: '/usr/local/bin/codex', transport: 'app-server' },
+    });
+    const agent = createRuntimeAgent(profile, {
+      profileDir: '/tmp/lark-channel-bridge/profiles/codex-app-server',
+    });
+
+    expect(agent.id).toBe('codex');
+    expect(agent.displayName).toBe('Codex App Server');
+  });
+
   it('seeds a default Codex binary when bootstrapping a new Codex profile', () => {
     const profile = createRuntimeProfileConfig({
       agentKind: 'codex',

--- a/tests/unit/codex-task/context.test.ts
+++ b/tests/unit/codex-task/context.test.ts
@@ -1,0 +1,68 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolveCodexTaskContext } from '../../../src/codex-task/context';
+import { resolveAppPaths } from '../../../src/config/app-paths';
+import {
+  createDefaultProfileConfig,
+  type ProfileConfig,
+  type RootConfig,
+} from '../../../src/config/profile-schema';
+import { saveRootConfig, writeActiveProfile } from '../../../src/config/profile-store';
+
+describe('resolveCodexTaskContext', () => {
+  const cleanup: string[] = [];
+  const originalProfile = process.env.LARK_CHANNEL_PROFILE;
+
+  afterEach(async () => {
+    if (originalProfile === undefined) delete process.env.LARK_CHANNEL_PROFILE;
+    else process.env.LARK_CHANNEL_PROFILE = originalProfile;
+    await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+  });
+
+  it('uses explicit profile, then bridge environment, then active-profile without rewriting config', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'codex-task-context-'));
+    cleanup.push(rootDir);
+    const root: RootConfig = {
+      schemaVersion: 2,
+      activeProfile: 'root-default',
+      preferences: {},
+      profiles: {
+        explicit: profile(),
+        environment: profile(),
+        active: profile(),
+        'root-default': profile(),
+      },
+    };
+    const configPath = resolveAppPaths({ rootDir }).configFile;
+    await saveRootConfig(root, configPath);
+    await writeActiveProfile(rootDir, 'active');
+    const before = await readFile(configPath, 'utf8');
+    process.env.LARK_CHANNEL_PROFILE = 'environment';
+
+    await expect(resolveCodexTaskContext({ rootDir, profile: 'explicit' })).resolves.toMatchObject({
+      profile: 'explicit',
+    });
+    await expect(resolveCodexTaskContext({ rootDir })).resolves.toMatchObject({
+      profile: 'environment',
+    });
+    delete process.env.LARK_CHANNEL_PROFILE;
+    await expect(resolveCodexTaskContext({ rootDir })).resolves.toMatchObject({
+      profile: 'active',
+    });
+    expect(await readFile(configPath, 'utf8')).toBe(before);
+  });
+});
+
+function profile(): ProfileConfig {
+  return createDefaultProfileConfig({
+    agentKind: 'codex',
+    accounts: { app: { id: 'cli_test', secret: 'test-secret', tenant: 'feishu' } },
+    codex: {
+      binaryPath: 'codex',
+      transport: 'app-server',
+      inheritCodexHome: true,
+    },
+  });
+}

--- a/tests/unit/codex-task/context.test.ts
+++ b/tests/unit/codex-task/context.test.ts
@@ -14,10 +14,13 @@ import { saveRootConfig, writeActiveProfile } from '../../../src/config/profile-
 describe('resolveCodexTaskContext', () => {
   const cleanup: string[] = [];
   const originalProfile = process.env.LARK_CHANNEL_PROFILE;
+  const originalBridgeConfig = process.env.LARK_CHANNEL_BRIDGE_CONFIG;
 
   afterEach(async () => {
     if (originalProfile === undefined) delete process.env.LARK_CHANNEL_PROFILE;
     else process.env.LARK_CHANNEL_PROFILE = originalProfile;
+    if (originalBridgeConfig === undefined) delete process.env.LARK_CHANNEL_BRIDGE_CONFIG;
+    else process.env.LARK_CHANNEL_BRIDGE_CONFIG = originalBridgeConfig;
     await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
   });
 
@@ -52,6 +55,28 @@ describe('resolveCodexTaskContext', () => {
       profile: 'active',
     });
     expect(await readFile(configPath, 'utf8')).toBe(before);
+  });
+
+  it('loads the exact custom Bridge config passed explicitly or inherited from the Bridge', async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), 'codex-task-context-custom-'));
+    cleanup.push(rootDir);
+    const customConfig = join(rootDir, 'custom.json');
+    await saveRootConfig({
+      schemaVersion: 2,
+      activeProfile: 'custom',
+      preferences: {},
+      profiles: { custom: profile() },
+    }, customConfig);
+
+    process.env.LARK_CHANNEL_BRIDGE_CONFIG = customConfig;
+    await expect(resolveCodexTaskContext({})).resolves.toMatchObject({
+      profile: 'custom',
+      configPath: customConfig,
+    });
+    await expect(resolveCodexTaskContext({ config: customConfig })).resolves.toMatchObject({
+      profile: 'custom',
+      configPath: customConfig,
+    });
   });
 });
 

--- a/tests/unit/codex-task/registry.test.ts
+++ b/tests/unit/codex-task/registry.test.ts
@@ -71,6 +71,57 @@ describe('CodexTaskRegistry', () => {
     expect(await registry.list()).toHaveLength(1);
   });
 
+  it('persists pending thread import and turn reconciliation records', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'codex-task-registry-'));
+    cleanup.push(dir);
+    const dates = [
+      new Date('2026-07-31T08:00:00.000Z'),
+      new Date('2026-07-31T08:00:01.000Z'),
+      new Date('2026-07-31T08:00:02.000Z'),
+      new Date('2026-07-31T08:00:03.000Z'),
+      new Date('2026-07-31T08:00:04.000Z'),
+    ];
+    const registry = new CodexTaskRegistry(
+      join(dir, 'codex-tasks.json'),
+      () => dates.shift()!,
+      () => 'T-C0FFEE',
+    );
+
+    const pending = await registry.reserve({ title: 'Pending worker', cwd: '/tmp/pending' });
+    expect(pending).toMatchObject({ handle: 'T-C0FFEE', status: 'pending' });
+    expect(pending.threadId).toBeUndefined();
+
+    await expect(registry.importThread(pending.handle, 'thread-durable')).resolves.toMatchObject({
+      status: 'pending',
+      threadId: 'thread-durable',
+    });
+    await expect(registry.markReconcile(pending.handle, {
+      desiredStatus: 'completed',
+      error: 'simulated final write failure',
+      threadId: 'thread-durable',
+      lastTurnId: 'turn-durable',
+      lastResult: 'done once',
+    })).resolves.toMatchObject({
+      status: 'reconcile',
+      reconciliation: {
+        desiredStatus: 'completed',
+        lastTurnId: 'turn-durable',
+      },
+    });
+    await expect(registry.reconcile(pending.handle)).resolves.toEqual([
+      expect.objectContaining({
+        status: 'completed',
+        threadId: 'thread-durable',
+        lastTurnId: 'turn-durable',
+        lastResult: 'done once',
+      }),
+    ]);
+
+    await expect(registry.update(pending.handle, { status: 'running' })).resolves.not.toHaveProperty(
+      'lastTurnId',
+    );
+  });
+
   it('serializes concurrent writers without losing updates', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'codex-task-registry-'));
     cleanup.push(dir);

--- a/tests/unit/codex-task/registry.test.ts
+++ b/tests/unit/codex-task/registry.test.ts
@@ -1,0 +1,132 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { CodexTaskRegistry } from '../../../src/codex-task/registry';
+
+describe('CodexTaskRegistry', () => {
+  const cleanup: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+  });
+
+  it('registers, resolves, updates, and persists stable opaque handles', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'codex-task-registry-'));
+    cleanup.push(dir);
+    const path = join(dir, 'codex-tasks.json');
+    const dates = [
+      new Date('2026-07-31T08:00:00.000Z'),
+      new Date('2026-07-31T08:01:00.000Z'),
+    ];
+    const registry = new CodexTaskRegistry(path, () => dates.shift()!, () => 'T-A1B2C3');
+
+    const created = await registry.register({
+      threadId: 'thread-1',
+      title: ' Worker One ',
+      cwd: '/tmp/project',
+      model: 'gpt-test',
+    });
+    expect(created).toEqual({
+      handle: 'T-A1B2C3',
+      threadId: 'thread-1',
+      title: 'Worker One',
+      cwd: '/tmp/project',
+      model: 'gpt-test',
+      status: 'idle',
+      createdAt: '2026-07-31T08:00:00.000Z',
+      updatedAt: '2026-07-31T08:00:00.000Z',
+    });
+    expect(await registry.get('t-a1b2c3')).toEqual(created);
+
+    const updated = await registry.update('T-A1B2C3', {
+      status: 'completed',
+      lastResult: 'done',
+    });
+    expect(updated).toMatchObject({
+      handle: 'T-A1B2C3',
+      status: 'completed',
+      lastResult: 'done',
+      updatedAt: '2026-07-31T08:01:00.000Z',
+    });
+    expect(JSON.parse(await readFile(path, 'utf8'))).toEqual({
+      schemaVersion: 1,
+      tasks: [updated],
+    });
+  });
+
+  it('reuses a handle when the same durable thread is registered again', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'codex-task-registry-'));
+    cleanup.push(dir);
+    const registry = new CodexTaskRegistry(
+      join(dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-ABCDEF',
+    );
+    const first = await registry.register({ threadId: 'thread-1', title: 'First', cwd: '/tmp/a' });
+    const second = await registry.register({ threadId: 'thread-1', title: 'Renamed', cwd: '/tmp/b' });
+
+    expect(second.handle).toBe(first.handle);
+    expect(second).toMatchObject({ title: 'Renamed', cwd: '/tmp/b' });
+    expect(await registry.list()).toHaveLength(1);
+  });
+
+  it('serializes concurrent writers without losing updates', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'codex-task-registry-'));
+    cleanup.push(dir);
+    const path = join(dir, 'codex-tasks.json');
+    const first = new CodexTaskRegistry(
+      path,
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-AAAAAA',
+    );
+    const second = new CodexTaskRegistry(
+      path,
+      () => new Date('2026-07-31T08:00:01.000Z'),
+      () => 'T-BBBBBB',
+    );
+
+    const [left, right] = await Promise.all([
+      first.register({ threadId: 'thread-left', title: 'Left', cwd: '/tmp/left' }),
+      second.register({ threadId: 'thread-right', title: 'Right', cwd: '/tmp/right' }),
+    ]);
+
+    expect(new Set([left.handle, right.handle])).toEqual(new Set(['T-AAAAAA', 'T-BBBBBB']));
+    expect(await first.list()).toHaveLength(2);
+  });
+
+  it('retries an opaque handle collision while holding the registry lock', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'codex-task-registry-'));
+    cleanup.push(dir);
+    const path = join(dir, 'codex-tasks.json');
+    const first = new CodexTaskRegistry(
+      path,
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => 'T-ABCDEF',
+    );
+    await first.register({ threadId: 'thread-left', title: 'Left', cwd: '/tmp/left' });
+    const handles = ['T-ABCDEF', 'T-123456'];
+    const second = new CodexTaskRegistry(
+      path,
+      () => new Date('2026-07-31T08:00:01.000Z'),
+      () => handles.shift()!,
+    );
+
+    await expect(second.register({
+      threadId: 'thread-right',
+      title: 'Right',
+      cwd: '/tmp/right',
+    })).resolves.toMatchObject({ handle: 'T-123456' });
+  });
+
+  it('fails closed on damaged data and rejects malformed handles', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'codex-task-registry-'));
+    cleanup.push(dir);
+    const path = join(dir, 'codex-tasks.json');
+    await writeFile(path, JSON.stringify([{ handle: 'bad', threadId: 'thread-1' }]), 'utf8');
+    const registry = new CodexTaskRegistry(path);
+
+    await expect(registry.list()).rejects.toThrow(/invalid Codex task registry/);
+    await expect(registry.get('../bad')).rejects.toThrow(/invalid Codex task handle/);
+  });
+});

--- a/tests/unit/codex-task/registry.test.ts
+++ b/tests/unit/codex-task/registry.test.ts
@@ -80,6 +80,8 @@ describe('CodexTaskRegistry', () => {
       new Date('2026-07-31T08:00:02.000Z'),
       new Date('2026-07-31T08:00:03.000Z'),
       new Date('2026-07-31T08:00:04.000Z'),
+      new Date('2026-07-31T08:00:05.000Z'),
+      new Date('2026-07-31T08:00:06.000Z'),
     ];
     const registry = new CodexTaskRegistry(
       join(dir, 'codex-tasks.json'),
@@ -91,10 +93,16 @@ describe('CodexTaskRegistry', () => {
     expect(pending).toMatchObject({ handle: 'T-C0FFEE', status: 'pending' });
     expect(pending.threadId).toBeUndefined();
 
+    await registry.update(pending.handle, { status: 'running' });
+    await expect(registry.setThreadCandidate(pending.handle, 'thread-durable')).resolves.toMatchObject({
+      status: 'running',
+      candidateThreadId: 'thread-durable',
+    });
     await expect(registry.importThread(pending.handle, 'thread-durable')).resolves.toMatchObject({
-      status: 'pending',
+      status: 'running',
       threadId: 'thread-durable',
     });
+    await expect(registry.get(pending.handle)).resolves.not.toHaveProperty('candidateThreadId');
     await expect(registry.markReconcile(pending.handle, {
       desiredStatus: 'completed',
       error: 'simulated final write failure',
@@ -119,6 +127,32 @@ describe('CodexTaskRegistry', () => {
 
     await expect(registry.update(pending.handle, { status: 'running' })).resolves.not.toHaveProperty(
       'lastTurnId',
+    );
+  });
+
+  it('keeps candidate and durable thread ownership unique across handles', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'codex-task-registry-'));
+    cleanup.push(dir);
+    const handles = ['T-CA11D0', 'T-CA11D1'];
+    const registry = new CodexTaskRegistry(
+      join(dir, 'codex-tasks.json'),
+      () => new Date('2026-07-31T08:00:00.000Z'),
+      () => handles.shift()!,
+    );
+    const first = await registry.reserve({ title: 'First', cwd: '/tmp/first' });
+    const second = await registry.reserve({ title: 'Second', cwd: '/tmp/second' });
+
+    await registry.setThreadCandidate(first.handle, 'thread-shared');
+    await expect(registry.setThreadCandidate(second.handle, 'thread-shared')).rejects.toThrow(
+      /thread-shared.*T-CA11D0/i,
+    );
+    await expect(registry.importThread(second.handle, 'thread-shared')).rejects.toThrow(
+      /thread-shared.*T-CA11D0/i,
+    );
+
+    await registry.importThread(first.handle, 'thread-shared');
+    await expect(registry.setThreadCandidate(second.handle, 'thread-shared')).rejects.toThrow(
+      /thread-shared.*T-CA11D0/i,
     );
   });
 

--- a/tests/unit/codex-task/workspace.test.ts
+++ b/tests/unit/codex-task/workspace.test.ts
@@ -1,0 +1,43 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { initializeControllerWorkspace } from '../../../src/codex-task/workspace';
+
+describe('initializeControllerWorkspace', () => {
+  const cleanup: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+  });
+
+  it('installs a concise AGENTS.md and repo-scoped Codex task skill', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'codex-controller-workspace-'));
+    cleanup.push(workspace);
+
+    const result = await initializeControllerWorkspace({ workspace });
+    const agentsPath = join(workspace, 'AGENTS.md');
+    const skillPath = join(workspace, '.agents', 'skills', 'codex-task-controller', 'SKILL.md');
+    expect(result).toEqual({ workspace, created: [agentsPath, skillPath], skipped: [] });
+    expect(await readFile(agentsPath, 'utf8')).toContain('主 task 的 cwd 始终保持为本目录');
+    const skill = await readFile(skillPath, 'utf8');
+    expect(skill).toContain('name: codex-task-controller');
+    expect(skill).toContain('lark-channel-bridge codex-task send');
+    expect(skill).toContain('Never edit Codex rollout JSONL');
+  });
+
+  it('preserves existing local instructions unless force is explicit', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'codex-controller-workspace-'));
+    cleanup.push(workspace);
+    const agentsPath = join(workspace, 'AGENTS.md');
+    await writeFile(agentsPath, 'local instructions\n', 'utf8');
+
+    const first = await initializeControllerWorkspace({ workspace });
+    expect(first.skipped).toContain(agentsPath);
+    expect(await readFile(agentsPath, 'utf8')).toBe('local instructions\n');
+
+    const forced = await initializeControllerWorkspace({ workspace, force: true });
+    expect(forced.created).toContain(agentsPath);
+    expect(await readFile(agentsPath, 'utf8')).toContain('飞书 Codex 主控工作区');
+  });
+});

--- a/tests/unit/codex-task/workspace.test.ts
+++ b/tests/unit/codex-task/workspace.test.ts
@@ -25,7 +25,11 @@ describe('initializeControllerWorkspace', () => {
     expect(skill).toContain('lark-channel-bridge codex-task send');
     expect(skill).toContain('Never edit Codex rollout JSONL');
     expect(skill).toContain('LARK_CHANNEL_BRIDGE_CONFIG');
-    expect(skill).toContain('"${bridge_config_args[@]}"');
+    expect(skill).toContain('<config-option>');
+    expect(skill).toContain('PowerShell');
+    expect(skill).toContain('pending worker handle');
+    expect(skill).not.toContain('bridge_config_args');
+    expect(skill).not.toContain('[[ ');
   });
 
   it('uses atomic no-clobber creation when initializers race without --force', async () => {

--- a/tests/unit/codex-task/workspace.test.ts
+++ b/tests/unit/codex-task/workspace.test.ts
@@ -24,6 +24,25 @@ describe('initializeControllerWorkspace', () => {
     expect(skill).toContain('name: codex-task-controller');
     expect(skill).toContain('lark-channel-bridge codex-task send');
     expect(skill).toContain('Never edit Codex rollout JSONL');
+    expect(skill).toContain('LARK_CHANNEL_BRIDGE_CONFIG');
+    expect(skill).toContain('"${bridge_config_args[@]}"');
+  });
+
+  it('uses atomic no-clobber creation when initializers race without --force', async () => {
+    const workspace = await mkdtemp(join(tmpdir(), 'codex-controller-workspace-race-'));
+    cleanup.push(workspace);
+
+    const results = await Promise.all(Array.from(
+      { length: 8 },
+      () => initializeControllerWorkspace({ workspace }),
+    ));
+    const agentsPath = join(workspace, 'AGENTS.md');
+    const skillPath = join(workspace, '.agents', 'skills', 'codex-task-controller', 'SKILL.md');
+
+    expect(results.flatMap((result) => result.created).filter((path) => path === agentsPath)).toHaveLength(1);
+    expect(results.flatMap((result) => result.created).filter((path) => path === skillPath)).toHaveLength(1);
+    expect(results.flatMap((result) => result.skipped).filter((path) => path === agentsPath)).toHaveLength(7);
+    expect(results.flatMap((result) => result.skipped).filter((path) => path === skillPath)).toHaveLength(7);
   });
 
   it('preserves existing local instructions unless force is explicit', async () => {

--- a/tests/unit/config/app-paths.test.ts
+++ b/tests/unit/config/app-paths.test.ts
@@ -42,6 +42,7 @@ describe('resolveAppPaths', () => {
     expect(paths.profileDir).toBe(profileDir);
     expect(paths.defaultWorkspaceDir).toBe(join(`${root}-workspaces`, 'claude', 'default'));
     expect(paths.sessionsFile).toBe(join(profileDir, 'sessions.json'));
+    expect(paths.codexTasksFile).toBe(join(profileDir, 'codex-tasks.json'));
     expect(paths.workspacesFile).toBe(join(profileDir, 'workspaces.json'));
     expect(paths.secretsFile).toBe(join(profileDir, 'secrets.enc'));
     expect(paths.keystoreSaltFile).toBe(join(profileDir, '.keystore.salt'));

--- a/tests/unit/config/profile-schema.test.ts
+++ b/tests/unit/config/profile-schema.test.ts
@@ -4,7 +4,9 @@ import {
   clampAccess,
 } from '../../../src/config/permissions';
 import {
+  codexTransportFromString,
   createDefaultProfileConfig,
+  effectiveCodexTransport,
   effectiveLarkCliIdentity,
   normalizeProfileConfig,
 } from '../../../src/config/profile-schema';
@@ -308,6 +310,37 @@ describe('profile schema', () => {
       ignoreRules: true,
     });
     expect(cfg.codex).not.toHaveProperty('flags');
+    expect(effectiveCodexTransport(cfg.codex)).toBe('exec');
+    expect(cfg.codex).not.toHaveProperty('transport');
+  });
+
+  it('preserves an explicit Codex app-server transport and rejects invalid values', () => {
+    const cfg = normalizeProfileConfig({
+      schemaVersion: 2,
+      agentKind: 'codex',
+      accounts: { app },
+      codex: {
+        binaryPath: '/usr/local/bin/codex',
+        transport: 'app-server',
+      },
+    });
+
+    expect(cfg.codex?.transport).toBe('app-server');
+    expect(effectiveCodexTransport(cfg.codex)).toBe('app-server');
+    expect(codexTransportFromString('exec')).toBe('exec');
+    expect(codexTransportFromString('app-server')).toBe('app-server');
+    expect(() => codexTransportFromString('desktop')).toThrow(/unsupported Codex transport/);
+    expect(() =>
+      normalizeProfileConfig({
+        schemaVersion: 2,
+        agentKind: 'codex',
+        accounts: { app },
+        codex: {
+          binaryPath: '/usr/local/bin/codex',
+          transport: 'desktop',
+        },
+      }),
+    ).toThrow(/codex\.transport must be exec or app-server/);
   });
 
   it('preserves explicit Codex home isolation when configured', () => {

--- a/tests/unit/config/profile-store.test.ts
+++ b/tests/unit/config/profile-store.test.ts
@@ -56,6 +56,7 @@ describe('profile store canonical serialization', () => {
         },
         codex: {
           binaryPath: '/usr/local/bin/codex',
+          transport: 'app-server',
           codexHome: '/tmp/codex-home',
           inheritCodexHome: false,
         },

--- a/tests/unit/docs/readme-contract.test.ts
+++ b/tests/unit/docs/readme-contract.test.ts
@@ -26,6 +26,11 @@ describe('README runtime contract', () => {
       'pnpm test',
       'pnpm typecheck',
       'pnpm build',
+      '--codex-transport app-server',
+      'Codex Desktop sidebar',
+      'process-local lean overrides',
+      '局部 lean override',
+      '/model',
     ]) {
       expect(docs).toContain(phrase);
     }
@@ -90,6 +95,23 @@ describe('README runtime contract', () => {
     expect(docs).toContain('legacy `sandbox`');
     expect(docs).toContain('旧版 `sandbox`');
     expect(docs).not.toContain('"sandbox"');
+  });
+
+  it('documents the controller workspace task MVP in both languages', async () => {
+    const [en, zh] = await Promise.all([
+      readFile(new URL('../../../README.md', import.meta.url), 'utf8'),
+      readFile(new URL('../../../README.zh.md', import.meta.url), 'utf8'),
+    ]);
+
+    for (const docs of [en, zh]) {
+      expect(docs).toContain('lark-channel-bridge codex-task init');
+      expect(docs).toContain('.agents/skills/codex-task-controller/SKILL.md');
+      expect(docs).toContain('codex-tasks.json');
+      expect(docs).toContain('thread/read');
+      expect(docs).toContain('thread/resume');
+    }
+    expect(en).toContain('sequentially');
+    expect(zh).toContain('顺序交接');
   });
 });
 

--- a/tests/unit/session/catalog.test.ts
+++ b/tests/unit/session/catalog.test.ts
@@ -64,6 +64,47 @@ describe('agent-aware session catalog', () => {
     await catalog.flush();
   });
 
+  it('persists the actual model for the same conversation without leaking it to another thread', async () => {
+    const catalogPath = await path();
+    const catalog = new SessionCatalog(catalogPath);
+    const identity = {
+      scopeId: 'chat-1',
+      agentId: 'codex' as const,
+      cwdRealpath: '/repo',
+      policyFingerprint: 'fp-1',
+    };
+
+    catalog.upsertActive({
+      ...identity,
+      threadId: 'thread-1',
+      model: 'gpt-5.6-luna',
+      now: 1000,
+    });
+    catalog.upsertActive({ ...identity, threadId: 'thread-1', now: 2000 });
+    expect(catalog.activeFor(identity)).toMatchObject({
+      threadId: 'thread-1',
+      model: 'gpt-5.6-luna',
+    });
+
+    catalog.upsertActive({ ...identity, threadId: 'thread-2', now: 3000 });
+    expect(catalog.activeFor(identity)).toMatchObject({ threadId: 'thread-2' });
+    expect(catalog.activeFor(identity)?.model).toBeUndefined();
+
+    catalog.upsertActive({
+      ...identity,
+      threadId: 'thread-2',
+      model: 'gpt-5.6-sol',
+      now: 4000,
+    });
+    await catalog.flush();
+    const reloaded = new SessionCatalog(catalogPath);
+    await reloaded.load();
+    expect(reloaded.activeFor(identity)).toMatchObject({
+      threadId: 'thread-2',
+      model: 'gpt-5.6-sol',
+    });
+  });
+
   it('rejects mismatched Claude/Codex identity fields and does not auto-resume damaged entries', async () => {
     const catalog = new SessionCatalog(await path());
 


### PR DESCRIPTION
## 结果

新增可选的 Codex App Server 传输和 profile 级持久任务控制器，并修正 fresh thread、首个 turn、并发发送、超时中断与子进程回收中的生命周期问题。现有 profile 仍默认使用 `codex exec --json`；只有显式配置 `codex.transport: app-server` 时才启用新路径。

App Server task 现在不会把仅存在于内存、尚未开始首个 turn 的 thread 误报为可恢复任务。首次发送会在同一 App Server 进程中完成 thread 创建与 turn 启动；若响应在边界处丢失，会先核验持久化 candidate，并在结果不确定时 fail closed，避免自动重复执行用户指令。

## 主要变更

- 增加 App Server JSON-RPC client、事件翻译、lean feature/config 探测、MCP 禁用校验和 transport 选择。
- 将 fresh thread 生命周期调整为 `thread/start → turn/start → thread/name/set`；名称设置为 best-effort，不影响已经启动的 turn。
- 空 `codex-task create` 只预留 `pending` handle；首次 `send` 或 `create --message` 在一个 App Server 生命周期内物化 durable thread。
- 使用私有 `candidateThreadId` 覆盖 `thread/start` 成功但 `turn/start` 响应丢失的窗口：只有精确的 `thread/read` not-found 才允许安全重建，其他不确定结果均拒绝自动重发。
- 在获取专用 task execution lock 后重新读取 task 状态；并发发送返回领域错误，不再使用过期 model 或 thread。
- 增加默认 5 分钟 idle watchdog；command、file-change、MCP 等不产生展示事件的 raw progress 同样刷新活动时间。
- 支持 `AbortSignal`、`SIGINT` 和 `SIGTERM`，将状态落为 `interrupted` 并释放锁；timeout/interrupted 使用非零 CLI 退出码。
- resume 使用 `excludeTurns: true`，并按 `threadId`/`turnId` 隔离历史和当前 turn 的 token usage。
- 补齐 MCP elicitation 的 `content: null`、initialize experimental capability，以及带 method/code/data 的 typed RPC error。
- capability、config、control 和 run 子进程统一执行 stdin EOF、`SIGTERM`、`SIGKILL`、等待 close；POSIX 同时清理 process group。
- 生成的 controller Skill 改为 shell-neutral 示例，不再依赖 Bash 数组、`[[ ... ]]` 或数组展开语法。
- 普通 CLI JSON/text 输出隐藏 durable/candidate thread ID；中英文 README 同步最终语义和恢复边界。

## 兼容性和边界

- 现有 Codex exec transport、默认 profile 行为及用户 Codex 配置保持不变。
- lean override 仅作用于当前 App Server 子进程，不会重写用户配置。
- task lock 只协调 Bridge 自身的发送，不能阻止独立 Codex App 同时写入同一个 thread，二者仍需顺序交接。
- Windows 当前只保证 direct child 回收；POSIX 后代若主动通过 `setsid` 或 double-fork 脱离原 process group，不在当前回收保证内。
- 本 PR 不增加 delete/archive、后台 fire-and-forget、跨进程 stop、全局 thread discovery 或 App-to-Lark 实时镜像。
- 未执行真实模型 turn，也未进行部署；验证覆盖本地完整测试、进程级 fake App Server 合约、类型检查和正式构建。

## 验证

- `pnpm test`：110 个测试文件、720 个测试全部通过。
- `pnpm typecheck`：通过。
- `pnpm build`：Web、ESM、CLI、DTS 构建通过。
- `git diff --check`：通过。
- 新增回归覆盖 fresh thread 命名顺序、candidate 两阶段持久化、响应丢失、typed not-found、ambiguous fail-closed、raw progress watchdog、AbortSignal、CLI signal/exit code、并发 fail-fast、thread ownership 和 POSIX process-group 回收。

## 重点评审

- `src/agent/codex/app-server-adapter.ts` 的通知缓存、usage 归属和 fresh thread 发布顺序。
- `src/agent/codex/app-server-process.ts` 的 direct-child/process-group 终止与 close 等待语义。
- `src/codex-task/controller.ts` 和 `registry.ts` 的 candidate 提升、ambiguous outcome、task lock 和终态落盘。
