### PR TITLE
fix(keystore): stop deriving the encryption key from the hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ The legacy `sandbox` field is still readable for old configs. After the bridge s
 | `~/.lark-channel/profiles/<profile>/sessions.json.catalog.json` | Agent-aware session catalog |
 | `~/.lark-channel/profiles/<profile>/workspaces.json` | Current and named workspace bindings |
 | `~/.lark-channel/profiles/<profile>/secrets.enc` | Profile-local encrypted secrets |
+| `~/.lark-channel/profiles/<profile>/.keystore.key` | Machine-local key that encrypts `secrets.enc` |
 | `~/.lark-channel/profiles/<profile>/lark-cli/` | Profile-local lark-cli directory |
 | `~/.lark-channel/profiles/<profile>/media/` | Attachment cache |
 | `~/.lark-channel/profiles/<profile>/logs/` | Structured run logs |
@@ -235,6 +236,8 @@ The legacy `sandbox` field is still readable for old configs. After the bridge s
 | `~/.lark-channel/registry/locks/` | Profile and app locks |
 
 Set `LARK_CHANNEL_HOME=/path/to/state` to move all local bridge state. `LARK_CHANNEL_LOG_DAYS` overrides log retention.
+
+`.keystore.key` stays on the machine that created it, so a profile copied to another host needs its secrets re-added with `lark-channel-bridge secrets set`. Entries written before that file existed were keyed off the machine hostname instead; they are re-keyed automatically the first time they are read. If one of them outlived a hostname change (an mDNS `.local` collision bump, or a fleet rename) it can no longer be opened — start once with `LARK_CHANNEL_KEYSTORE_LEGACY_HOSTNAME="<previous hostname>"` to recover it, or re-add the secret.
 
 ## Access control
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -228,6 +228,7 @@ bridge 会检查所选目录存在、是目录，并且不是 `/`、Home 根、�
 | `~/.lark-channel/profiles/<profile>/sessions.json.catalog.json` | agent-aware 会话索引 |
 | `~/.lark-channel/profiles/<profile>/workspaces.json` | 当前和命名工作空间绑定 |
 | `~/.lark-channel/profiles/<profile>/secrets.enc` | profile 本地加密 secret |
+| `~/.lark-channel/profiles/<profile>/.keystore.key` | 加密 `secrets.enc` 的本机密钥 |
 | `~/.lark-channel/profiles/<profile>/lark-cli/` | 当前 profile 的 lark-cli 目录 |
 | `~/.lark-channel/profiles/<profile>/media/` | 附件缓存 |
 | `~/.lark-channel/profiles/<profile>/logs/` | 结构化运行日志 |
@@ -235,6 +236,8 @@ bridge 会检查所选目录存在、是目录，并且不是 `/`、Home 根、�
 | `~/.lark-channel/registry/locks/` | profile lock 和 app lock |
 
 设置 `LARK_CHANNEL_HOME=/path/to/state` 可以迁移整棵本地状态目录。`LARK_CHANNEL_LOG_DAYS` 可以调整日志保留天数。
+
+`.keystore.key` 只留在生成它的机器上，把 profile 拷到别的机器需要用 `lark-channel-bridge secrets set` 重新录入 secret。这个文件出现之前写入的条目是用主机名派生密钥的，首次读取时会自动换成新密钥。如果某个旧条目经历过主机名变化（mDNS `.local` 重名自动加后缀，或者机器被批量改名）就打不开了，带上 `LARK_CHANNEL_KEYSTORE_LEGACY_HOSTNAME="<原主机名>"` 启动一次即可恢复，也可以直接重新录入 secret。
 
 ## 访问控制
 

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -38,6 +38,7 @@ import {
   getRunIdleTimeoutMs,
   getShowToolCalls,
 } from '../config/schema';
+import type { KeystorePaths } from '../config/keystore';
 import { resolveAppSecret } from '../config/secret-resolver';
 import { log, reportMetric, withTrace } from '../core/logger';
 import { MediaCache, type LocalAttachment } from '../media/cache';
@@ -175,7 +176,7 @@ export interface StartChannelDeps {
   sessionCatalog?: SessionCatalog;
   workspaces: WorkspaceStore;
   controls: Controls;
-  appPaths?: Pick<AppPaths, 'secretsFile' | 'keystoreSaltFile' | 'mediaDir'>;
+  appPaths?: KeystorePaths & Pick<AppPaths, 'mediaDir'>;
 }
 
 export async function startChannel(deps: StartChannelDeps): Promise<BridgeChannel> {

--- a/src/config/app-paths.ts
+++ b/src/config/app-paths.ts
@@ -17,6 +17,7 @@ export interface AppPaths {
   workspacesFile: string;
   secretsFile: string;
   keystoreSaltFile: string;
+  keystoreKeyFile: string;
   secretsGetterScript: string;
   larkCliConfigDir: string;
   larkCliSourceDir: string;
@@ -60,6 +61,7 @@ export function resolveAppPaths(opts: ResolveAppPathsOptions = {}): AppPaths {
     workspacesFile: join(profileDir, 'workspaces.json'),
     secretsFile: join(profileDir, 'secrets.enc'),
     keystoreSaltFile: join(profileDir, '.keystore.salt'),
+    keystoreKeyFile: join(profileDir, '.keystore.key'),
     secretsGetterScript: join(rootDir, 'secrets-getter'),
     larkCliConfigDir: join(profileDir, 'lark-cli'),
     larkCliSourceDir: join(profileDir, 'lark-cli-source'),

--- a/src/config/keystore.ts
+++ b/src/config/keystore.ts
@@ -11,13 +11,22 @@ import { writeFileAtomic } from '../platform/atomic-write';
  * Layout on disk:
  *   ~/.lark-channel/secrets.enc      — JSON map { id → encrypted envelope }
  *   ~/.lark-channel/.keystore.salt   — 32 random bytes, generated once
+ *   ~/.lark-channel/.keystore.key    — 32 random bytes, generated once
  *
- * Both files are chmod 0600. The encryption key is derived (PBKDF2-SHA256,
- * 100k iters) from `hostname + userInfo().username + salt`. This is
- * **defense-in-depth against accidental disclosure** (backups, git commits,
- * log dumps) — *not* against a same-user process actively decrypting. That
- * threat needs a real OS keychain, which is out of scope for this bridge
- * given lark-cli already terminates secrets in its own keychain on bind.
+ * All three are chmod 0600. The encryption key is derived (PBKDF2-SHA256,
+ * 100k iters) from the key file + salt. This is **defense-in-depth against
+ * accidental disclosure** (backups, git commits, log dumps) — *not* against
+ * a same-user process actively decrypting. That threat needs a real OS
+ * keychain, which is out of scope for this bridge given lark-cli already
+ * terminates secrets in its own keychain on bind.
+ *
+ * Envelopes written before the key file existed were keyed off
+ * `hostname + username + salt` instead. A hostname is not stable identity —
+ * mDNS renames a colliding `.local` name (`host-2` → `host-3`), and managed
+ * fleets rename hosts outright — and every such rename silently stranded the
+ * keystore behind an unreadable `Unsupported state or unable to authenticate
+ * data`. Those envelopes are still read (see `KDF_HOSTNAME`) and are
+ * re-keyed onto the key file the first time they are opened.
  */
 
 const KEY_LEN = 32;
@@ -25,6 +34,12 @@ const IV_LEN = 12; // GCM standard
 const TAG_LEN = 16; // GCM auth tag
 const PBKDF2_ITER = 100_000;
 const FILE_VERSION = 1;
+/** Legacy KDF: key from `hostname|username`. Implied when `kdf` is absent. */
+const KDF_HOSTNAME = 'hostname';
+/** Current KDF: key from the machine-local random key file. */
+const KDF_KEYFILE = 'keyfile';
+/** Escape hatch to re-open entries stranded by a rename, see module doc. */
+const LEGACY_HOSTNAME_ENV = 'LARK_CHANNEL_KEYSTORE_LEGACY_HOSTNAME';
 const derivedKeyCache = new Map<string, Buffer>();
 
 interface Envelope {
@@ -34,6 +49,8 @@ interface Envelope {
   data: string;
   /** base64 of 16-byte GCM auth tag */
   tag: string;
+  /** Which key derivation produced this envelope. Absent → `hostname`. */
+  kdf?: typeof KDF_HOSTNAME | typeof KDF_KEYFILE;
 }
 
 interface StoreFile {
@@ -41,7 +58,7 @@ interface StoreFile {
   entries: Record<string, Envelope>;
 }
 
-export type KeystorePaths = Pick<AppPaths, 'secretsFile' | 'keystoreSaltFile'>;
+export type KeystorePaths = Pick<AppPaths, 'secretsFile' | 'keystoreSaltFile' | 'keystoreKeyFile'>;
 
 /** Read + return the full keystore. Missing file or unreadable → empty store. */
 async function readStore(storePaths: KeystorePaths = paths): Promise<StoreFile> {
@@ -83,12 +100,48 @@ async function loadOrCreateSalt(storePaths: KeystorePaths = paths): Promise<Buff
   return salt;
 }
 
+/**
+ * Load the machine-local key material, or generate it if absent. Unlike the
+ * salt this *is* the secret, so a wrong-sized file is treated as corruption
+ * rather than silently replaced — overwriting it would strand every entry.
+ */
+async function loadOrCreateKeyMaterial(storePaths: KeystorePaths = paths): Promise<Buffer> {
+  let existing: Buffer | undefined;
+  try {
+    existing = await readFile(storePaths.keystoreKeyFile);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+  if (existing) {
+    if (existing.length === KEY_LEN) return existing;
+    throw new Error(
+      `keystore key file ${storePaths.keystoreKeyFile} is ${existing.length} bytes, ` +
+        `expected ${KEY_LEN}; refusing to overwrite it — move it aside and re-add ` +
+        'your secrets to start over',
+    );
+  }
+  const material = randomBytes(KEY_LEN);
+  await writeFileAtomic(storePaths.keystoreKeyFile, material, { mode: 0o600 });
+  return material;
+}
+
 async function deriveKey(storePaths: KeystorePaths = paths): Promise<Buffer> {
-  const cacheKey = `${storePaths.keystoreSaltFile}`;
+  const cacheKey = `${storePaths.keystoreSaltFile}|${KDF_KEYFILE}`;
   const cached = derivedKeyCache.get(cacheKey);
   if (cached) return cached;
   const salt = await loadOrCreateSalt(storePaths);
-  const seed = `${hostname()}|${userInfo().username}`;
+  const material = await loadOrCreateKeyMaterial(storePaths);
+  const key = pbkdf2Sync(material, salt, PBKDF2_ITER, KEY_LEN, 'sha256');
+  derivedKeyCache.set(cacheKey, key);
+  return key;
+}
+
+async function deriveLegacyKey(host: string, storePaths: KeystorePaths = paths): Promise<Buffer> {
+  const cacheKey = `${storePaths.keystoreSaltFile}|${KDF_HOSTNAME}|${host}`;
+  const cached = derivedKeyCache.get(cacheKey);
+  if (cached) return cached;
+  const salt = await loadOrCreateSalt(storePaths);
+  const seed = `${host}|${userInfo().username}`;
   const key = pbkdf2Sync(seed, salt, PBKDF2_ITER, KEY_LEN, 'sha256');
   derivedKeyCache.set(cacheKey, key);
   return key;
@@ -103,6 +156,7 @@ function encrypt(key: Buffer, plaintext: string): Envelope {
     iv: iv.toString('base64'),
     data: enc.toString('base64'),
     tag: tag.toString('base64'),
+    kdf: KDF_KEYFILE,
   };
 }
 
@@ -128,8 +182,59 @@ export async function getSecret(
   const store = await readStore(storePaths);
   const env = store.entries[id];
   if (!env) return undefined;
-  const key = await deriveKey(storePaths);
-  return decrypt(key, env);
+  if (env.kdf === KDF_KEYFILE) {
+    return decrypt(await deriveKey(storePaths), env);
+  }
+  const plaintext = await decryptLegacy(id, env, storePaths);
+  await migrateEntry(id, plaintext, store, storePaths);
+  return plaintext;
+}
+
+/**
+ * Open a pre-key-file envelope. Tries this machine's current hostname, then
+ * whatever the operator pinned in `LARK_CHANNEL_KEYSTORE_LEGACY_HOSTNAME`.
+ */
+async function decryptLegacy(
+  id: string,
+  env: Envelope,
+  storePaths: KeystorePaths,
+): Promise<string> {
+  const current = hostname();
+  const override = process.env[LEGACY_HOSTNAME_ENV]?.trim();
+  const candidates = override && override !== current ? [current, override] : [current];
+  for (const host of candidates) {
+    try {
+      return decrypt(await deriveLegacyKey(host, storePaths), env);
+    } catch {
+      // Wrong hostname → GCM tag mismatch. Fall through to the next guess.
+    }
+  }
+  throw new Error(
+    `failed to decrypt keystore entry "${id}": it was encrypted with a key derived from this ` +
+      `machine's hostname, which has changed since (now "${current}"). Re-add the secret with ` +
+      '`lark-channel-bridge secrets set`, or — if you know the hostname it was stored under — ' +
+      `start once with ${LEGACY_HOSTNAME_ENV}="<previous hostname>" to re-key it automatically.`,
+  );
+}
+
+/**
+ * Re-encrypt a legacy entry onto the key file so the next rename cannot
+ * strand it. Best effort: a read-only or otherwise unwritable profile must
+ * not turn a successful read into a failure.
+ */
+async function migrateEntry(
+  id: string,
+  plaintext: string,
+  store: StoreFile,
+  storePaths: KeystorePaths,
+): Promise<void> {
+  try {
+    const key = await deriveKey(storePaths);
+    store.entries[id] = encrypt(key, plaintext);
+    await writeStore(store, storePaths);
+  } catch {
+    // Keep serving the secret; we retry the migration on the next read.
+  }
 }
 
 /** Store / overwrite the secret for `id`. */

--- a/src/runtime/profile-runtime.ts
+++ b/src/runtime/profile-runtime.ts
@@ -9,7 +9,7 @@ import {
   resolveBootstrapWorkspace,
 } from '../cli/profile-bootstrap';
 import { promptPassword } from '../cli/prompt';
-import { setSecret } from '../config/keystore';
+import { setSecret, type KeystorePaths } from '../config/keystore';
 import { resolveAppPaths, type AppPaths } from '../config/app-paths';
 import {
   ActiveBridgeMigrationConflictError,
@@ -619,7 +619,7 @@ function displayAgentKind(kind: AgentKind): string {
 async function maybeMigrateRootPlaintextSecret(
   rootConfig: RootConfig,
   profile: string,
-  appPaths: Pick<AppPaths, 'secretsGetterScript' | 'secretsFile' | 'keystoreSaltFile'>,
+  appPaths: KeystorePaths & Pick<AppPaths, 'secretsGetterScript'>,
   configPath: string,
 ): Promise<AppConfig & { agentKind?: AgentKind }> {
   const cfg = runtimeProfileConfig(rootConfig, profile);
@@ -642,7 +642,7 @@ async function maybeMigrateRootPlaintextSecret(
 
 async function encryptedConfigForProfile(
   cfg: AppConfig,
-  appPaths: Pick<AppPaths, 'secretsGetterScript' | 'secretsFile' | 'keystoreSaltFile'>,
+  appPaths: KeystorePaths & Pick<AppPaths, 'secretsGetterScript'>,
 ): Promise<AppConfig> {
   const secret = cfg.accounts.app.secret;
   if (typeof secret !== 'string') return cfg;
@@ -659,7 +659,7 @@ async function encryptedConfigForProfile(
 async function encryptedConfigForResolvedSecret(
   cfg: AppConfig,
   plaintext: string,
-  appPaths: Pick<AppPaths, 'secretsGetterScript' | 'secretsFile' | 'keystoreSaltFile'>,
+  appPaths: KeystorePaths & Pick<AppPaths, 'secretsGetterScript'>,
 ): Promise<AppConfig> {
   const next = await buildEncryptedAccountConfig(
     cfg.accounts.app.id,
@@ -679,7 +679,7 @@ function isEnvBackedSecret(secret: SecretInput): boolean {
 async function maybeMigratePlaintextSecret(
   cfg: AppConfig,
   configPath: string,
-  appPaths: Pick<AppPaths, 'secretsGetterScript' | 'secretsFile' | 'keystoreSaltFile'>,
+  appPaths: KeystorePaths & Pick<AppPaths, 'secretsGetterScript'>,
 ): Promise<AppConfig> {
   const s = cfg.accounts.app.secret;
   if (typeof s === 'string' && !/^\$\{[A-Z][A-Z0-9_]*\}$/.test(s)) {

--- a/tests/unit/config/app-paths.test.ts
+++ b/tests/unit/config/app-paths.test.ts
@@ -45,6 +45,7 @@ describe('resolveAppPaths', () => {
     expect(paths.workspacesFile).toBe(join(profileDir, 'workspaces.json'));
     expect(paths.secretsFile).toBe(join(profileDir, 'secrets.enc'));
     expect(paths.keystoreSaltFile).toBe(join(profileDir, '.keystore.salt'));
+    expect(paths.keystoreKeyFile).toBe(join(profileDir, '.keystore.key'));
     expect(paths.larkCliConfigDir).toBe(join(profileDir, 'lark-cli'));
     expect(paths.larkCliSourceDir).toBe(join(profileDir, 'lark-cli-source'));
     expect(paths.larkCliSourceConfigFile).toBe(join(profileDir, 'lark-cli-source', 'config.json'));

--- a/tests/unit/config/keystore.test.ts
+++ b/tests/unit/config/keystore.test.ts
@@ -1,0 +1,166 @@
+import { createCipheriv, pbkdf2Sync, randomBytes } from 'node:crypto';
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir, userInfo } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const host = { value: 'machine-a.local' };
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return { ...actual, hostname: () => host.value };
+});
+
+const { resolveAppPaths } = await import('../../../src/config/app-paths');
+const { clearKeystoreDerivedKeyCache, getSecret, listSecretIds, setSecret } = await import(
+  '../../../src/config/keystore'
+);
+
+const LEGACY_HOSTNAME_ENV = 'LARK_CHANNEL_KEYSTORE_LEGACY_HOSTNAME';
+const roots: string[] = [];
+
+type TestPaths = ReturnType<typeof resolveAppPaths>;
+
+async function tempPaths(): Promise<TestPaths> {
+  const root = await mkdtemp(join(tmpdir(), 'bridge-keystore-'));
+  roots.push(root);
+  const paths = resolveAppPaths({ rootDir: root, profile: 'claude' });
+  await mkdir(dirname(paths.secretsFile), { recursive: true });
+  return paths;
+}
+
+/** Write an entry in the pre-fix format: key derived from `hostname|username`. */
+async function writeLegacyEntry(
+  paths: TestPaths,
+  id: string,
+  plaintext: string,
+  atHostname: string,
+): Promise<void> {
+  const salt = randomBytes(32);
+  await writeFile(paths.keystoreSaltFile, salt, { mode: 0o600 });
+  const key = pbkdf2Sync(`${atHostname}|${userInfo().username}`, salt, 100_000, 32, 'sha256');
+  const iv = randomBytes(12);
+  const cipher = createCipheriv('aes-256-gcm', key, iv);
+  const data = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const store = {
+    version: 1,
+    entries: {
+      [id]: {
+        iv: iv.toString('base64'),
+        data: data.toString('base64'),
+        tag: cipher.getAuthTag().toString('base64'),
+      },
+    },
+  };
+  await writeFile(paths.secretsFile, `${JSON.stringify(store, null, 2)}\n`, { mode: 0o600 });
+}
+
+async function readEntry(secretsFile: string, id: string): Promise<{ kdf?: string } | undefined> {
+  const parsed = JSON.parse(await readFile(secretsFile, 'utf8')) as {
+    entries: Record<string, { kdf?: string }>;
+  };
+  return parsed.entries[id];
+}
+
+beforeEach(() => {
+  host.value = 'machine-a.local';
+  delete process.env[LEGACY_HOSTNAME_ENV];
+  clearKeystoreDerivedKeyCache();
+});
+
+afterEach(async () => {
+  delete process.env[LEGACY_HOSTNAME_ENV];
+  clearKeystoreDerivedKeyCache();
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('keystore', () => {
+  it('round-trips a secret and lists its id', async () => {
+    const paths = await tempPaths();
+
+    await setSecret('app-cli_x', 'super-secret', paths);
+
+    expect(await getSecret('app-cli_x', paths)).toBe('super-secret');
+    expect(await listSecretIds(paths)).toEqual(['app-cli_x']);
+  });
+
+  it('returns undefined for an unknown id', async () => {
+    const paths = await tempPaths();
+
+    expect(await getSecret('app-missing', paths)).toBeUndefined();
+  });
+
+  it('keeps entries readable after the machine hostname changes', async () => {
+    const paths = await tempPaths();
+    await setSecret('app-cli_x', 'super-secret', paths);
+
+    // mDNS bumps the .local name on a collision, IT renames the host, …
+    host.value = 'machine-b.local';
+    clearKeystoreDerivedKeyCache();
+
+    expect(await getSecret('app-cli_x', paths)).toBe('super-secret');
+  });
+
+  it('reads a legacy hostname-encrypted entry and migrates it off the hostname', async () => {
+    const paths = await tempPaths();
+    await writeLegacyEntry(paths, 'app-cli_x', 'legacy-secret', 'machine-a.local');
+    expect(await readEntry(paths.secretsFile, 'app-cli_x')).not.toHaveProperty('kdf', 'keyfile');
+
+    expect(await getSecret('app-cli_x', paths)).toBe('legacy-secret');
+
+    // Migrated in place, so a later rename cannot strand it.
+    expect(await readEntry(paths.secretsFile, 'app-cli_x')).toHaveProperty('kdf', 'keyfile');
+    host.value = 'machine-b.local';
+    clearKeystoreDerivedKeyCache();
+    expect(await getSecret('app-cli_x', paths)).toBe('legacy-secret');
+  });
+
+  it('fails with an actionable error when a legacy entry outlives its hostname', async () => {
+    const paths = await tempPaths();
+    await writeLegacyEntry(paths, 'app-cli_x', 'legacy-secret', 'machine-a.local');
+
+    host.value = 'machine-b.local';
+    clearKeystoreDerivedKeyCache();
+
+    const err = await getSecret('app-cli_x', paths).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    const message = (err as Error).message;
+    expect(message).toContain('app-cli_x');
+    expect(message).toContain('hostname');
+    expect(message).toContain('machine-b.local');
+    expect(message).toContain(LEGACY_HOSTNAME_ENV);
+    expect(message).toContain('secrets set');
+    // The bare node error text is what made this undiagnosable before.
+    expect(message).not.toBe('Unsupported state or unable to authenticate data');
+  });
+
+  it('recovers a stranded legacy entry when the previous hostname is supplied', async () => {
+    const paths = await tempPaths();
+    await writeLegacyEntry(paths, 'app-cli_x', 'legacy-secret', 'machine-a.local');
+
+    host.value = 'machine-b.local';
+    process.env[LEGACY_HOSTNAME_ENV] = 'machine-a.local';
+    clearKeystoreDerivedKeyCache();
+
+    expect(await getSecret('app-cli_x', paths)).toBe('legacy-secret');
+
+    // Recovery is one-shot: the entry is re-keyed, so the env var is no
+    // longer needed on the next start.
+    delete process.env[LEGACY_HOSTNAME_ENV];
+    clearKeystoreDerivedKeyCache();
+    expect(await getSecret('app-cli_x', paths)).toBe('legacy-secret');
+  });
+
+  it('still returns the secret when the migration write cannot be persisted', async () => {
+    const paths = await tempPaths();
+    await writeLegacyEntry(paths, 'app-cli_x', 'legacy-secret', 'machine-a.local');
+    const profileDir = dirname(paths.secretsFile);
+    await chmod(profileDir, 0o500);
+
+    try {
+      expect(await getSecret('app-cli_x', paths)).toBe('legacy-secret');
+    } finally {
+      await chmod(profileDir, 0o700);
+    }
+  });
+});


### PR DESCRIPTION
## Problem

The keystore key is derived from `hostname()|username`, so the moment the machine's hostname changes, every entry in `secrets.enc` becomes unreadable. What the user sees is:

```
$ lark-channel-bridge run
Error: Unsupported state or unable to authenticate data
```

`ps`, `status` and the launchd daemon all fail the same way, and the daemon crash-loops on it — the stderr log fills up with the same line. Nothing in the message points at the keystore, let alone at the hostname, so it reads like a corrupted file and the natural reaction is to wipe the config and re-onboard.

This is not an exotic failure. A hostname is not stable identity:

- mDNS renames a colliding `.local` name on its own — my laptop went from `MacBook-Air-8.local` to `MacBook-Air-9.local` with no user action, because there are a dozen similarly-named Macs on the office network. The bridge had been running fine for three weeks and broke on a morning when nothing was touched.
- Managed fleets rename hosts (MDM naming policies, asset-tag renames).
- `scutil --set` / `hostnamectl` by the user or by IT.

The salt file survives the rename, so the failure is silent and permanent until the secret is re-added by hand.

## Fix

Derive the key from a machine-local random key file (`.keystore.key`, 32 bytes, `0600`) instead of the hostname. The salt keeps its role; only the seed changes.

Envelopes now carry a `kdf` marker:

- `kdf: "keyfile"` — current format.
- absent — pre-existing envelope keyed off the hostname. Still opened with the old derivation, then **re-encrypted in place on first read**, so existing installs migrate silently on upgrade with no user action.

For entries already stranded by a rename, the error now says what happened and how to get out of it:

```
failed to decrypt keystore entry "app-cli_xxx": it was encrypted with a key derived from
this machine's hostname, which has changed since (now "MacBook-Air-9.local"). Re-add the
secret with `lark-channel-bridge secrets set`, or — if you know the hostname it was stored
under — start once with LARK_CHANNEL_KEYSTORE_LEGACY_HOSTNAME="<previous hostname>" to
re-key it automatically.
```

Setting that variable once re-keys the entry onto the key file; it is not needed on subsequent starts.

Two details worth calling out for review:

- The migration write is best effort. An unwritable profile directory must not turn a successful read into a failure, so the write is wrapped and retried on the next read.
- A wrong-sized `.keystore.key` is treated as corruption and raises, rather than being regenerated the way the salt is — silently replacing it would strand every entry in the store.

This does not change the threat model documented at the top of the module: the key file sits next to the ciphertext and protects against accidental disclosure, not against a same-user process. It only removes an availability bug.

## Compatibility

- Existing installs: transparent, migrate on first read.
- Downgrade: a `keyfile` envelope cannot be read by an older build. Re-adding the secret with `secrets set` restores the old format.
- `secrets.enc` file version stays `1`; the marker is per-envelope, so a store can hold both formats during migration.

## Testing

- New `tests/unit/config/keystore.test.ts` covering round-trip, survival across a hostname change, legacy read + in-place migration, the actionable error, one-shot recovery via the env var, and the unwritable-profile case. Written against the old code first — four of the seven fail on `main`.
- `pnpm ci:local` green (629 tests, typecheck, build).
- End-to-end against the built CLI (`bin/lark-channel-bridge.mjs`, real `secrets get` over the exec-provider protocol, temp `LARK_CHANNEL_HOME`):
  - legacy entry stranded by a rename → actionable error instead of `Unsupported state ...`
  - `LARK_CHANNEL_KEYSTORE_LEGACY_HOSTNAME=<old>` → recovered, envelope rewritten as `kdf: keyfile`, subsequent reads need no env var
  - legacy entry on an unchanged host → migrated with no user action
  - fresh `secrets set` → `list` → `get` round-trip
  - migrated entry decrypts from `.keystore.key` + salt alone, i.e. no hostname anywhere in the derivation
