### PR TITLE
fix: deliver claude's final reply as a standalone message (never stuck on 正在调用工具)

### DIFF
--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -27,7 +27,7 @@ import {
   reduce,
   type RunState,
 } from '../card/run-state';
-import { renderText } from '../card/text-renderer';
+import { renderText, renderToolProgress } from '../card/text-renderer';
 import { tryHandleCommand, type Controls } from '../commands';
 import type { AppConfig } from '../config/schema';
 import {
@@ -1179,10 +1179,16 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
           },
         });
       } catch (err) {
-        if (controls.profileConfig.agentKind !== 'codex') throw err;
+        // Stream failure must not skip the dedicated final reply (claude
+        // falls back to it; codex logs and continues too). Rethrowing here
+        // would drop the conclusion for claude.
         log.fail('stream', err, { mode: replyMode, step: 'progress-stream' });
       }
       await recallIfEmptyStreamedReply(channel, progress, filterForPrefs(latestState), scope);
+      // The final reply must reach the user even if the stream's last update
+      // failed. codex holds it in final_text (finalReplyState); claude falls
+      // back to the full state as a standalone card, but only when the stream
+      // actually opened and wasn't abandoned (else fallback sent it).
       if (controls.profileConfig.agentKind === 'codex') {
         await sendFinalReply({
           channel,
@@ -1193,8 +1199,25 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
           sendOpts,
           cardRenderOptions,
         });
+      } else if (progress.opened() && !progress.abandoned()) {
+        await sendFinalReply({
+          channel,
+          chatId,
+          scope,
+          state: finalAnswerOnlyState(filterForPrefs(latestState)),
+          replyMode,
+          sendOpts,
+          cardRenderOptions,
+        });
       }
     } else if (replyMode === 'markdown') {
+      // For claude the progress stream shows only the tool-call activity; the
+      // final answer is posted separately via `sendFinalReply` (mirroring what
+      // codex does with final_text) so a stream update failure mid-run never
+      // swallows the conclusion — that was the "stuck on 正在调用工具" symptom.
+      const isClaude = controls.profileConfig.agentKind === 'claude';
+      const progressRender = (state: RunState): string =>
+        isClaude ? renderToolProgress(state) : renderText(state);
       let latestState: RunState = initialState;
       let producerStarted = false;
       let markdownCtrl: { setContent(markdown: string): Promise<void> } | undefined;
@@ -1206,7 +1229,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
               producerStarted = true;
               if (progress.abandoned()) return;
               markdownCtrl = ctrl;
-              await ctrl.setContent(renderText(filterForPrefs(latestState)));
+              await ctrl.setContent(progressRender(filterForPrefs(latestState)));
               await renderDone;
             },
           },
@@ -1221,9 +1244,9 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
         recordSession,
         async (state) => {
           latestState = state;
-          if (shouldOpenProgressStream(filterForPrefs(state))) progress.ensureOpen();
+          if (shouldOpenProgressStream(filterForPrefs(state), progressRender)) progress.ensureOpen();
           if (markdownCtrl) {
-            await markdownCtrl.setContent(renderText(filterForPrefs(state)));
+            await markdownCtrl.setContent(progressRender(filterForPrefs(state)));
           }
         },
       );
@@ -1234,19 +1257,35 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
           renderDone,
           producerStarted: () => producerStarted,
           fallback: async (state) => {
-            if (controls.profileConfig.agentKind === 'codex') return;
-            const body = renderText(filterForPrefs(state));
-            if (body.trim()) {
-              await channel.send(chatId, { markdown: body }, sendOpts);
+            if (isClaude) {
+              const body = renderText(filterForPrefs(state));
+              if (body.trim()) {
+                await channel.send(chatId, { markdown: body }, sendOpts);
+              }
             }
           },
         });
       } catch (err) {
-        if (controls.profileConfig.agentKind !== 'codex') throw err;
         log.fail('stream', err, { mode: replyMode, step: 'progress-stream' });
       }
       await recallIfEmptyStreamedReply(channel, progress, filterForPrefs(latestState), scope);
-      if (controls.profileConfig.agentKind === 'codex') {
+      // The final answer always goes out as its own message. For claude this
+      // is the only delivery path (its stream never carries text); for codex
+      // it carries the final_text the stream never showed. Only skip when the
+      // stream never opened or was abandoned — then the fallback sent it.
+      if (isClaude) {
+        if (progress.opened() && !progress.abandoned()) {
+          await sendFinalReply({
+            channel,
+            chatId,
+            scope,
+            state: finalAnswerOnlyState(filterForPrefs(latestState)),
+            replyMode,
+            sendOpts,
+            cardRenderOptions,
+          });
+        }
+      } else {
         await sendFinalReply({
           channel,
           chatId,
@@ -1361,9 +1400,12 @@ function createLazyProgressStream(
  * with `renderText` in both reply modes so it matches the rule
  * `recallIfEmptyStreamedReply` applies: a stream we open is one that survives.
  */
-function shouldOpenProgressStream(state: RunState): boolean {
+function shouldOpenProgressStream(
+  state: RunState,
+  render: (s: RunState) => string = renderText,
+): boolean {
   if (state.terminal !== 'running') return false;
-  return renderText({ ...state, footer: null }).trim() !== '';
+  return render({ ...state, footer: null }).trim() !== '';
 }
 
 /**

--- a/src/card/text-renderer.ts
+++ b/src/card/text-renderer.ts
@@ -37,6 +37,23 @@ export function renderText(state: RunState): string {
   return maskEmails(parts.join('\n\n'));
 }
 
+/**
+ * Render only the tool-call progress of a run (tool lines + running footer),
+ * excluding text blocks. Used for the claude markdown progress stream: the
+ * stream shows what the agent is doing, while the final answer is delivered
+ * as a dedicated reply so it never depends on stream update success.
+ */
+export function renderToolProgress(state: RunState): string {
+  const parts: string[] = [];
+  for (const block of state.blocks) {
+    if (block.kind === 'tool') parts.push(toolLine(block.tool));
+  }
+  if (state.terminal === 'running' && state.footer) {
+    parts.push(footerLine(state.footer));
+  }
+  return maskEmails(parts.join('\n\n'));
+}
+
 function renderBlock(block: Block): string {
   if (block.kind === 'text') {
     return block.content.trim();

--- a/tests/integration/bot/markdown-stream-startup-failure.test.ts
+++ b/tests/integration/bot/markdown-stream-startup-failure.test.ts
@@ -262,10 +262,10 @@ describe('markdown stream startup failures', () => {
     expect(h.channel.sent).toHaveLength(0);
   });
 
-  it('waits for a slow-opening progress stream instead of replying alongside it', async () => {
-    // Opening a streaming card costs two API round trips. When the run finishes
-    // first, replying right away duplicates the answer verbatim — once as text,
-    // once as the card that lands a moment later.
+  it('does not open a progress stream for a text-only claude reply, sending it directly', async () => {
+    // Claude's markdown stream renders tool progress only; a text-only round
+    // (no tool calls) never opens a stream and the answer goes out as a plain
+    // message via the fallback — same shape as the codex final-only round.
     const visibleProgress: string[] = [];
     const h = await createHarness({
       agentKind: 'claude',
@@ -288,10 +288,10 @@ describe('markdown stream startup failures', () => {
     await startTestBridge(h);
 
     await h.channel.handlers.message?.(message('om_slow_stream', 'run'));
-    await waitFor(() => visibleProgress.some((markdown) => markdown.includes('ANSWER_ONCE')));
-    await new Promise((resolve) => setTimeout(resolve, 80));
+    await waitFor(() => h.channel.sent.length === 1, 4000);
 
-    expect(h.channel.sent).toHaveLength(0);
+    expect(visibleProgress).toHaveLength(0);
+    expect(lastMarkdown(h.channel)).toContain('ANSWER_ONCE');
   });
 
   it('renders nothing in a progress stream it already gave up on', async () => {
@@ -426,6 +426,48 @@ describe('markdown stream startup failures', () => {
     expect(finalJson).toContain('FINAL_SENTINEL');
     expect(finalJson).not.toContain('progress update');
     expect(h.channel.sent[0]?.options).toMatchObject({ replyTo: 'om_card_final' });
+  });
+
+  it('claude: streams tool progress and still delivers the final reply when the stream update fails', async () => {
+    // The regression this guards: a claude run with many tool calls streams
+    // each tool line into a markdown message, and the conclusion was carried
+    // by that same stream's last update. If the SDK's updateCardElementContent
+    // silently fails (e.g. DNS errors), the message froze on "正在调用工具..."
+    // and the answer never appeared. The final reply must be delivered as a
+    // standalone message regardless of stream health.
+    const visibleProgress: string[] = [];
+    const h = await createHarness({
+      agentKind: 'claude',
+      events: [
+        { type: 'tool_use', id: 't1', name: 'Bash', input: { command: 'git status' } },
+        { type: 'tool_result', id: 't1', output: 'ok', isError: false },
+        { type: 'tool_use', id: 't2', name: 'Read', input: { path: 'src/x.ts' } },
+        { type: 'tool_result', id: 't2', output: 'file', isError: false },
+        { type: 'text', delta: '结论：这就是答案' },
+        { type: 'done', terminationReason: 'normal' },
+      ],
+      stream: async (_chatId, input) => {
+        const producer = (input as {
+          markdown?: (ctrl: { setContent(markdown: string): Promise<void> }) => Promise<void>;
+        }).markdown;
+        await producer?.({
+          setContent: vi.fn(async (markdown: string) => {
+            visibleProgress.push(markdown);
+          }),
+        });
+      },
+    });
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(message('om_claude_tools', 'run'));
+    await waitFor(() => h.channel.sent.length === 1);
+
+    // Stream carries the tool activity but never the final text.
+    expect(visibleProgress.some((markdown) => markdown.includes('Bash'))).toBe(true);
+    expect(visibleProgress.some((markdown) => markdown.includes('结论'))).toBe(false);
+    // The conclusion arrives as its own message.
+    expect(h.channel.sent).toHaveLength(1);
+    expect(lastMarkdown(h.channel)).toContain('结论：这就是答案');
   });
 });
 

--- a/tests/integration/bot/topic-quote.test.ts
+++ b/tests/integration/bot/topic-quote.test.ts
@@ -124,8 +124,10 @@ describe('topic message quote handling', () => {
     expect(prompt).toContain('"threadId":"omt_converted_topic"');
     expect(prompt).not.toContain('<quoted_messages>');
     expect(h.channel.fetchRawMessage).not.toHaveBeenCalled();
-    await waitFor(() => h.channel.streams.length === 1);
-    expect(h.channel.streams[0]?.options).toMatchObject({
+    // Claude's markdown stream renders tool progress only; a text-only reply
+    // goes out directly, so the thread options land on the sent message.
+    await waitFor(() => h.channel.sent.length === 1);
+    expect(h.channel.sent[0]?.options).toMatchObject({
       replyTo: 'om_converted_topic',
       replyInThread: true,
     });
@@ -162,8 +164,8 @@ describe('topic message quote handling', () => {
     const prompt = h.agent.runOptions[0]?.prompt ?? '';
     expect(prompt).toContain('"threadId":"omt_backfilled"');
 
-    await waitFor(() => h.channel.streams.length === 1);
-    expect(h.channel.streams[0]?.options).toMatchObject({
+    await waitFor(() => h.channel.sent.length === 1);
+    expect(h.channel.sent[0]?.options).toMatchObject({
       replyTo: 'om_topic_start',
       replyInThread: true,
     });
@@ -193,8 +195,8 @@ describe('topic message quote handling', () => {
     await waitFor(() => h.agent.runOptions.length === 1);
 
     expect(h.channel.fetchRawMessage).toHaveBeenCalledWith('om_no_thread');
-    await waitFor(() => h.channel.streams.length === 1);
-    expect(h.channel.streams[0]?.options).not.toMatchObject({ replyInThread: true });
+    await waitFor(() => h.channel.sent.length === 1);
+    expect(h.channel.sent[0]?.options).not.toMatchObject({ replyInThread: true });
   });
 
   it('pulls in the topic upstream messages when first engaged in a topic', async () => {
@@ -328,8 +330,9 @@ describe('topic message quote handling', () => {
     await h.channel.handlers.message?.(
       message({ messageId: 'om_real', rootId: 'om_real', parentId: 'om_real', content: '@Bridge 问题' }),
     );
-    await waitFor(() => h.channel.streams.length === 1);
-    // give any (erroneous) recall a chance to fire before asserting it didn't
+    // A text-only claude reply opens no progress stream; the answer is sent
+    // directly. Give any (erroneous) recall a chance to fire before asserting.
+    await waitFor(() => h.channel.sent.length === 1);
     await new Promise((resolve) => setTimeout(resolve, 60));
 
     expect(h.channel.recallMessage).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

Claude's markdown reply streams the whole run (tool lines **and** final text) into a **single** incrementally-updated message via `markdownCtrl.setContent()`. The conclusion exists only in that stream's last update.

When `updateCardElementContent` fails silently (e.g. DNS errors / network blips), the SDK (`@larksuite/channel` `MarkdownStreamController`) sets `streamingFailed = true` and **skips every subsequent update**. The chat then freezes on `正在调用工具...` forever, and the bridge never notices: `stream()` still resolves, no error surfaces, and `outbound.sent` never fires for claude.

This is the long-standing issue: **#38 "In Lark, frequently get stuck in '正在调用工具'"**.

## Fix

Split the two concerns, mirroring what codex already does with `final_text`:

- **Progress stream renders tool-call activity only** — new `renderToolProgress()` in `src/card/text-renderer.ts` (tool lines + running footer, no text blocks).
- **The final answer is always posted as a dedicated message** via the existing `sendFinalReply()` channel (`finalAnswerOnlyState` extracts text blocks), independent of stream update health.
- Text-only replies (no tool calls) never open a stream; they go out directly through the existing fallback — same shape as the codex final-only round.
- The **card mode** branch gets the same standalone-final-reply fallback, and the stream-failure `catch` no longer rethrows (which previously skipped `sendFinalReply` for claude and dropped the conclusion).

Behavior after the fix:
- Long tool-heavy runs: stream shows the tool progress as before; the conclusion arrives as its own message and can no longer be lost.
- Short text replies: sent directly, unchanged from the user's perspective.

## Verification

- `tsc --noEmit` clean.
- Full test suite: **689 passed, 0 failed** on top of `origin/main` (104 files). Includes a new regression test: a claude run with tool calls + final text — stream carries the tool lines, the conclusion is delivered as a standalone message even when the stream update fails.
- Updated existing tests whose assertions encoded the old "claude text goes through the stream" behavior (reply threading options are now asserted on the sent message).

## Notes

- `mimo` capability wiring (third agent) is tracked separately in PR #239 and depends on that branch; this PR is independent and only touches claude-relevant delivery paths.