### PR TITLE
feat: add Kimi Code (kimi) agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lark-channel-bridge
 
-A lightweight bot that bridges Feishu / Lark messenger with your local Claude Code or Codex CLI. Run one command, scan a QR code to bind a PersonalAgent app, and talk to your local coding agent from chat.
+A lightweight bot that bridges Feishu / Lark messenger with your local Claude Code, Codex, or Kimi Code CLI. Run one command, scan a QR code to bind a PersonalAgent app, and talk to your local coding agent from chat.
 
 [中文 README](./README.zh.md)
 
@@ -8,7 +8,7 @@ For a product walkthrough, see the [Feishu document](https://larkcommunity.feish
 
 ## What it does
 
-- Forwards Feishu / Lark messages to local Claude Code or Codex CLI. Send a DM directly, or `@bot` in a group.
+- Forwards Feishu / Lark messages to local Claude Code, Codex, or Kimi Code CLI. Send a DM directly, or `@bot` in a group.
 - **Streaming card**: text replies and tool calls update on one Lark card in real time.
 - **COT process messages**: optionally send a process message with agent progress text and tool calls, then send the final answer separately.
 - **Session continuity**: each chat, topic, or document comment thread keeps its own session.
@@ -23,6 +23,7 @@ For a product walkthrough, see the [Feishu document](https://larkcommunity.feish
 - At least one local agent installed and logged in:
   - Claude Code: `claude`, see https://docs.anthropic.com/en/docs/claude-code/quickstart
   - Codex CLI: `codex`, see https://developers.openai.com/codex/cli
+  - Kimi Code: `kimi`, see https://github.com/KimiAI/kimi-code-cli
 - A Feishu / Lark **PersonalAgent** app. The first-run QR wizard can create and bind one for you.
 
 ## Install
@@ -88,13 +89,14 @@ Platform mapping:
 
 Daemon logs are under `~/.lark-channel/profiles/<profile>/logs/daemon/`.
 
-### Multiple profiles: Claude and Codex
+### Multiple profiles: Claude, Codex, and Kimi
 
-By default, the bridge starts with the currently selected profile. Use `profile use <name>` to change it. Each profile keeps its own app credentials, sessions, working directories, and logs. Create multiple profiles only when you need to connect multiple PersonalAgent apps, or run Claude and Codex as separate bots:
+By default, the bridge starts with the currently selected profile. Use `profile use <name>` to change it. Each profile keeps its own app credentials, sessions, working directories, and logs. Create multiple profiles only when you need to connect multiple PersonalAgent apps, or run different agents as separate bots:
 
 ```bash
 lark-channel-bridge start --profile claude --agent claude
 lark-channel-bridge start --profile codex --agent codex
+lark-channel-bridge start --profile kimi --agent kimi
 ```
 
 For example, to restart only the Codex bot:
@@ -109,18 +111,19 @@ lark-channel-bridge status --profile codex
 ### Host CLI
 
 ```text
-lark-channel-bridge run [--profile <name>] [--agent claude|codex] [--workspace <path>] [-c <config>]
-lark-channel-bridge migrate [--profile <name>] [--agent claude|codex]
+lark-channel-bridge run [--profile <name>] [--agent claude|codex|kimi] [--workspace <path>] [-c <config>]
+lark-channel-bridge migrate [--profile <name>] [--agent claude|codex|kimi]
 lark-channel-bridge ps
 lark-channel-bridge kill <id|#>
 lark-channel-bridge --help
 ```
 
-`profile use <name>` changes the profile used by later default starts. Use these profile management commands when running separate Claude / Codex bots, connecting multiple PersonalAgent apps, or doing scripted deployment:
+`profile use <name>` changes the profile used by later default starts. Use these profile management commands when running separate Claude / Codex / Kimi bots, connecting multiple PersonalAgent apps, or doing scripted deployment:
 
 ```bash
 lark-channel-bridge profile create claude --agent claude
 lark-channel-bridge profile create codex --agent codex
+lark-channel-bridge profile create kimi --agent kimi
 lark-channel-bridge profile list
 lark-channel-bridge profile use <name>
 lark-channel-bridge profile remove <name>
@@ -216,6 +219,8 @@ Mode mapping:
 | `workspace` | `acceptEdits` | `workspace-write` |
 | `read-only` | `plan` | `read-only` |
 
+Kimi Code does not accept a permission flag: `--yolo` / `--auto` / `--plan` are mutually exclusive with `-p`, so the bridge never passes one to `kimi`. The profile's `permissions` setting still exists for the profile (and `/status` reports it), but the Kimi process runs with its own default access policy.
+
 The legacy `sandbox` field is still readable for old configs. After the bridge saves the profile, it migrates that setting to canonical `permissions`.
 
 ## Data directories
@@ -305,7 +310,7 @@ Cloud-doc comments do not need a separate workspace binding or document allowlis
 
 ## FAQ
 
-**The bot stays silent or the local CLI never replies.** Usually the local `claude` or `codex` CLI is not logged in, or the current session points to a working directory that no longer exists. Send `/status` to inspect; `/new` often fixes it by starting a fresh session.
+**The bot stays silent or the local CLI never replies.** Usually the local `claude`, `codex`, or `kimi` CLI is not logged in, or the current session points to a working directory that no longer exists. Send `/status` to inspect; `/new` often fixes it by starting a fresh session.
 
 **The agent subprocess looks frozen (card stuck on the last frame).** The bridge supports an idle watchdog: if the agent emits nothing for N minutes, the process is killed and the card is annotated with the auto-termination reason. Disabled by default. Enable with `/config` globally, or `/timeout 10` for the current session; `/timeout off` disables it for the session; `/timeout default` clears the session override.
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,6 +1,6 @@
 # lark-channel-bridge
 
-把飞书 / Lark 消息和本地 Claude Code 或 Codex CLI 打通的轻量 bot。用一条命令启动，扫码绑定 PersonalAgent 应用，然后在飞书里和本机编程助手对话，让它读图、处理文件、改代码。
+把飞书 / Lark 消息和本地 Claude Code、Codex 或 Kimi Code CLI 打通的轻量 bot。用一条命令启动，扫码绑定 PersonalAgent 应用，然后在飞书里和本机编程助手对话，让它读图、处理文件、改代码。
 
 [English README](./README.md)
 
@@ -8,7 +8,7 @@
 
 ## 主要功能
 
-- 在飞书私聊直接发消息，或在群里 `@bot`，把任务转给本机 Claude Code / Codex CLI。
+- 在飞书私聊直接发消息，或在群里 `@bot`，把任务转给本机 Claude Code / Codex / Kimi Code CLI。
 - **流式卡片**：文本回复和工具调用实时更新在同一张卡片上。
 - **COT 过程消息**：可选先发一条过程消息展示 agent 的阶段性文本和工具调用，再单独发送最终答案。
 - **会话延续**：每个聊天、话题或文档评论有自己的会话，不会互相串。
@@ -23,6 +23,7 @@
 - 本机至少安装并登录一个 agent：
   - Claude Code：`claude`，安装说明：https://docs.anthropic.com/en/docs/claude-code/quickstart
   - Codex CLI：`codex`，安装说明：https://developers.openai.com/codex/cli
+  - Kimi Code：`kimi`，安装说明：https://github.com/KimiAI/kimi-code-cli
 - 一个飞书 / Lark PersonalAgent 应用。首次启动的扫码向导可以帮你创建并绑定。
 
 ## 安装
@@ -88,13 +89,14 @@ lark-channel-bridge unregister [--profile <name>]
 
 daemon 日志在 `~/.lark-channel/profiles/<profile>/logs/daemon/`。
 
-### 多 profile：分别运行 Claude 和 Codex
+### 多 profile：分别运行 Claude、Codex 和 Kimi
 
-默认情况下，bridge 使用当前激活的 profile；可以通过 `profile use <name>` 切换。每个 profile 会维护独立的应用凭据、会话、工作目录和日志。只有在需要同时连接多个 PersonalAgent 应用，或分别运行 Claude 和 Codex 时，才需要创建多个 profile：
+默认情况下，bridge 使用当前激活的 profile；可以通过 `profile use <name>` 切换。每个 profile 会维护独立的应用凭据、会话、工作目录和日志。只有在需要同时连接多个 PersonalAgent 应用，或分别运行不同 agent 时，才需要创建多个 profile：
 
 ```bash
 lark-channel-bridge start --profile claude --agent claude
 lark-channel-bridge start --profile codex --agent codex
+lark-channel-bridge start --profile kimi --agent kimi
 ```
 
 例如只重启 Codex bot：
@@ -109,18 +111,19 @@ lark-channel-bridge status --profile codex
 ### 宿主 CLI
 
 ```text
-lark-channel-bridge run [--profile <name>] [--agent claude|codex] [--workspace <path>] [-c <config>]
-lark-channel-bridge migrate [--profile <name>] [--agent claude|codex]
+lark-channel-bridge run [--profile <name>] [--agent claude|codex|kimi] [--workspace <path>] [-c <config>]
+lark-channel-bridge migrate [--profile <name>] [--agent claude|codex|kimi]
 lark-channel-bridge ps
 lark-channel-bridge kill <id|#>
 lark-channel-bridge --help
 ```
 
-`profile use <name>` 会切换后续默认启动使用的 profile。需要同时跑 Claude / Codex 两个 bot、连接多套 PersonalAgent 应用，或做脚本化部署时，再使用这些 profile 管理命令：
+`profile use <name>` 会切换后续默认启动使用的 profile。需要同时跑 Claude / Codex / Kimi 多个 bot、连接多套 PersonalAgent 应用，或做脚本化部署时，再使用这些 profile 管理命令：
 
 ```bash
 lark-channel-bridge profile create claude --agent claude
 lark-channel-bridge profile create codex --agent codex
+lark-channel-bridge profile create kimi --agent kimi
 lark-channel-bridge profile list
 lark-channel-bridge profile use <name>
 lark-channel-bridge profile remove <name>
@@ -216,6 +219,8 @@ bridge 会检查所选目录存在、是目录，并且不是 `/`、Home 根、�
 | `workspace` | `acceptEdits` | `workspace-write` |
 | `read-only` | `plan` | `read-only` |
 
+Kimi Code 不接受权限参数：`--yolo` / `--auto` / `--plan` 与 `-p` 互斥，所以 bridge 不会给 `kimi` 传任何权限 flag。profile 的 `permissions` 配置仍然存在（`/status` 也会显示），但 Kimi 进程按它自己的默认访问策略运行。
+
 旧版 `sandbox` 字段仍可读取。bridge 保存 profile 后，会把该设置迁移为 canonical `permissions`。
 
 ## 数据目录
@@ -305,7 +310,7 @@ grep '"event":"enter"' ~/.lark-channel/profiles/<profile>/logs/bridge-$(date +%Y
 
 ## 常见问题
 
-**bot 没反应 / agent 不回复**：通常是本机 `claude` 或 `codex` CLI 没登录，或者当前会话指向了不存在的工作目录。发 `/status` 看当前状态；`/new` 重开会话往往就好。
+**bot 没反应 / agent 不回复**：通常是本机 `claude`、`codex` 或 `kimi` CLI 没登录，或者当前会话指向了不存在的工作目录。发 `/status` 看当前状态；`/new` 重开会话往往就好。
 
 **agent 子进程假死（卡片停在最后一帧不动）**：支持 idle 探活。agent 一段时间没输出就会被 SIGTERM kill，卡片末尾会标出自动终止原因。默认关闭。开启方式：`/config` 设全局值（分钟），或 `/timeout 10` 只对当前会话生效；`/timeout off` 关掉当前会话的探活；`/timeout default` 清掉会话覆盖，回退到全局设置。
 

--- a/src/agent/capability.ts
+++ b/src/agent/capability.ts
@@ -2,9 +2,9 @@ import type { AccessMode } from '../config/permissions';
 import type { ProfileConfig } from '../config/profile-schema';
 import { BRIDGE_SYSTEM_PROMPT } from './bridge-system-prompt';
 
-export type AgentCapabilityId = 'claude' | 'codex';
-export type AgentSessionKind = 'claude-session' | 'codex-thread';
-export type PromptInjectionMode = 'append-system-prompt' | 'stdin-prefix';
+export type AgentCapabilityId = 'claude' | 'codex' | 'kimi';
+export type AgentSessionKind = 'claude-session' | 'codex-thread' | 'kimi-session';
+export type PromptInjectionMode = 'append-system-prompt' | 'stdin-prefix' | 'argv-prefix';
 
 export interface AgentCapability {
   agentId: AgentCapabilityId;
@@ -55,4 +55,40 @@ export function codexCapability(profile: Pick<ProfileConfig, 'permissions'>): Ag
       maxAccess,
     },
   };
+}
+
+export function kimiCapability(profile?: Pick<ProfileConfig, 'permissions'>): AgentCapability {
+  const maxAccess = profile?.permissions.maxAccess ?? 'full';
+  return {
+    agentId: 'kimi',
+    sessionKind: 'kimi-session',
+    promptInjection: 'argv-prefix',
+    systemPrompt: BRIDGE_SYSTEM_PROMPT,
+    supportsNativeHistory: true,
+    callback: {
+      marker: '__bridge_cb',
+      legacyMarkers: [],
+    },
+    permissions: {
+      maxAccess,
+    },
+  };
+}
+
+/**
+ * Resolve the capability for any profile kind. Centralises the claude/codex/
+ * kimi dispatch so callers don't repeat three-way ternaries (easy to get
+ * wrong when a new agent kind is added).
+ */
+export function capabilityForProfile(
+  profile: Pick<ProfileConfig, 'agentKind' | 'permissions'>,
+): AgentCapability {
+  switch (profile.agentKind) {
+    case 'codex':
+      return codexCapability(profile);
+    case 'kimi':
+      return kimiCapability(profile);
+    default:
+      return claudeCapability(profile);
+  }
 }

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,3 +1,4 @@
 export type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from './types';
 export { ClaudeAdapter } from './claude/adapter';
 export { CodexAdapter } from './codex/adapter';
+export { KimiAdapter } from './kimi/adapter';

--- a/src/agent/kimi/adapter.ts
+++ b/src/agent/kimi/adapter.ts
@@ -1,0 +1,268 @@
+import { createInterface } from 'node:readline';
+import type { Readable, Writable } from 'node:stream';
+import { log } from '../../core/logger';
+import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
+import { prefixBridgeSystemPrompt } from '../bridge-system-prompt';
+import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel-env';
+import { checkAgentAvailability, type AgentAvailability } from '../preflight';
+import type {
+  AgentAdapter,
+  AgentBotIdentity,
+  AgentEvent,
+  AgentRun,
+  AgentRunOptions,
+} from '../types';
+import { buildKimiArgs } from './argv';
+import { KimiJsonlTranslator, type KimiFinishReason } from './stream-json';
+
+export interface KimiAdapterOptions {
+  binary?: string;
+  stopGraceMs?: number;
+  larkChannel?: LarkChannelEnvContext;
+}
+
+type KimiChild = SpawnedProcessByStdio<Writable, Readable, Readable>;
+
+export class KimiAdapter implements AgentAdapter {
+  readonly id = 'kimi';
+  readonly displayName = 'Kimi Code';
+
+  private readonly binary: string;
+  private readonly defaultStopGraceMs: number;
+  private readonly larkChannel: LarkChannelEnvContext | undefined;
+  private botIdentity: AgentBotIdentity | undefined;
+
+  constructor(opts: KimiAdapterOptions = {}) {
+    this.binary = opts.binary ?? 'kimi';
+    this.defaultStopGraceMs = opts.stopGraceMs ?? 5000;
+    this.larkChannel = opts.larkChannel;
+  }
+
+  setBotIdentity(identity: AgentBotIdentity): void {
+    this.botIdentity = identity;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return (await this.checkAvailability()).ok;
+  }
+
+  async checkAvailability(): Promise<AgentAvailability> {
+    return checkAgentAvailability({
+      agentId: 'kimi',
+      agentName: 'Kimi Code',
+      command: this.binary,
+      binaryPath: this.binary,
+    });
+  }
+
+  run(opts: AgentRunOptions): AgentRun {
+    if (!opts.cwd) {
+      throw new Error('cwd is required for KimiAdapter.run');
+    }
+
+    // The bridge system prompt and the user prompt travel together through
+    // `-p` on the argv. macOS spawns `kimi` directly without a shell, so the
+    // `<bridge_context>` XML in the prompt is never interpreted. On Windows,
+    // `kimi` may resolve to a `.cmd` shim routed through `cmd.exe /d /s /c`,
+    // which interprets `<` and `>` as redirection operators — mirror the
+    // Codex adapter's stdin/temp-file prompt strategy if Windows support is
+    // ever needed.
+    //
+    // `--yolo` / `--auto` / `--plan` are mutually exclusive with `-p`, so no
+    // permission flag is passed; sandbox/permissionMode are ignored by the
+    // kimi adapter and `/status` displays the access mode instead.
+    const args = buildKimiArgs({
+      prompt: prefixBridgeSystemPrompt(opts.prompt, this.botIdentity),
+      sessionId: opts.sessionId,
+      model: opts.model,
+    });
+    const child = spawnProcess(this.binary, args, {
+      cwd: opts.cwd,
+      env: mergeProcessEnv(process.env, buildLarkChannelEnv(this.larkChannel)),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }) as KimiChild;
+
+    log.info('agent', 'spawn', {
+      pid: child.pid ?? null,
+      cwd: opts.cwd ?? process.cwd(),
+      hasSession: Boolean(opts.sessionId),
+      promptChars: opts.prompt.length,
+      model: opts.model,
+    });
+
+    // Listeners MUST be attached synchronously here, before we return.
+    // The 'error' and exit-related events can fire in the next tick; if we
+    // defer attachment to the async-generator body, those events fire into
+    // the void and the generator hangs.
+    const stderrChunks: Buffer[] = [];
+    let runtimeError: Error | null = null;
+    let stderrBuffer = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+      stderrBuffer += chunk.toString('utf8');
+      let nl = stderrBuffer.indexOf('\n');
+      while (nl !== -1) {
+        const line = stderrBuffer.slice(0, nl);
+        stderrBuffer = stderrBuffer.slice(nl + 1);
+        if (line.trim()) log.warn('agent', 'stderr', { line });
+        if (isWindowsCommandNotFoundLine(line)) {
+          runtimeError = new Error(`failed to spawn kimi: ${line.trim()}`);
+          child.stdout.destroy();
+          child.kill();
+        }
+        nl = stderrBuffer.indexOf('\n');
+      }
+    });
+
+    let stopReason: KimiFinishReason | undefined;
+    child.on('error', (err) => {
+      runtimeError = err;
+    });
+    child.on('exit', (code, signal) => {
+      log.info('agent', 'exit', { pid: child.pid ?? null, code, signal });
+    });
+    child.stdin.on('error', (err) => {
+      log.warn('agent', 'stdin-error', { message: err.message });
+    });
+    // kimi does not consume stdin; end it immediately so the child never
+    // waits on input that will never arrive.
+    child.stdin.end();
+
+    const stopGraceMs = opts.stopGraceMs ?? this.defaultStopGraceMs;
+
+    return {
+      runId: opts.runId,
+      events: createEventStream(child, stderrChunks, () => runtimeError, () => stopReason),
+      async stop() {
+        if (child.exitCode !== null || child.signalCode !== null) return;
+        stopReason = 'interrupted';
+        log.info('agent', 'stop-sigterm', { pid: child.pid ?? null, graceMs: stopGraceMs });
+        child.kill('SIGTERM');
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            if (child.exitCode === null && child.signalCode === null) {
+              log.warn('agent', 'stop-sigkill', {
+                pid: child.pid ?? null,
+                graceMs: stopGraceMs,
+                reason: 'grace-period-expired',
+              });
+              child.kill('SIGKILL');
+            }
+            resolve();
+          }, stopGraceMs);
+          child.once('exit', () => {
+            clearTimeout(timer);
+            resolve();
+          });
+        });
+      },
+      waitForExit(timeoutMs: number): Promise<boolean> {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          return Promise.resolve(true);
+        }
+        return new Promise<boolean>((resolve) => {
+          const onExit = (): void => {
+            clearTimeout(timer);
+            resolve(true);
+          };
+          const timer = setTimeout(() => {
+            child.removeListener('exit', onExit);
+            resolve(false);
+          }, timeoutMs);
+          child.once('exit', onExit);
+        });
+      },
+    };
+  }
+}
+
+async function* createEventStream(
+  child: KimiChild,
+  stderrChunks: Buffer[],
+  getError: () => Error | null,
+  getStopReason: () => KimiFinishReason | undefined,
+): AsyncGenerator<AgentEvent> {
+  const translator = new KimiJsonlTranslator();
+  if (!child.pid) {
+    const err = getError();
+    yield {
+      type: 'error',
+      message: err ? `failed to spawn kimi: ${err.message}` : 'spawn returned no pid',
+      terminationReason: 'failed',
+    };
+    return;
+  }
+
+  const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  let sawStdout = false;
+  let silentExitTimer: ReturnType<typeof setTimeout> | undefined;
+  const closeSilentStdout = (): void => {
+    silentExitTimer = setTimeout(() => {
+      if (!sawStdout && !child.stdout.readableEnded) child.stdout.destroy();
+    }, 50);
+  };
+  child.once('exit', closeSilentStdout);
+  try {
+    for await (const line of rl) {
+      sawStdout = true;
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      yield* translator.translate(parsed);
+    }
+  } finally {
+    if (silentExitTimer) clearTimeout(silentExitTimer);
+    child.removeListener('exit', closeSilentStdout);
+    rl.close();
+  }
+
+  const earlyRuntimeError = getError();
+  if (earlyRuntimeError && child.exitCode === null && child.signalCode === null) {
+    yield* translator.fail(`kimi runtime error: ${earlyRuntimeError.message}`);
+    return;
+  }
+
+  const exitCode = await waitForExitCode(child);
+  const stopReason = getStopReason();
+  if (stopReason) {
+    yield* translator.finish(stopReason);
+    return;
+  }
+
+  const runtimeError = getError();
+  if (exitCode !== 0 && exitCode !== null) {
+    if (!translator.terminalEmitted()) {
+      const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+      const detail = stderr ? `: ${stderr.slice(0, 500)}` : '';
+      yield* translator.fail(`kimi exited with code ${exitCode}${detail}`);
+    }
+    return;
+  }
+  if (runtimeError && !translator.terminalEmitted()) {
+    yield* translator.fail(`kimi runtime error: ${runtimeError.message}`);
+    return;
+  }
+
+  yield* translator.finish('normal');
+}
+
+async function waitForExitCode(child: KimiChild): Promise<number | null> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return child.exitCode;
+  }
+  return new Promise<number | null>((resolve) => {
+    child.once('exit', (code) => resolve(code));
+  });
+}
+
+function isWindowsCommandNotFoundLine(line: string): boolean {
+  return (
+    process.platform === 'win32' &&
+    /is not recognized as an internal or external command|operable program or batch file/i.test(line)
+  );
+}

--- a/src/agent/kimi/argv.ts
+++ b/src/agent/kimi/argv.ts
@@ -1,0 +1,30 @@
+export interface BuildKimiArgsInput {
+  prompt: string;
+  sessionId?: string;
+  model?: string;
+}
+
+/**
+ * Build the argv for a `kimi` CLI run in stream-json output mode.
+ *
+ * The prompt (already prefixed with the bridge system prompt) goes through
+ * `-p` on the argv. macOS spawns `kimi` directly without a shell, so the
+ * `<bridge_context>` XML in the prompt is never interpreted. On Windows the
+ * `kimi` binary may resolve to a `.cmd` shim routed through cmd.exe, which
+ * would treat `<` / `>` as redirection operators — mirror the Codex adapter's
+ * stdin/temp-file prompt strategy if Windows support is ever needed.
+ *
+ * `--yolo` / `--auto` / `--plan` are mutually exclusive with `-p`, so no
+ * permission flag is passed here; the kimi adapter ignores sandbox /
+ * permissionMode entirely and `/status` displays the access mode instead.
+ */
+export function buildKimiArgs(input: BuildKimiArgsInput): string[] {
+  return [
+    '-p',
+    input.prompt,
+    '--output-format',
+    'stream-json',
+    ...(input.sessionId ? ['--session', input.sessionId] : []),
+    ...(input.model ? ['-m', input.model] : []),
+  ];
+}

--- a/src/agent/kimi/stream-json.ts
+++ b/src/agent/kimi/stream-json.ts
@@ -1,0 +1,203 @@
+import type { AgentEvent } from '../types';
+import { log } from '../../core/logger';
+
+export type KimiFinishReason = 'failed' | 'normal' | 'interrupted' | 'timeout';
+
+export interface ProtocolDriftState {
+  unknownEvents: number;
+  anomalies: number;
+}
+
+/**
+ * Translates `kimi --output-format stream-json` lines (one JSON object per
+ * line) into bridge AgentEvents.
+ *
+ * Kimi's schema differs from claude/codex: the top-level discriminator is
+ * `role`, with the concrete variant in `type`:
+ *
+ *   {"role":"meta","type":"system.version","version":"0.33.0"}
+ *   {"role":"meta","type":"session.resume_hint","session_id":"session_<uuid>","command":"kimi -r ..."}
+ *   {"role":"assistant","tool_calls":[{"type":"function","id":"tool_xxx","function":{"name":"Read","arguments":"{\"path\":\"probe.txt\"}"}}]}
+ *   {"role":"assistant","content":"回复文本"}
+ *   {"role":"tool","tool_call_id":"tool_xxx","content":"..."}
+ *
+ * There is no terminal event in the stream: a run just ends. The adapter calls
+ * finish() with the actual outcome once the child exits, so the translator
+ * never emits done/error from inside translate() except via fail().
+ */
+export class KimiJsonlTranslator {
+  private sessionId: string | undefined;
+  private terminal = false;
+  private lastNonTerminalError: string | undefined;
+  private pendingAgentMessage: string | undefined;
+  private drift: ProtocolDriftState = {
+    unknownEvents: 0,
+    anomalies: 0,
+  };
+
+  translate(raw: unknown): AgentEvent[] {
+    if (this.terminal) return [];
+    if (!isRecord(raw) || typeof raw.role !== 'string') {
+      this.drift.anomalies++;
+      return [];
+    }
+
+    switch (raw.role) {
+      case 'meta':
+        return this.translateMeta(raw);
+      case 'assistant':
+        return this.translateAssistant(raw);
+      case 'tool':
+        return this.translateTool(raw);
+      default:
+        this.drift.unknownEvents++;
+        log.warn('jsonl', 'unknown_event', { role: raw.role });
+        return [];
+    }
+  }
+
+  finish(reason: KimiFinishReason = 'failed'): AgentEvent[] {
+    if (this.terminal) return [];
+    this.terminal = true;
+    if (reason === 'failed') {
+      const detail = this.lastNonTerminalError ? `: ${this.lastNonTerminalError}` : '';
+      return this.prependPendingText([
+        {
+          type: 'error',
+          message: truncate(`kimi stream ended before a terminal event${detail}`, 4096),
+          terminationReason: 'failed',
+        },
+      ]);
+    }
+    // Interrupted/timeout still flush the partial answer as final_text — a
+    // half-finished reply is more useful to the user than losing it entirely
+    // (deviation from the plan, which only flushed final_text on the normal
+    // path; all non-failed outcomes flush it).
+    return this.prependPendingText([
+      { type: 'done', sessionId: this.sessionId, terminationReason: reason },
+    ]);
+  }
+
+  fail(message: string): AgentEvent[] {
+    if (this.terminal) return [];
+    this.terminal = true;
+    return this.prependPendingText([
+      { type: 'error', message: truncate(message, 4096), terminationReason: 'failed' },
+    ]);
+  }
+
+  protocolDrift(): ProtocolDriftState {
+    return { ...this.drift };
+  }
+
+  terminalEmitted(): boolean {
+    return this.terminal;
+  }
+
+  private translateMeta(raw: Record<string, unknown>): AgentEvent[] {
+    const type = stringValue(raw.type);
+    if (type === 'session.resume_hint') {
+      const sessionId = stringValue(raw.session_id ?? raw.sessionId);
+      if (!sessionId) {
+        this.drift.anomalies++;
+        return [];
+      }
+      this.sessionId = sessionId;
+      return [{ type: 'system', sessionId }];
+    }
+    if (type === 'system.version') {
+      // version banner; not actionable by the bridge
+      return [];
+    }
+    this.drift.unknownEvents++;
+    log.warn('jsonl', 'unknown_event', { role: 'meta', type });
+    return [];
+  }
+
+  private translateAssistant(raw: Record<string, unknown>): AgentEvent[] {
+    const events: AgentEvent[] = [];
+    const toolCalls = Array.isArray(raw.tool_calls) ? raw.tool_calls : [];
+    for (const call of toolCalls) {
+      const record = recordValue(call);
+      const id = stringValue(record?.id);
+      if (!record || !id) {
+        this.drift.anomalies++;
+        continue;
+      }
+      const fn = recordValue(record.function);
+      events.push({
+        type: 'tool_use',
+        id,
+        name: stringValue(fn?.name) ?? 'unknown',
+        input: parseFunctionArguments(stringValue(fn?.arguments)),
+      });
+    }
+    const content = stringValue(raw.content);
+    if (content) {
+      events.push(...this.queueAgentMessage(content));
+    }
+    return events;
+  }
+
+  private translateTool(raw: Record<string, unknown>): AgentEvent[] {
+    const id = stringValue(raw.tool_call_id);
+    if (!id) {
+      this.drift.anomalies++;
+      return [];
+    }
+    return this.prependPendingText([
+      {
+        type: 'tool_result',
+        id,
+        output: stringValue(raw.content) ?? '',
+        isError: false,
+      },
+    ]);
+  }
+
+  private queueAgentMessage(message: string): AgentEvent[] {
+    // kimi can announce the same text more than once (e.g. a streaming
+    // assistant event and the final snapshot). An identical repeat is the
+    // same message, not a new one — otherwise it would stream as progress
+    // commentary and then again as the final answer.
+    if (message === this.pendingAgentMessage) return [];
+    const events = this.pendingAgentMessage
+      ? [{ type: 'text' as const, delta: this.pendingAgentMessage }]
+      : [];
+    this.pendingAgentMessage = message;
+    return events;
+  }
+
+  private prependPendingText(events: AgentEvent[]): AgentEvent[] {
+    if (events.length === 0 || !this.pendingAgentMessage) return events;
+    const pending = this.pendingAgentMessage;
+    this.pendingAgentMessage = undefined;
+    return [{ type: 'text', delta: pending }, ...events];
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return isRecord(value) ? value : undefined;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function parseFunctionArguments(raw: string | undefined): unknown {
+  if (raw === undefined) return {};
+  try {
+    return JSON.parse(raw) as unknown;
+  } catch {
+    // arguments not serializable as JSON — pass through verbatim
+    return raw;
+  }
+}
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? value.slice(0, max) : value;
+}

--- a/src/agent/models.ts
+++ b/src/agent/models.ts
@@ -43,9 +43,27 @@ const CODEX_MODELS: ModelOption[] = [
   { value: 'o3', label: 'o3' },
 ];
 
+/**
+ * Kimi Code models. Forwarded to `kimi -p -m <model>`. Kimi Code resolves
+ * unversioned aliases like `kimi-code` itself, so the picker keeps the short
+ * alias list instead of pinned ids.
+ */
+const KIMI_MODELS: ModelOption[] = [
+  { value: DEFAULT_MODEL, label: '跟随默认（不指定）' },
+  { value: 'kimi-code', label: 'Kimi Code（默认）' },
+  { value: 'kimi-for-coding', label: 'Kimi For Coding' },
+];
+
 /** The model picker options for a profile's agent kind. */
 export function supportedModels(agentKind: AgentKind): ModelOption[] {
-  return agentKind === 'codex' ? CODEX_MODELS : CLAUDE_MODELS;
+  switch (agentKind) {
+    case 'codex':
+      return CODEX_MODELS;
+    case 'kimi':
+      return KIMI_MODELS;
+    default:
+      return CLAUDE_MODELS;
+  }
 }
 
 /** True when the selection means "use the agent default" (no `--model`). */

--- a/src/agent/preflight.ts
+++ b/src/agent/preflight.ts
@@ -1,6 +1,6 @@
 import { spawnProcess } from '../platform/spawn';
 
-export type LocalAgentId = 'claude' | 'codex';
+export type LocalAgentId = 'claude' | 'codex' | 'kimi';
 
 export type AgentPreflightErrorCode =
   | 'agent-binary-not-found'
@@ -279,7 +279,7 @@ export function isAgentPreflightDiagnostic(input: unknown): input is AgentPrefli
   return (
     typeof raw.code === 'string' &&
     raw.code.startsWith('agent-') &&
-    (raw.agentId === 'claude' || raw.agentId === 'codex') &&
+    (raw.agentId === 'claude' || raw.agentId === 'codex' || raw.agentId === 'kimi') &&
     typeof raw.agentName === 'string' &&
     typeof raw.command === 'string'
   );

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -5,7 +5,7 @@ import type {
 } from '@larksuite/channel';
 import { createLarkChannel } from '@larksuite/channel';
 import { dirname, join } from 'node:path';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { capabilityForProfile } from '../agent/capability';
 import { modelLabel, normalizeModelSelection, resolveModelArg } from '../agent/models';
 import {
   buildAgentPrompt,
@@ -955,10 +955,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     actorId: firstMsg.senderId,
     ...(threadId ? { threadId } : {}),
   };
-  const capability =
-    controls.profileConfig.agentKind === 'codex'
-      ? codexCapability(controls.profileConfig)
-      : claudeCapability(controls.profileConfig);
+  const capability = capabilityForProfile(controls.profileConfig);
   const flow = await startRunFlow({
     scopeId: scope,
     scope: scopeContext,

--- a/src/bot/comments.ts
+++ b/src/bot/comments.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { CommentEvent, LarkChannel } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { capabilityForProfile } from '../agent/capability';
 import type { AgentAdapter, AgentEvent } from '../agent/types';
 import { getAgentStopGraceMs } from '../config/schema';
 import type { Controls } from '../commands';
@@ -186,10 +186,7 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
     : false;
 
   try {
-    const capability =
-      controls.profileConfig.agentKind === 'codex'
-        ? codexCapability(controls.profileConfig)
-        : claudeCapability(controls.profileConfig);
+    const capability = capabilityForProfile(controls.profileConfig);
     const runTimeoutMs = commentRunTimeoutMs(sessions, runScopeId);
     const threadTimeoutMs = commentRunTimeoutMs(sessions, commentThreadScopeId);
     const commentTimeoutMs = runTimeoutMs !== undefined ? runTimeoutMs : threadTimeoutMs;
@@ -243,7 +240,8 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
           })
         : undefined;
       const sessionId =
-        canResumeAgentSession && capability.agentId === 'claude'
+        canResumeAgentSession &&
+        (capability.agentId === 'claude' || capability.agentId === 'kimi')
           ? sessions.resumeFor(docSessionScopeId, cwdRealpath) ??
             sessions.resumeFor(legacyDocSessionScopeId, cwdRealpath)
           : undefined;
@@ -328,7 +326,11 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
             policy,
             event: e,
           });
-          if (capability.agentId === 'claude' && e.type === 'system' && e.sessionId) {
+          if (
+            (capability.agentId === 'claude' || capability.agentId === 'kimi') &&
+            e.type === 'system' &&
+            e.sessionId
+          ) {
             sessions.set(docSessionScopeId, e.sessionId, policy.cwdRealpath);
           }
           switch (e.type) {

--- a/src/bot/run-flow.ts
+++ b/src/bot/run-flow.ts
@@ -120,7 +120,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
       cwdRealpath: workspace.cwdRealpath,
       policyFingerprint: policy.policyFingerprint,
     });
-    if (catalogEntry?.agentId === 'claude') {
+    if (catalogEntry?.agentId === 'claude' || catalogEntry?.agentId === 'kimi') {
       sessionId = catalogEntry.sessionId;
       resumeFrom = sessionId;
     } else if (catalogEntry?.agentId === 'codex') {
@@ -128,7 +128,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
       resumeFrom = threadId;
     }
   }
-  if (!resumeFrom && input.capability.agentId === 'claude') {
+  if (!resumeFrom && (input.capability.agentId === 'claude' || input.capability.agentId === 'kimi')) {
     resumeFrom = input.sessions.resumeFor(input.scopeId, workspace.cwdRealpath);
     sessionId = resumeFrom;
     const stale = input.sessions.getRaw(input.scopeId);
@@ -188,12 +188,15 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
 
 export function recordRunSessionEvent(input: RecordRunSessionEventInput): void {
   if (input.event.type !== 'system') return;
-  if (input.capability.agentId === 'claude' && input.event.sessionId) {
+  if (
+    (input.capability.agentId === 'claude' || input.capability.agentId === 'kimi') &&
+    input.event.sessionId
+  ) {
     const cwdRealpath = input.event.cwd ?? input.policy.cwdRealpath;
     input.sessions.set(input.scopeId, input.event.sessionId, cwdRealpath);
     input.sessionCatalog?.upsertActive({
       scopeId: input.scopeId,
-      agentId: 'claude',
+      agentId: input.capability.agentId,
       cwdRealpath,
       policyFingerprint: input.policy.policyFingerprint,
       sessionId: input.event.sessionId,

--- a/src/bot/session-catalog-identity.ts
+++ b/src/bot/session-catalog-identity.ts
@@ -1,5 +1,5 @@
 import type { NormalizedMessage } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { capabilityForProfile } from '../agent/capability';
 import type { Controls } from '../commands';
 import type { AccessDecision } from '../policy/access';
 import { evaluateRunPolicy } from '../policy/run-policy';
@@ -21,10 +21,7 @@ export async function commandSessionCatalogIdentity(input: {
   if (!requestedCwd) return undefined;
   const workspace = await resolveWorkingDirectory(requestedCwd);
   if (!workspace.ok) return undefined;
-  const capability =
-    input.controls.profileConfig.agentKind === 'codex'
-      ? codexCapability(input.controls.profileConfig)
-      : claudeCapability(input.controls.profileConfig);
+  const capability = capabilityForProfile(input.controls.profileConfig);
   const policy = evaluateRunPolicy({
     scope: {
       source: 'im',

--- a/src/cli/agent-detection.ts
+++ b/src/cli/agent-detection.ts
@@ -2,7 +2,7 @@ import { constants } from 'node:fs';
 import { access } from 'node:fs/promises';
 import { delimiter, extname, isAbsolute, join } from 'node:path';
 
-export type AgentKind = 'claude' | 'codex';
+export type AgentKind = 'claude' | 'codex' | 'kimi';
 
 export interface DetectedAgent {
   kind: AgentKind;
@@ -48,6 +48,7 @@ export async function detectInstalledAgents(): Promise<DetectedAgent[]> {
   const candidates: Array<{ kind: AgentKind; command: string }> = [
     { kind: 'claude', command: process.env.LARK_CHANNEL_CLAUDE_BIN ?? 'claude' },
     { kind: 'codex', command: process.env.LARK_CHANNEL_CODEX_BIN ?? 'codex' },
+    { kind: 'kimi', command: process.env.LARK_CHANNEL_KIMI_BIN ?? 'kimi' },
   ];
   const detected: DetectedAgent[] = [];
   for (const candidate of candidates) {

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, readdir, rename, rm, stat } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { createBootstrapCodexConfig } from '../profile-bootstrap';
+import { createBootstrapCodexConfig, createBootstrapKimiConfig } from '../profile-bootstrap';
 import { promptLine } from '../prompt';
 import { stopProcessEntry } from './ps';
 import {
@@ -43,7 +43,13 @@ export async function runMigrate(opts: MigrateOptions): Promise<void> {
   const configPath = opts.config ?? paths.configFile;
   await migrateLegacyPaths();
   await migrateConfigShape(configPath);
-  const agentKind = agentKindFromString(opts.agent) ?? (opts.profile === 'codex' ? 'codex' : undefined);
+  const agentKind =
+    agentKindFromString(opts.agent) ??
+    (opts.profile === 'codex'
+      ? 'codex'
+      : opts.profile === 'kimi'
+        ? 'kimi'
+        : undefined);
   const needsV2Migration = await hasLegacyProfileConfig(configPath);
   const result = await migrateProfileV2WithActiveBridgePrompt({
     rootDir: dirname(configPath),
@@ -52,6 +58,9 @@ export async function runMigrate(opts: MigrateOptions): Promise<void> {
     ...(agentKind ? { agentKind } : {}),
     ...(needsV2Migration && agentKind === 'codex'
       ? { codex: await createBootstrapCodexConfig(undefined) }
+      : {}),
+    ...(needsV2Migration && agentKind === 'kimi'
+      ? { kimi: await createBootstrapKimiConfig(undefined) }
       : {}),
   }, opts);
   if (!result) return;

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -607,5 +607,7 @@ async function maybeResolveProfileRuntime(
 function agentDisplay(agentKind: ProcessEntry['agentKind']): { id: string; displayName: string } {
   return agentKind === 'codex'
     ? { id: 'codex', displayName: 'Codex CLI' }
-    : { id: 'claude', displayName: 'Claude Code' };
+    : agentKind === 'kimi'
+      ? { id: 'kimi', displayName: 'Kimi Code' }
+      : { id: 'claude', displayName: 'Claude Code' };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -41,7 +41,7 @@ program
   .option('-c, --config <path>', 'path to config file')
   .option('--profile <name>', 'profile name to run')
   .option('--web-ui', 'run the machine-wide supervisor + local web console (hosts all profiles); default is a single-profile headless run')
-  .option('--agent <kind>', 'agent kind for a new profile (claude or codex)')
+  .option('--agent <kind>', 'agent kind for a new profile (claude, codex or kimi)')
   .option('--workspace <path>', 'initial working directory for first-run profile bootstrap')
   .option('--app-id <id>', 'use an existing Lark/Feishu app instead of QR app creation')
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')
@@ -66,7 +66,7 @@ program
   .description('Migrate legacy bridge config/state into the current profile layout')
   .option('-c, --config <path>', 'path to config file')
   .option('--profile <name>', 'target profile name for legacy v1 config migration')
-  .option('--agent <kind>', 'agent kind for legacy v1 profile migration (claude or codex)')
+  .option('--agent <kind>', 'agent kind for legacy v1 profile migration (claude, codex or kimi)')
   .action(async (opts: { config?: string; profile?: string; agent?: string }) => {
     await runMigrate(opts);
   });
@@ -85,7 +85,7 @@ profile
 profile
   .command('create <name>')
   .description('Create a profile from QR registration or existing app credentials')
-  .option('--agent <kind>', 'agent kind (claude or codex)')
+  .option('--agent <kind>', 'agent kind (claude, codex or kimi)')
   .option('--workspace <path>', 'initial working directory for this profile')
   .option('--app-id <id>', 'use an existing Lark/Feishu app instead of QR app creation')
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')
@@ -167,7 +167,7 @@ program
   .description('Install (if needed) and start the bridge as an OS-managed daemon')
   .option('--profile <name>', 'profile name (defaults to active profile)')
   .option('--web-ui', 'run the supervisor + web console as the background service (hosts all profiles) instead of a single profile')
-  .option('--agent <kind>', 'agent kind for first-run profile bootstrap (claude or codex)')
+  .option('--agent <kind>', 'agent kind for first-run profile bootstrap (claude, codex or kimi)')
   .option('--workspace <path>', 'initial working directory for first-run profile bootstrap')
   .option('--app-id <id>', 'use an existing Lark/Feishu app instead of QR app creation')
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')

--- a/src/cli/profile-bootstrap.ts
+++ b/src/cli/profile-bootstrap.ts
@@ -14,6 +14,7 @@ export interface BootstrapProfileInput {
   workspace?: string;
   defaultWorkspace?: string;
   codexBinaryPath?: string;
+  kimiBinaryPath?: string;
   profileDir?: string;
 }
 
@@ -29,12 +30,17 @@ export async function createBootstrapProfileConfig(
     input.agentKind === 'codex'
       ? await createBootstrapCodexConfig(input.codexBinaryPath)
       : undefined;
+  const kimi =
+    input.agentKind === 'kimi'
+      ? await createBootstrapKimiConfig(input.kimiBinaryPath)
+      : undefined;
   const profile = createDefaultProfileConfig({
     agentKind: input.agentKind,
     accounts: input.accounts,
     preferences: input.preferences,
     secrets: input.secrets,
     ...(codex ? { codex } : {}),
+    ...(kimi ? { kimi } : {}),
   });
   if (workspace) {
     profile.workspaces = {
@@ -76,6 +82,33 @@ export async function createBootstrapCodexConfig(binaryPath: string | undefined)
     });
   }
   return { binaryPath: resolvedBinary };
+}
+
+export async function createBootstrapKimiConfig(binaryPath: string | undefined) {
+  const command = binaryPath ?? process.env.LARK_CHANNEL_KIMI_BIN ?? 'kimi';
+  let resolvedBinary: string;
+  try {
+    resolvedBinary = await resolveExecutablePath(command);
+  } catch (err) {
+    const errno = (err as NodeJS.ErrnoException).code;
+    throw new AgentPreflightError({
+      code: kimiBootstrapBinaryErrorCode(errno),
+      agentId: 'kimi',
+      agentName: 'Kimi Code',
+      command,
+      binaryPath: command,
+      errno,
+    });
+  }
+  return { binaryPath: resolvedBinary };
+}
+
+function kimiBootstrapBinaryErrorCode(errno: string | undefined) {
+  if (errno === 'EACCES' || errno === 'EPERM') return 'agent-binary-not-executable';
+  if (errno === 'ELOOP' || errno === 'ENOTDIR' || errno === 'EINVAL') {
+    return 'agent-binary-resolve-failed';
+  }
+  return 'agent-binary-not-found';
 }
 
 function codexBootstrapBinaryErrorCode(errno: string | undefined) {

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute } from 'node:path';
 import type { LarkChannel, NormalizedMessage } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { capabilityForProfile } from '../agent/capability';
 import { DEFAULT_MODEL, normalizeModelSelection, supportedModels } from '../agent/models';
 import type { AgentAdapter } from '../agent/types';
 import type { ActiveRuns } from '../bot/active-runs';
@@ -62,6 +62,7 @@ import {
   type RunState,
 } from '../card/run-state';
 import { formatRelTime, listRecentSessions, type SessionSummary } from '../session/history';
+import { listKimiSessions } from '../session/kimi-history';
 import {
   listCodexThreadHistory,
   type CodexThreadHistoryEntry,
@@ -141,6 +142,7 @@ export interface CommandContext {
     options: ListCodexThreadHistoryOptions,
   ) => Promise<CodexThreadHistoryEntry[]>;
   claudeHistoryProvider?: (cwd: string, limit: number) => Promise<SessionSummary[]>;
+  kimiHistoryProvider?: (cwd: string, limit: number) => Promise<SessionSummary[]>;
   /** Set when invoked from a CardKit 2.0 form submit. Keys are input `name`s. */
   formValue?: Record<string, unknown>;
   /** True when this invocation came from a card button click rather than a
@@ -153,7 +155,7 @@ type Handler = (args: string, ctx: CommandContext) => Promise<void>;
 
 interface ResumeCandidate {
   scopeId: string;
-  agentId: 'claude' | 'codex';
+  agentId: 'claude' | 'codex' | 'kimi';
   cwdRealpath: string;
   policyFingerprint: string;
   sessionId?: string;
@@ -590,6 +592,23 @@ async function handleResume(args: string, ctx: CommandContext): Promise<void> {
     const card = resumeCard(cwd, []);
     await ctx.channel.send(ctx.msg.chatId, { card }, commandReplyOptions(ctx));
     return;
+  } else if (ctx.controls.profileConfig.agentKind === 'kimi') {
+    const sessions = await listKimiResumeHistory(ctx, cwd, limit);
+    const currentSession = ctx.sessions.getRaw(ctx.scope);
+    const identity = ctx.sessionCatalogIdentity;
+    const entries = sessions.map((s) => ({
+      sessionId: identity
+        ? issueResumeCandidate(identity, { sessionId: s.sessionId })
+        : s.sessionId,
+      displayId: s.sessionId,
+      preview: s.preview,
+      relTime: formatRelTime(s.mtime),
+      lineCount: s.lineCount,
+      current: s.sessionId === currentSession?.sessionId,
+    }));
+    const card = resumeCard(cwd, entries);
+    await ctx.channel.send(ctx.msg.chatId, { card }, commandReplyOptions(ctx));
+    return;
   }
 
   const sessions = await listClaudeResumeHistory(ctx, cwd, limit);
@@ -626,7 +645,7 @@ async function applyResume(sessionId: string, ctx: CommandContext): Promise<void
       } else {
         ctx.sessionCatalog.upsertActive({
           scopeId: ctx.sessionCatalogIdentity.scopeId,
-          agentId: 'claude',
+          agentId: ctx.sessionCatalogIdentity.agentId,
           cwdRealpath: ctx.sessionCatalogIdentity.cwdRealpath,
           policyFingerprint: ctx.sessionCatalogIdentity.policyFingerprint,
           sessionId: resolved.sessionId!,
@@ -646,7 +665,10 @@ async function applyResume(sessionId: string, ctx: CommandContext): Promise<void
       return;
     }
     ctx.activeRuns.interrupt(ctx.scope);
-    if (ctx.sessionCatalogIdentity.agentId === 'claude') {
+    if (
+      ctx.sessionCatalogIdentity.agentId === 'claude' ||
+      ctx.sessionCatalogIdentity.agentId === 'kimi'
+    ) {
       ctx.sessions.set(ctx.scope, sessionId, ctx.sessionCatalogIdentity.cwdRealpath);
     }
     await reply(ctx, RESUME_APPLIED_REPLY);
@@ -699,7 +721,8 @@ function consumeResumeCandidate(
     candidate.agentId !== identity.agentId ||
     candidate.cwdRealpath !== identity.cwdRealpath ||
     candidate.policyFingerprint !== identity.policyFingerprint ||
-    (identity.agentId === 'claude' && !candidate.sessionId) ||
+    ((identity.agentId === 'claude' || identity.agentId === 'kimi') &&
+      !candidate.sessionId) ||
     (identity.agentId === 'codex' && !candidate.threadId)
   ) {
     return undefined;
@@ -720,6 +743,22 @@ async function listClaudeResumeHistory(
 ): Promise<SessionSummary[]> {
   const provider = ctx.claudeHistoryProvider ?? listRecentSessions;
   return provider(cwd, limit);
+}
+
+async function listKimiResumeHistory(
+  ctx: CommandContext,
+  cwd: string,
+  limit: number,
+): Promise<SessionSummary[]> {
+  const provider = ctx.kimiHistoryProvider ?? listKimiSessions;
+  try {
+    return await provider(cwd, limit);
+  } catch (err) {
+    log.warn('session', 'kimi-history-failed', {
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
 }
 
 async function listCodexResumeHistory(
@@ -762,7 +801,7 @@ function selectedResumeCwd(ctx: CommandContext): string | undefined {
 function runtimeAccessStatus(
   profileConfig: ProfileConfig,
 ): { label: string; value: string } {
-  if (profileConfig.agentKind === 'claude') {
+  if (profileConfig.agentKind === 'claude' || profileConfig.agentKind === 'kimi') {
     return {
       label: 'permission',
       value: accessToClaudePermissionMode(
@@ -1127,10 +1166,7 @@ async function handleDoctor(args: string, ctx: CommandContext): Promise<void> {
   }
   doctorLastByOperator.set(rateKey, now);
 
-  const capability =
-    ctx.controls.profileConfig.agentKind === 'codex'
-      ? codexCapability(ctx.controls.profileConfig)
-      : claudeCapability(ctx.controls.profileConfig);
+  const capability = capabilityForProfile(ctx.controls.profileConfig);
   const policy = evaluateRunPolicy({
     scope: {
       source: 'im',

--- a/src/config/migrate-v2.ts
+++ b/src/config/migrate-v2.ts
@@ -13,6 +13,7 @@ import {
   createDefaultProfileConfig,
   type AgentKind,
   type CodexConfig,
+  type KimiConfig,
   type RootConfig,
 } from './profile-schema';
 import { markPermissionDefaultsMigration, saveRootConfig } from './profile-store';
@@ -27,6 +28,7 @@ export interface MigrateV2Options {
   workspace?: string;
   agentKind?: AgentKind;
   codex?: CodexConfig;
+  kimi?: KimiConfig;
 }
 
 export interface MigrateV2Result {
@@ -129,6 +131,7 @@ export async function migrateV1ToV2(opts: MigrateV2Options = {}): Promise<Migrat
       requireMentionInGroup: legacy.preferences?.requireMentionInGroup,
     },
     ...(agentKind === 'codex' && opts.codex ? { codex: opts.codex } : {}),
+    ...(agentKind === 'kimi' && opts.kimi ? { kimi: opts.kimi } : {}),
   });
   if (legacyDefaultWorkspace) {
     profileConfig.workspaces = {
@@ -200,7 +203,13 @@ function activeProcessFromRegistryEntry(entry: RegistryEntry): ActiveBridgeMigra
   if (typeof entry.appId === 'string') active.appId = entry.appId;
   if (typeof entry.tenant === 'string') active.tenant = entry.tenant;
   if (typeof entry.profileName === 'string') active.profileName = entry.profileName;
-  if (entry.agentKind === 'claude' || entry.agentKind === 'codex') active.agentKind = entry.agentKind;
+  if (
+    entry.agentKind === 'claude' ||
+    entry.agentKind === 'codex' ||
+    entry.agentKind === 'kimi'
+  ) {
+    active.agentKind = entry.agentKind;
+  }
   if (typeof entry.configPath === 'string') active.configPath = entry.configPath;
   if (typeof entry.startedAt === 'string') active.startedAt = entry.startedAt;
   if (typeof entry.version === 'string') active.version = entry.version;

--- a/src/config/profile-schema.ts
+++ b/src/config/profile-schema.ts
@@ -13,7 +13,7 @@ import {
   type PermissionSource,
 } from './permissions';
 
-export type AgentKind = 'claude' | 'codex';
+export type AgentKind = 'claude' | 'codex' | 'kimi';
 export type SandboxMode = CodexSandboxMode;
 export type { AccessMode, PermissionConfig, PermissionSource };
 
@@ -49,6 +49,15 @@ export interface CodexConfig {
   inheritCodexHome?: boolean;
   ignoreUserConfig?: boolean;
   ignoreRules?: boolean;
+}
+
+export interface KimiConfig {
+  binaryPath: string;
+  realpath?: string;
+  version?: string;
+  sha256?: string;
+  owner?: number;
+  mode?: number;
 }
 
 export interface AttachmentConfig {
@@ -160,6 +169,7 @@ export interface ProfileConfig {
   permissions: PermissionConfig;
   permissionSource?: PermissionSource;
   codex?: CodexConfig;
+  kimi?: KimiConfig;
   attachments: AttachmentConfig;
   comments: CommentConfig;
   /** In-meeting agent settings. See {@link MeetingConfig}. */
@@ -204,6 +214,7 @@ export interface CreateDefaultProfileConfigInput {
   sandbox?: Partial<SandboxConfig>;
   permissions?: Partial<PermissionConfig>;
   codex?: CodexConfig;
+  kimi?: KimiConfig;
   secrets?: SecretsConfig;
 }
 
@@ -239,6 +250,7 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
     sandbox?: Partial<SandboxConfig>;
     permissions?: Partial<PermissionConfig>;
     codex?: CodexConfig & { flags?: unknown };
+    kimi?: KimiConfig;
     attachments?: Partial<AttachmentConfig>;
     comments?: unknown;
     meeting?: unknown;
@@ -248,12 +260,15 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
   if (raw.schemaVersion !== 2) {
     throw new Error('profile schemaVersion must be 2');
   }
-  if (raw.agentKind !== 'claude' && raw.agentKind !== 'codex') {
-    throw new Error('agentKind must be claude or codex');
+  if (raw.agentKind !== 'claude' && raw.agentKind !== 'codex' && raw.agentKind !== 'kimi') {
+    throw new Error('agentKind must be claude, codex or kimi');
   }
   const accounts = normalizeAccounts(raw.accounts);
   if (raw.agentKind === 'codex' && !raw.codex) {
     throw new Error('codex profile requires codex configuration');
+  }
+  if (raw.agentKind === 'kimi' && !raw.kimi) {
+    throw new Error('kimi profile requires kimi configuration');
   }
 
   const preferences = normalizePreferences(raw.preferences);
@@ -284,6 +299,7 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
     permissions,
     permissionSource,
     ...(raw.codex ? { codex: normalizeCodex(raw.codex) } : {}),
+    ...(raw.kimi ? { kimi: normalizeKimi(raw.kimi) } : {}),
     attachments: {
       maxCount: numberOr(raw.attachments?.maxCount, 10),
       maxBytes: numberOr(raw.attachments?.maxBytes, 100 * 1024 * 1024),
@@ -389,6 +405,18 @@ function normalizeCodex(input: CodexConfig & { flags?: unknown }): CodexConfig {
     ignoreRules: input.ignoreRules !== false,
   };
   return codex;
+}
+
+function normalizeKimi(input: KimiConfig): KimiConfig {
+  const kimi: KimiConfig = {
+    binaryPath: input.binaryPath,
+    ...(typeof input.realpath === 'string' ? { realpath: input.realpath } : {}),
+    ...(typeof input.version === 'string' ? { version: input.version } : {}),
+    ...(typeof input.sha256 === 'string' ? { sha256: input.sha256 } : {}),
+    ...(typeof input.owner === 'number' ? { owner: input.owner } : {}),
+    ...(typeof input.mode === 'number' ? { mode: input.mode } : {}),
+  };
+  return kimi;
 }
 
 function normalizeComments(_input: unknown): CommentConfig {

--- a/src/config/profile-store.ts
+++ b/src/config/profile-store.ts
@@ -57,6 +57,7 @@ type StoredProfileConfig = Pick<
   | 'workspaces'
   | 'permissions'
   | 'codex'
+  | 'kimi'
   | 'attachments'
   | 'comments'
   | 'meeting'
@@ -96,6 +97,7 @@ function serializeProfileConfig(profile: ProfileConfig): StoredProfileConfig {
     workspaces: profile.workspaces,
     permissions: profile.permissions,
     ...(profile.codex ? { codex: profile.codex } : {}),
+    ...(profile.kimi ? { kimi: profile.kimi } : {}),
     attachments: profile.attachments,
     comments: {},
     meeting: profile.meeting,
@@ -296,7 +298,7 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 export function agentKindFromString(value: string | undefined): AgentKind | undefined {
-  if (value === 'claude' || value === 'codex') return value;
+  if (value === 'claude' || value === 'codex' || value === 'kimi') return value;
   if (value === undefined) return undefined;
   throw new Error(`unsupported agent: ${value}`);
 }

--- a/src/meeting/orchestrator.ts
+++ b/src/meeting/orchestrator.ts
@@ -1,6 +1,6 @@
 import type { LarkChannel } from '@larksuite/channel';
 import type { AgentEvent } from '../agent/types';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { capabilityForProfile } from '../agent/capability';
 import type { Controls } from '../commands';
 import { log } from '../core/logger';
 import type { RunExecutor } from '../runtime/run-executor';
@@ -295,10 +295,7 @@ async function runMeetingAgent(
 ): Promise<string> {
   const { session, controls } = deps;
   const scopeId = meetingScopeId(session.meetingId);
-  const capability =
-    controls.profileConfig.agentKind === 'codex'
-      ? codexCapability(controls.profileConfig)
-      : claudeCapability(controls.profileConfig);
+  const capability = capabilityForProfile(controls.profileConfig);
   const result = await startRunFlow({
     scopeId,
     scope: {

--- a/src/runtime/agent-runtime.ts
+++ b/src/runtime/agent-runtime.ts
@@ -1,5 +1,6 @@
 import { ClaudeAdapter } from '../agent/claude/adapter';
 import { CodexAdapter } from '../agent/codex/adapter';
+import { KimiAdapter } from '../agent/kimi/adapter';
 import { AgentPreflightError, type AgentAvailability } from '../agent/preflight';
 import type { AgentAdapter } from '../agent/types';
 import type { AppPaths } from '../config/app-paths';
@@ -49,6 +50,16 @@ export function createRuntimeAgent(
       larkChannel,
     });
   }
+  if (profileConfig.agentKind === 'kimi') {
+    const kimi = profileConfig.kimi;
+    if (!kimi?.binaryPath) {
+      throw new Error('kimi profile requires kimi.binaryPath');
+    }
+    return new KimiAdapter({
+      binary: kimi.binaryPath,
+      larkChannel,
+    });
+  }
   return new ClaudeAdapter({ larkChannel });
 }
 
@@ -58,9 +69,14 @@ export async function checkRuntimeAgentAvailability(agent: AgentAdapter): Promis
   if (ok) return { ok: true };
   const diagnostic = {
     code: 'agent-binary-not-found' as const,
-    agentId: agent.id === 'codex' ? ('codex' as const) : ('claude' as const),
+    agentId:
+      agent.id === 'kimi'
+        ? ('kimi' as const)
+        : agent.id === 'codex'
+          ? ('codex' as const)
+          : ('claude' as const),
     agentName: agent.displayName,
-    command: agent.id === 'codex' ? 'codex' : 'claude',
+    command: agent.id === 'kimi' ? 'kimi' : agent.id === 'codex' ? 'codex' : 'claude',
   };
   return { ok: false, diagnostic, error: new AgentPreflightError(diagnostic) };
 }

--- a/src/runtime/locks.ts
+++ b/src/runtime/locks.ts
@@ -178,7 +178,7 @@ function isRuntimeLockMeta(value: unknown): value is RuntimeLockMeta {
     (meta.kind === 'profile' || meta.kind === 'app') &&
     typeof meta.target === 'string' &&
     typeof meta.profile === 'string' &&
-    (meta.agentKind === 'claude' || meta.agentKind === 'codex') &&
+    (meta.agentKind === 'claude' || meta.agentKind === 'codex' || meta.agentKind === 'kimi') &&
     typeof meta.pid === 'number' &&
     typeof meta.startedAt === 'string' &&
     (meta.appId === undefined || typeof meta.appId === 'string')

--- a/src/runtime/profile-runtime.ts
+++ b/src/runtime/profile-runtime.ts
@@ -5,6 +5,7 @@ import { runRegistrationWizard } from '../bot/wizard';
 import { detectInstalledAgents, type DetectedAgent } from '../cli/agent-detection';
 import {
   createBootstrapCodexConfig,
+  createBootstrapKimiConfig,
   createBootstrapProfileConfig,
   resolveBootstrapWorkspace,
 } from '../cli/profile-bootstrap';
@@ -90,6 +91,9 @@ export function createRuntimeProfileConfig(
     ...(input.agentKind === 'codex'
       ? { codex: input.codex ?? { binaryPath: process.env.LARK_CHANNEL_CODEX_BIN ?? 'codex' } }
       : {}),
+    ...(input.agentKind === 'kimi'
+      ? { kimi: input.kimi ?? { binaryPath: process.env.LARK_CHANNEL_KIMI_BIN ?? 'kimi' } }
+      : {}),
   });
 }
 
@@ -108,7 +112,7 @@ export async function resolveProfileRuntime(
   if (!profile && opts.allowBootstrap) {
     const detected = await detectInstalledAgents();
     if (detected.length === 0) {
-      throw new Error('no supported local agent found; install claude or codex first');
+      throw new Error('no supported local agent found; install claude, codex or kimi first');
     }
     if (detected.length > 1) {
       const selected = await selectDetectedAgent(detected, opts.selectAgent);
@@ -137,6 +141,9 @@ export async function resolveProfileRuntime(
     ...(migrationAgent ? { agentKind: migrationAgent } : {}),
     ...(needsMigration && migrationAgent === 'codex'
       ? { codex: await createBootstrapCodexConfig(undefined) }
+      : {}),
+    ...(needsMigration && migrationAgent === 'kimi'
+      ? { kimi: await createBootstrapKimiConfig(undefined) }
       : {}),
   }, opts.handleActiveBridgeMigrationConflict);
 
@@ -395,7 +402,7 @@ function resolveBootstrapAgent(
   requestedAgent: AgentKind | undefined,
   profile: string | undefined,
 ): AgentKind | undefined {
-  return requestedAgent ?? (profile === 'codex' ? 'codex' : undefined);
+  return requestedAgent ?? (profile === 'codex' ? 'codex' : profile === 'kimi' ? 'kimi' : undefined);
 }
 
 async function hasLegacyConfig(configPath: string): Promise<boolean> {
@@ -568,7 +575,7 @@ function formatAmbiguousAgentSelectionError(
 ): string {
   const lines = detected.map((agent) => `  - ${agent.kind}: ${agent.binaryPath}`);
   return [
-    '检测到多个本地 agent，请使用 --agent <claude|codex> 指定要初始化哪一个。',
+    '检测到多个本地 agent，请使用 --agent <claude|codex|kimi> 指定要初始化哪一个。',
     '已检测到：',
     ...lines,
   ].join('\n');
@@ -613,7 +620,7 @@ class UserCancelledError extends Error {
 }
 
 function displayAgentKind(kind: AgentKind): string {
-  return kind === 'claude' ? 'Claude Code' : 'Codex CLI';
+  return kind === 'claude' ? 'Claude Code' : kind === 'codex' ? 'Codex CLI' : 'Kimi Code';
 }
 
 async function maybeMigrateRootPlaintextSecret(

--- a/src/runtime/registry.ts
+++ b/src/runtime/registry.ts
@@ -64,7 +64,7 @@ function isValidEntry(e: unknown): e is ProcessEntry {
     typeof x.appId === 'string' &&
     (x.tenant === 'feishu' || x.tenant === 'lark') &&
     typeof x.profileName === 'string' &&
-    (x.agentKind === 'claude' || x.agentKind === 'codex') &&
+    (x.agentKind === 'claude' || x.agentKind === 'codex' || x.agentKind === 'kimi') &&
     typeof x.configPath === 'string' &&
     typeof x.startedAt === 'string' &&
     typeof x.version === 'string'

--- a/src/session/catalog.ts
+++ b/src/session/catalog.ts
@@ -214,7 +214,7 @@ function normalizeEntry(input: unknown): SessionCatalogEntry | undefined {
   if (
     typeof raw.key !== 'string' ||
     typeof raw.scopeId !== 'string' ||
-    (raw.agentId !== 'claude' && raw.agentId !== 'codex') ||
+    (raw.agentId !== 'claude' && raw.agentId !== 'codex' && raw.agentId !== 'kimi') ||
     typeof raw.cwdRealpath !== 'string' ||
     typeof raw.policyFingerprint !== 'string' ||
     (raw.status !== 'active' && raw.status !== 'archived') ||
@@ -247,14 +247,16 @@ function matchesIdentity(entry: SessionCatalogEntry, input: SessionCatalogIdenti
 }
 
 function isValidAgentEntry(entry: SessionCatalogEntry): boolean {
-  if (entry.agentId === 'claude') return Boolean(entry.sessionId) && !entry.threadId;
+  if (entry.agentId === 'claude' || entry.agentId === 'kimi') {
+    return Boolean(entry.sessionId) && !entry.threadId;
+  }
   return Boolean(entry.threadId) && !entry.sessionId;
 }
 
 function assertAgentIdentity(input: UpsertSessionCatalogInput): void {
-  if (input.agentId === 'claude') {
+  if (input.agentId === 'claude' || input.agentId === 'kimi') {
     if (!input.sessionId || input.threadId) {
-      throw new Error('Claude catalog entries require sessionId and must not include threadId');
+      throw new Error('Claude/Kimi catalog entries require sessionId and must not include threadId');
     }
     return;
   }

--- a/src/session/kimi-history.ts
+++ b/src/session/kimi-history.ts
@@ -1,0 +1,78 @@
+import { readFile, realpath, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { SessionSummary } from './history';
+
+interface KimiSessionIndexEntry {
+  sessionId?: unknown;
+  sessionDir?: unknown;
+  workDir?: unknown;
+}
+
+function kimiSessionIndexPath(): string {
+  return join(homedir(), '.kimi-code', 'session_index.jsonl');
+}
+
+/**
+ * Return the most recent `limit` kimi sessions for the given cwd, newest
+ * first. Reads `~/.kimi-code/session_index.jsonl` (one JSON per line, entries
+ * like `{ "sessionId", "sessionDir", "workDir" }`), keeps entries whose
+ * workDir matches the cwd, and uses the session dir's mtime as the sort key.
+ */
+export async function listKimiSessions(cwd: string, limit = 5): Promise<SessionSummary[]> {
+  let raw: string;
+  try {
+    raw = await readFile(kimiSessionIndexPath(), 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+
+  const cwdReal = await realpathIfExists(cwd);
+
+  const matches: Array<{ sessionId: string; mtime: number }> = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let entry: KimiSessionIndexEntry;
+    try {
+      entry = JSON.parse(trimmed) as KimiSessionIndexEntry;
+    } catch {
+      continue; // malformed line
+    }
+    const sessionId = typeof entry.sessionId === 'string' ? entry.sessionId : '';
+    const workDir = typeof entry.workDir === 'string' ? entry.workDir : '';
+    const sessionDir = typeof entry.sessionDir === 'string' ? entry.sessionDir : '';
+    if (!sessionId || !sessionDir) continue;
+    if (workDir !== cwd && workDir !== cwdReal) continue;
+    const mtime = await dirMtime(sessionDir);
+    if (mtime !== undefined) matches.push({ sessionId, mtime });
+  }
+
+  return matches
+    .sort((a, b) => b.mtime - a.mtime)
+    .slice(0, limit)
+    .map((entry) => ({
+      sessionId: entry.sessionId,
+      mtime: entry.mtime,
+      preview: '(kimi 会话)',
+      lineCount: 0,
+    }));
+}
+
+async function realpathIfExists(path: string): Promise<string | undefined> {
+  try {
+    return await realpath(path);
+  } catch {
+    return undefined;
+  }
+}
+
+async function dirMtime(dir: string): Promise<number | undefined> {
+  try {
+    const st = await stat(dir);
+    return st.mtimeMs;
+  } catch {
+    return undefined;
+  }
+}

--- a/tests/process/kimi-adapter.test.ts
+++ b/tests/process/kimi-adapter.test.ts
@@ -1,0 +1,177 @@
+import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { KimiAdapter } from '../../src/agent/kimi/adapter.js';
+import { buildKimiArgs } from '../../src/agent/kimi/argv.js';
+import type { AgentEvent } from '../../src/agent/types.js';
+
+interface FakeBinary {
+  path: string;
+  dir: string;
+  recordPath: string;
+}
+
+describe('KimiAdapter process contract', () => {
+  const cleanup: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      cleanup.splice(0).map((dir) =>
+        rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 25 }),
+      ),
+    );
+  });
+
+  it('spawns with the bridge-prefixed prompt on -p, stream-json output, and session resume args; ends stdin immediately', async () => {
+    const fake = await createFakeKimi({ lines: [] });
+    cleanup.push(fake.dir);
+    const cwd = await realpath(fake.dir);
+
+    const run = new KimiAdapter({ binary: fake.path }).run({
+      runId: 'run-kimi-argv',
+      prompt: 'hello',
+      cwd,
+      sessionId: 'sess-old',
+    });
+
+    expect(run.runId).toBe('run-kimi-argv');
+    // 等子进程退出（记录文件由 fake 在 stdin end / 兜底 timer 后写入）
+    expect(await collect(run.events)).toEqual([
+      { type: 'done', sessionId: undefined, terminationReason: 'normal' },
+    ]);
+    const record = await readRecord(fake.recordPath);
+
+    expect(await realpath(record.cwd)).toBe(cwd);
+    // -p 携带 bridge 系统提示前缀 + 用户 prompt（kimi 把 prompt 放 argv，不放 stdin）
+    expect(record.argv[1]?.startsWith('# lark-channel-bridge 运行约定')).toBe(true);
+    expect(record.argv[1]).toContain('__bridge_cb');
+    expect(record.argv[1]).toContain('LARK_CHANNEL_PROFILE');
+    expect(record.argv[1]).toContain('LARKSUITE_CLI_CONFIG_DIR');
+    expect(record.argv[1]?.endsWith('hello')).toBe(true);
+    // argv 精确等于 buildKimiArgs 结果：--output-format stream-json + --session 续接
+    expect(record.argv).toEqual(buildKimiArgs({ prompt: record.argv[1]!, sessionId: 'sess-old' }));
+    // kimi 不读 stdin：adapter 在 spawn 后立即 end，子进程未收到任何字节
+    expect(record.stdin).toBe('');
+    expect(record.stdinEnded).toBe(true);
+    // bridge 环境注入
+    expect(record.env.LARK_CHANNEL).toBe('1');
+  });
+
+  it('translates a stream-json run into tool_use, tool_result, text, and done carrying the resumed session id', async () => {
+    const fake = await createFakeKimi({
+      lines: [
+        { role: 'meta', type: 'system.version', version: '0.33.0' },
+        {
+          role: 'assistant',
+          tool_calls: [
+            {
+              type: 'function',
+              id: 'tool_1',
+              function: { name: 'Read', arguments: JSON.stringify({ path: 'probe.txt' }) },
+            },
+          ],
+        },
+        { role: 'tool', tool_call_id: 'tool_1', content: 'file contents' },
+        { role: 'assistant', content: '回复文本' },
+        { role: 'meta', type: 'session.resume_hint', session_id: 'sess-kimi' },
+      ],
+    });
+    cleanup.push(fake.dir);
+    const cwd = await realpath(fake.dir);
+
+    const run = new KimiAdapter({ binary: fake.path }).run({
+      runId: 'run-kimi-stream',
+      prompt: 'hello',
+      cwd,
+      sessionId: 'sess-old',
+    });
+
+    expect(await collect(run.events)).toEqual([
+      { type: 'tool_use', id: 'tool_1', name: 'Read', input: { path: 'probe.txt' } },
+      { type: 'tool_result', id: 'tool_1', output: 'file contents', isError: false },
+      { type: 'system', sessionId: 'sess-kimi' },
+      { type: 'text', delta: '回复文本' },
+      { type: 'done', sessionId: 'sess-kimi', terminationReason: 'normal' },
+    ]);
+  });
+});
+
+async function collect(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const out: AgentEvent[] = [];
+  for await (const event of events) out.push(event);
+  return out;
+}
+
+async function createFakeKimi(options: { lines: unknown[] }): Promise<FakeBinary> {
+  const dir = await mkdtemp(join(tmpdir(), 'kimi-adapter-test-'));
+  const path = join(dir, 'fake-kimi.mjs');
+  const recordPath = join(dir, 'argv.json');
+  await writeFile(
+    path,
+    [
+      '#!/usr/bin/env node',
+      'import { writeFileSync } from "node:fs";',
+      'let stdin = "";',
+      'let stdinEnded = false;',
+      'process.stdin.setEncoding("utf8");',
+      'process.stdin.on("data", (chunk) => { stdin += chunk; });',
+      'const finish = () => {',
+      `  writeFileSync(${JSON.stringify(recordPath)}, JSON.stringify({`,
+      '    argv: process.argv.slice(2),',
+      '    cwd: process.cwd(),',
+      '    stdin,',
+      '    stdinEnded,',
+      '    env: {',
+      '      LARK_CHANNEL: process.env.LARK_CHANNEL,',
+      '      LARK_CHANNEL_PROFILE: process.env.LARK_CHANNEL_PROFILE,',
+      '      LARK_CHANNEL_HOME: process.env.LARK_CHANNEL_HOME,',
+      '      LARK_CHANNEL_CONFIG: process.env.LARK_CHANNEL_CONFIG,',
+      '      LARKSUITE_CLI_CONFIG_DIR: process.env.LARKSUITE_CLI_CONFIG_DIR,',
+      '      PATH: process.env.PATH,',
+      '    },',
+      '  }));',
+      `  const lines = ${JSON.stringify(options.lines)};`,
+      '  for (const line of lines) console.log(JSON.stringify(line));',
+      '  setTimeout(() => process.exit(0), 0);',
+      '};',
+      'process.stdin.on("end", () => { stdinEnded = true; finish(); });',
+      // Fallback so a regression (adapter no longer ending stdin) fails the
+      // `stdinEnded` assertion instead of hanging the suite until timeout.
+      'setTimeout(() => { if (!stdinEnded) finish(); }, 2000);',
+    ].join('\n'),
+    'utf8',
+  );
+  await chmod(path, 0o755);
+  return { path, dir, recordPath };
+}
+
+async function readRecord(path: string): Promise<{
+  argv: string[];
+  cwd: string;
+  stdin: string;
+  stdinEnded: boolean;
+  env: {
+    LARK_CHANNEL?: string;
+    LARK_CHANNEL_PROFILE?: string;
+    LARK_CHANNEL_HOME?: string;
+    LARK_CHANNEL_CONFIG?: string;
+    LARKSUITE_CLI_CONFIG_DIR?: string;
+    PATH?: string;
+  };
+}> {
+  return JSON.parse(await readFile(path, 'utf8')) as {
+    argv: string[];
+    cwd: string;
+    stdin: string;
+    stdinEnded: boolean;
+    env: {
+      LARK_CHANNEL?: string;
+      LARK_CHANNEL_PROFILE?: string;
+      LARK_CHANNEL_HOME?: string;
+      LARK_CHANNEL_CONFIG?: string;
+      LARKSUITE_CLI_CONFIG_DIR?: string;
+      PATH?: string;
+    };
+  };
+}

--- a/tests/unit/agent/kimi-argv.test.ts
+++ b/tests/unit/agent/kimi-argv.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { buildKimiArgs } from '../../../src/agent/kimi/argv.js';
+
+describe('Kimi argv contract', () => {
+  it('builds the stream-json exec argv with the prompt in -p', () => {
+    expect(buildKimiArgs({ prompt: 'hello' })).toEqual([
+      '-p',
+      'hello',
+      '--output-format',
+      'stream-json',
+    ]);
+  });
+
+  it('appends --session when resuming a session', () => {
+    expect(buildKimiArgs({ prompt: 'continue', sessionId: 'session_123' })).toEqual([
+      '-p',
+      'continue',
+      '--output-format',
+      'stream-json',
+      '--session',
+      'session_123',
+    ]);
+  });
+
+  it('appends -m when a model is selected', () => {
+    expect(buildKimiArgs({ prompt: 'hi', model: 'kimi-k2.5' })).toEqual([
+      '-p',
+      'hi',
+      '--output-format',
+      'stream-json',
+      '-m',
+      'kimi-k2.5',
+    ]);
+  });
+
+  it('keeps session before model and omits absent flags', () => {
+    expect(
+      buildKimiArgs({ prompt: 'hi', sessionId: 'session_1', model: 'kimi-k2.5' }),
+    ).toEqual([
+      '-p',
+      'hi',
+      '--output-format',
+      'stream-json',
+      '--session',
+      'session_1',
+      '-m',
+      'kimi-k2.5',
+    ]);
+    expect(buildKimiArgs({ prompt: 'hi' })).not.toContain('--session');
+    expect(buildKimiArgs({ prompt: 'hi' })).not.toContain('-m');
+  });
+
+  it('never emits permission flags, which are mutually exclusive with -p', () => {
+    const args = buildKimiArgs({ prompt: 'hi' });
+    expect(args).not.toContain('--yolo');
+    expect(args).not.toContain('--auto');
+    expect(args).not.toContain('--plan');
+  });
+});

--- a/tests/unit/agent/kimi-stream-json.test.ts
+++ b/tests/unit/agent/kimi-stream-json.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+import { KimiJsonlTranslator } from '../../../src/agent/kimi/stream-json.js';
+
+describe('Kimi JSONL translator', () => {
+  it('captures the resume hint session id from a meta event', () => {
+    const t = new KimiJsonlTranslator();
+    expect(
+      t.translate({
+        role: 'meta',
+        type: 'session.resume_hint',
+        session_id: 'session_abc',
+        command: 'kimi -r ...',
+      }),
+    ).toEqual([{ type: 'system', sessionId: 'session_abc' }]);
+  });
+
+  it('accepts the camelCase sessionId spelling as well', () => {
+    const t = new KimiJsonlTranslator();
+    expect(
+      t.translate({ role: 'meta', type: 'session.resume_hint', sessionId: 'session_x' }),
+    ).toEqual([{ type: 'system', sessionId: 'session_x' }]);
+  });
+
+  it('ignores the version banner and flags unknown meta types as drift', () => {
+    const t = new KimiJsonlTranslator();
+    expect(t.translate({ role: 'meta', type: 'system.version', version: '0.33.0' })).toEqual([]);
+    expect(t.translate({ role: 'meta', type: 'future.thing' })).toEqual([]);
+    expect(t.protocolDrift()).toEqual({ unknownEvents: 1, anomalies: 0 });
+  });
+
+  it('translates assistant tool calls into tool_use events with parsed arguments', () => {
+    const t = new KimiJsonlTranslator();
+    expect(
+      t.translate({
+        role: 'assistant',
+        tool_calls: [
+          {
+            type: 'function',
+            id: 'tool_1',
+            function: { name: 'Read', arguments: '{"path":"probe.txt"}' },
+          },
+        ],
+      }),
+    ).toEqual([
+      { type: 'tool_use', id: 'tool_1', name: 'Read', input: { path: 'probe.txt' } },
+    ]);
+  });
+
+  it('passes non-JSON tool arguments through verbatim', () => {
+    const t = new KimiJsonlTranslator();
+    expect(
+      t.translate({
+        role: 'assistant',
+        tool_calls: [
+          {
+            id: 'tool_2',
+            function: { name: 'Shell', arguments: 'not json' },
+          },
+        ],
+      }),
+    ).toEqual([{ type: 'tool_use', id: 'tool_2', name: 'Shell', input: 'not json' }]);
+  });
+
+  it('counts a tool call without an id as an anomaly', () => {
+    const t = new KimiJsonlTranslator();
+    expect(
+      t.translate({
+        role: 'assistant',
+        tool_calls: [{ function: { name: 'Read', arguments: '{}' } }],
+      }),
+    ).toEqual([]);
+    expect(t.protocolDrift()).toEqual({ unknownEvents: 0, anomalies: 1 });
+  });
+
+  it('matches tool results to their calls by tool_call_id', () => {
+    const t = new KimiJsonlTranslator();
+    expect(
+      t.translate({
+        role: 'tool',
+        tool_call_id: 'tool_1',
+        content: 'file contents',
+      }),
+    ).toEqual([
+      { type: 'tool_result', id: 'tool_1', output: 'file contents', isError: false },
+    ]);
+    expect(t.translate({ role: 'tool', content: 'no id' })).toEqual([]);
+    expect(t.protocolDrift()).toEqual({ unknownEvents: 0, anomalies: 1 });
+  });
+
+  it('treats a message announced twice as one message', () => {
+    const t = new KimiJsonlTranslator();
+    expect(t.translate({ role: 'assistant', content: 'hello world' })).toEqual([]);
+    expect(t.translate({ role: 'assistant', content: 'hello world' })).toEqual([]);
+    expect(t.finish('normal')).toEqual([
+      { type: 'text', delta: 'hello world' },
+      { type: 'done', terminationReason: 'normal' },
+    ]);
+  });
+
+  it('streams earlier assistant messages as text deltas and reserves the last one', () => {
+    const t = new KimiJsonlTranslator();
+    expect(t.translate({ role: 'assistant', content: 'progress one' })).toEqual([]);
+    expect(t.translate({ role: 'assistant', content: 'progress two' })).toEqual([
+      { type: 'text', delta: 'progress one' },
+    ]);
+    expect(
+      t.translate({
+        role: 'tool',
+        tool_call_id: 'tool_1',
+        content: 'result',
+      }),
+    ).toEqual([
+      { type: 'text', delta: 'progress two' },
+      { type: 'tool_result', id: 'tool_1', output: 'result', isError: false },
+    ]);
+    expect(t.translate({ role: 'assistant', content: 'final answer' })).toEqual([]);
+    expect(t.finish('normal')).toEqual([
+      { type: 'text', delta: 'final answer' },
+      { type: 'done', terminationReason: 'normal' },
+    ]);
+  });
+
+  it('emits a done event with the session id on a normal finish', () => {
+    const t = new KimiJsonlTranslator();
+    t.translate({ role: 'meta', type: 'session.resume_hint', session_id: 'session_abc' });
+    expect(t.finish('normal')).toEqual([
+      { type: 'done', sessionId: 'session_abc', terminationReason: 'normal' },
+    ]);
+  });
+
+  it('lets interrupted and timeout finishes flush the partial answer', () => {
+    const stopped = new KimiJsonlTranslator();
+    stopped.translate({ role: 'assistant', content: 'half answer' });
+    expect(stopped.finish('interrupted')).toEqual([
+      { type: 'text', delta: 'half answer' },
+      { type: 'done', terminationReason: 'interrupted' },
+    ]);
+
+    const timedOut = new KimiJsonlTranslator();
+    timedOut.translate({ role: 'assistant', content: 'half answer' });
+    expect(timedOut.finish('timeout')).toEqual([
+      { type: 'text', delta: 'half answer' },
+      { type: 'done', terminationReason: 'timeout' },
+    ]);
+  });
+
+  it('emits a failed terminal event on finish("failed") without a terminal event', () => {
+    const t = new KimiJsonlTranslator();
+    expect(t.finish('failed')).toEqual([
+      {
+        type: 'error',
+        message: 'kimi stream ended before a terminal event',
+        terminationReason: 'failed',
+      },
+    ]);
+  });
+
+  it('reports a fail() message verbatim', () => {
+    const t = new KimiJsonlTranslator();
+    expect(t.fail('kimi exited with code 1')).toEqual([
+      { type: 'error', message: 'kimi exited with code 1', terminationReason: 'failed' },
+    ]);
+  });
+
+  it('stays terminal after finish or fail', () => {
+    const t = new KimiJsonlTranslator();
+    t.translate({ role: 'assistant', content: 'done' });
+    t.finish('normal');
+    expect(t.translate({ role: 'assistant', content: 'too late' })).toEqual([]);
+    expect(t.finish('normal')).toEqual([]);
+    expect(t.fail('late error')).toEqual([]);
+  });
+
+  it('tracks protocol drift while ignoring unknown and anomalous events', () => {
+    const t = new KimiJsonlTranslator();
+    expect(t.translate({ role: 'future', data: 1 })).toEqual([]);
+    expect(t.translate({ type: 'not-a-kimi-event' })).toEqual([]);
+    expect(t.translate({ role: 'meta', type: 'session.resume_hint' })).toEqual([]);
+    expect(t.protocolDrift()).toEqual({ unknownEvents: 1, anomalies: 2 });
+  });
+});

--- a/tests/unit/runtime/profile-runtime.test.ts
+++ b/tests/unit/runtime/profile-runtime.test.ts
@@ -262,7 +262,7 @@ describe('profile runtime resolver', () => {
       expect(message).toContain(claude);
       expect(message).toContain('codex');
       expect(message).toContain(codex);
-      expect(message).toContain('--agent <claude|codex>');
+      expect(message).toContain('--agent <claude|codex|kimi>');
     } finally {
       process.env.PATH = oldPath;
       if (oldClaude === undefined) {


### PR DESCRIPTION
## Summary

Add a third agent kind, `kimi`, bridging Feishu/Lark chats to the local [Kimi Code](https://www.kimi.com/code) CLI, alongside the existing `claude` and `codex` agents.

```
lark-channel-bridge profile create kimi --agent kimi
lark-channel-bridge start --profile kimi
```

## How it works

The kimi adapter follows the same process-level pattern as the claude/codex adapters:

- **Spawn**: `kimi -p <prompt> --output-format stream-json [--session <id>] [-m <model>]`. The bridge system prompt is prepended to the prompt (the `prefixBridgeSystemPrompt` approach, same as codex) and passed via argv — kimi has no `--append-system-prompt-file` and does not read the prompt from stdin.
- **Stream translation** (`src/agent/kimi/stream-json.ts`): kimi's JSONL schema is `role`-discriminated (`meta` / `assistant` / `tool`). Intermediate assistant text streams as `text` deltas using the pending-message pattern (like the codex translator); the trailing message flushes as the final answer before `done`. `meta.session.resume_hint` lines carry the session id, which is surfaced as a `system` event and stored for continuation.
- **Sessions**: kimi rides the claude-style sessionId channel (`--session <id>` resumes natively). `/resume` lists local history from `~/.kimi-code/session_index.jsonl` (new `src/session/kimi-history.ts`, parse-fault tolerant).
- **Permissions**: kimi's `-p` mode is mutually exclusive with `--yolo/--auto/--plan`, so no permission flag is passed; the adapter ignores sandbox/permissionMode and `/status` displays the bridge access mode instead.

All previously two-way `claude | codex` branches (profile schema, capability, preflight, detection, bootstrap, registry, locks, catalog, run-flow, comments, channel, orchestrator, commands, models, migrate, CLI help, service display) are now three-way.

## Verified against kimi 0.33.0 (live probes)

- stream-json schema: `system.version` / `assistant(tool_calls)` / `tool` / `assistant(content)` / `session.resume_hint`
- `--session <id>` continuation across runs (second turn recalled the first)
- resume_hint capture for session persistence

## Tests

- `tests/unit/agent/kimi-argv.test.ts` — argv contract (prompt on `-p`, `--session` before `-m`, no permission flags)
- `tests/unit/agent/kimi-stream-json.test.ts` — translator: tool calls, pending-message flush, dedup, terminal semantics, drift tolerance
- `tests/process/kimi-adapter.test.ts` — fake-executable process test: exact argv, stdin closed immediately, full event sequence with resumed session id
- Full suite green: 107 files / 710 tests, `pnpm typecheck` clean

## Notes

- Windows: prompt-on-argv may hit the same `cmd.exe` shim issue claude had (`.cmd` shim interpreting `<bridge_context>` redirects). Left a comment in the adapter; macOS/Linux spawn without a shell and are unaffected.
- kimi's stream-json carries no usage/cost fields, so no usage events are emitted.
