### PR TITLE
fix: keep session continuity when allowedChats changes (/invite group)

### DIFF
--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -552,8 +552,9 @@ async function handleResume(args: string, ctx: CommandContext): Promise<void> {
     return;
   }
 
-  if (ctx.chatMode !== 'p2p') {
-    await reply(ctx, '群聊中不展示历史会话详情。请私聊 bot 使用 `/resume` 查看和选择历史会话。');
+  // In group chats, only admins can list resume candidates (to avoid leaking session details to non-admins).
+  if (ctx.chatMode !== 'p2p' && !canRunAdminCommand(ctx.controls.profileConfig, ctx.controls, ctx.msg.senderId).ok) {
+    await reply(ctx, '群聊中只有管理员可以查看和恢复历史会话。');
     return;
   }
 
@@ -690,6 +691,15 @@ function consumeResumeCandidate(
   nonce: string,
   identity: SessionCatalogIdentity,
 ): ResumeCandidate | undefined {
+  // TODO(future): Previously this also compared `candidate.policyFingerprint` to
+  // `identity.policyFingerprint`, which broke resume whenever the access policy
+  // changed (e.g. /invite group mutated allowedChats — issue #151). We now match
+  // only on scopeId/agentId/cwdRealpath. SECURITY NOTE: resume does NOT bypass
+  // access control — every inbound message still re-runs `evaluateRunPolicy`, so a
+  // user removed from the allowlist between listing and consuming a candidate is
+  // denied on the next message. Do NOT re-add a fingerprint check here without
+  // first re-introducing scope-aware continuity (see `scopeAwareAccessDigest`), or
+  // #151 will regress.
   pruneResumeCandidates();
   const candidate = resumeCandidates.get(nonce);
   if (!candidate) return undefined;
@@ -698,7 +708,6 @@ function consumeResumeCandidate(
     candidate.scopeId !== identity.scopeId ||
     candidate.agentId !== identity.agentId ||
     candidate.cwdRealpath !== identity.cwdRealpath ||
-    candidate.policyFingerprint !== identity.policyFingerprint ||
     (identity.agentId === 'claude' && !candidate.sessionId) ||
     (identity.agentId === 'codex' && !candidate.threadId)
   ) {

--- a/src/policy/fingerprint.ts
+++ b/src/policy/fingerprint.ts
@@ -53,6 +53,27 @@ export function accessPolicyDigest(access: ProfileConfig['access']): string {
   });
 }
 
+/**
+ * Scope-aware access digest for session catalog continuity.
+ * Unlike `accessPolicyDigest`, this excludes `allowedChats` so that
+ * adding/removing other unrelated groups does not break existing sessions.
+ *
+ * TODO(future): This digest deliberately diverges from `accessPolicyDigest`
+ * (which still hashes the full `allowedChats` list and is used for one-way
+ * callback identity fingerprints — see PR #214). If a new field is added to
+ * `ProfileConfig['access']`, decide explicitly whether it belongs in the
+ * session-continuity digest (this function) or only in the security/callback
+ * digest. Forgetting to update one of them silently splits or over-couples
+ * session continuity. Keep the two in sync by intent, not by accident.
+ */
+export function scopeAwareAccessDigest(access: ProfileConfig['access']): string {
+  return digestCanonical({
+    admins: [...access.admins].sort(),
+    allowedUsers: [...access.allowedUsers].sort(),
+    requireMentionInGroup: access.requireMentionInGroup,
+  });
+}
+
 export function resourceScopeDigest(input: ResourceScopeDigestInput): string {
   return digestCanonical({
     source: input.source,

--- a/src/policy/run-policy.ts
+++ b/src/policy/run-policy.ts
@@ -10,10 +10,10 @@ import {
 import type { ProfileConfig } from '../config/profile-schema';
 import type { AccessDecision } from './access';
 import {
-  accessPolicyDigest,
   attachmentPolicyConfigDigest,
   policyFingerprint,
   resourceScopeDigest,
+  scopeAwareAccessDigest,
 } from './fingerprint';
 
 export interface ScopeContext {
@@ -125,7 +125,7 @@ export function evaluateRunPolicy(input: RunPolicyInput): RunPolicyResult {
   const accessDigest =
     input.scope.source === 'comment' && input.access.reason === 'comment-mention'
       ? 'comment-mention'
-      : accessPolicyDigest(input.profileConfig.access);
+      : scopeAwareAccessDigest(input.profileConfig.access);
 
   return {
     ok: true,

--- a/src/session/catalog.ts
+++ b/src/session/catalog.ts
@@ -48,6 +48,14 @@ const DEFAULT_MAX_ENTRIES_PER_PROFILE = 1000;
 const KEY_SEPARATOR = '\x1f';
 
 export function sessionCatalogKey(input: SessionCatalogIdentity): string {
+  // TODO(future): The key embeds `policyFingerprint`, which changed shape when
+  // `scopeAwareAccessDigest` replaced `accessPolicyDigest` (allowedChats dropped).
+  // Entries written by a previous build therefore carry a different fingerprint
+  // and will NOT be matched by `activeFor` after a deploy — the next message in an
+  // already-active scope starts a fresh session/thread once, then self-heals.
+  // If we ever change the fingerprint shape again, add a one-time migration or a
+  // fingerprint-agnostic fallback lookup so existing active sessions survive the
+  // upgrade instead of being silently split.
   return [
     input.scopeId,
     input.agentId,

--- a/tests/integration/commands/commands-v1.test.ts
+++ b/tests/integration/commands/commands-v1.test.ts
@@ -209,12 +209,13 @@ describe('Bridge command contracts', () => {
     expect(lastMarkdown(h.channel)).not.toContain(target);
   });
 
-  it('keeps Claude resume history details out of group chats', async () => {
+  it('keeps Claude resume history details out of group chats for non-admins', async () => {
     const h = await createHarness();
 
-    await expect(h.run('/resume', { chatMode: 'group' })).resolves.toBe(true);
+    // A non-admin sender in a group chat must not see resume history; only admins can.
+    await expect(h.run('/resume', { chatMode: 'group', senderId: 'ou-stranger' })).resolves.toBe(true);
 
-    expect(lastMarkdown(h.channel)).toContain('私聊');
+    expect(lastMarkdown(h.channel)).toContain('群聊中只有管理员可以查看和恢复历史会话');
     expect(lastMarkdown(h.channel)).not.toContain(h.tmp.workspace);
   });
 

--- a/tests/integration/commands/resume-command.test.ts
+++ b/tests/integration/commands/resume-command.test.ts
@@ -226,16 +226,32 @@ describe('agent-aware resume commands', () => {
     expect(lastMarkdown(h.channel)).toContain('已完成');
   });
 
-  it('keeps Codex resume history details out of group chats like Claude', async () => {
+  it('keeps Codex resume history details out of group chats for non-admins like Claude', async () => {
     const h = await createHarness('codex');
     h.codexHistory.push(codexThread('thread-alpha-secret', 'alpha prompt', 1_700_000_100_000));
+
+    // The default harness sender (ou-user) is both the bot owner and in access.admins.
+    // Strip both so the group-chat admin gate blocks history instead of showing it.
+    h.controls.botOwnerId = 'ou-other-owner';
+    h.controls.profileConfig.access.admins = [];
 
     await expect(h.run('/resume', { chatMode: 'group' })).resolves.toBe(true);
 
     const rendered = lastContentString(h.channel);
-    expect(rendered).toContain('私聊');
+    expect(rendered).toContain('群聊中只有管理员可以查看和恢复历史会话');
     expect(rendered).not.toContain('alpha prompt');
     expect(rendered).not.toContain('thread-alpha-secret');
+  });
+
+  it('lets an admin list Codex resume history in a group chat', async () => {
+    const h = await createHarness('codex');
+    h.codexHistory.push(codexThread('thread-alpha-secret', 'alpha prompt', 1_700_000_100_000));
+
+    // The default harness sender is the bot owner, i.e. an admin: history is shown.
+    await expect(h.run('/resume', { chatMode: 'group' })).resolves.toBe(true);
+
+    const rendered = lastContentString(h.channel);
+    expect(rendered).toContain('alpha prompt');
   });
 
   it('labels Codex status as session while reading the recorded thread id', async () => {

--- a/tests/unit/policy/fingerprint.test.ts
+++ b/tests/unit/policy/fingerprint.test.ts
@@ -1,10 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { createDefaultProfileConfig } from '../../../src/config/profile-schema';
+import { createDefaultProfileConfig, type ProfileConfig } from '../../../src/config/profile-schema';
 import {
   accessPolicyDigest,
   attachmentPolicyShapeDigest,
   policyFingerprint,
   resourceScopeDigest,
+  scopeAwareAccessDigest,
   type FingerprintInputV2,
 } from '../../../src/policy/fingerprint';
 import { canonicalizeJcs } from '../../../src/session/jcs';
@@ -129,6 +130,58 @@ describe('policy fingerprint', () => {
         resourceBindings: ['doc_a', 'doc_b'],
       }),
     );
+  });
+});
+
+describe('scopeAwareAccessDigest', () => {
+  function accessProfile(access: Partial<ProfileConfig['access']> = {}) {
+    return createDefaultProfileConfig({
+      agentKind: 'claude',
+      accounts: { app: { id: 'cli_test', secret: '${APP_SECRET}', tenant: 'feishu' } },
+      access: {
+        allowedUsers: ['ou_a'],
+        allowedChats: ['oc_a', 'oc_b'],
+        admins: ['ou_admin'],
+        requireMentionInGroup: true,
+        ...access,
+      },
+    });
+  }
+
+  it('excludes allowedChats so unrelated group changes preserve session continuity', () => {
+    const base = accessProfile();
+    const changed = accessProfile({ allowedChats: ['oc_a', 'oc_b', 'oc_c'] });
+
+    expect(scopeAwareAccessDigest(changed.access)).toBe(scopeAwareAccessDigest(base.access));
+  });
+
+  it('still changes when admins, allowedUsers, or requireMentionInGroup change', () => {
+    const base = accessProfile();
+
+    expect(scopeAwareAccessDigest(accessProfile({ admins: ['ou_admin', 'ou_admin2'] }).access)).not.toBe(
+      scopeAwareAccessDigest(base.access),
+    );
+    expect(scopeAwareAccessDigest(accessProfile({ allowedUsers: ['ou_a', 'ou_b'] }).access)).not.toBe(
+      scopeAwareAccessDigest(base.access),
+    );
+    expect(scopeAwareAccessDigest(accessProfile({ requireMentionInGroup: false }).access)).not.toBe(
+      scopeAwareAccessDigest(base.access),
+    );
+  });
+
+  it('sorts admins and allowedUsers so ordering does not change the digest', () => {
+    const a = accessProfile({ admins: ['ou_admin_b', 'ou_admin_a'], allowedUsers: ['ou_b', 'ou_a'] });
+    const b = accessProfile({ admins: ['ou_admin_a', 'ou_admin_b'], allowedUsers: ['ou_a', 'ou_b'] });
+
+    expect(scopeAwareAccessDigest(a.access)).toBe(scopeAwareAccessDigest(b.access));
+  });
+
+  it('diverges from accessPolicyDigest which still includes allowedChats', () => {
+    const a = accessProfile();
+    const b = accessProfile({ allowedChats: ['oc_a', 'oc_b', 'oc_c'] });
+
+    expect(accessPolicyDigest(a.access)).not.toBe(accessPolicyDigest(b.access));
+    expect(scopeAwareAccessDigest(a.access)).toBe(scopeAwareAccessDigest(b.access));
   });
 });
 

--- a/tests/unit/policy/run-policy.test.ts
+++ b/tests/unit/policy/run-policy.test.ts
@@ -133,6 +133,34 @@ describe('run policy', () => {
     expect(stricterPolicy.policyFingerprint).not.toBe(noAttachment.policyFingerprint);
   });
 
+  it('keeps the policy fingerprint stable when allowedChats changes (session continuity)', () => {
+    const withTwo = evaluateRunPolicy(baseInput({ profileConfig: profileWithAccess({ allowedChats: ['oc_a', 'oc_b'] }) }));
+    const withThree = evaluateRunPolicy(baseInput({ profileConfig: profileWithAccess({ allowedChats: ['oc_a', 'oc_b', 'oc_c'] }) }));
+
+    expect(withTwo.ok).toBe(true);
+    expect(withThree.ok).toBe(true);
+    if (!withTwo.ok || !withThree.ok) throw new Error('expected run policy to allow');
+    expect(withThree.policyFingerprint).toBe(withTwo.policyFingerprint);
+  });
+
+  it('changes the policy fingerprint when admins, allowedUsers, or requireMentionInGroup change', () => {
+    const base = evaluateRunPolicy(baseInput({ profileConfig: profileWithAccess({}) }));
+    const moreAdmins = evaluateRunPolicy(baseInput({ profileConfig: profileWithAccess({ admins: ['ou_admin', 'ou_admin2'] }) }));
+    const moreUsers = evaluateRunPolicy(baseInput({ profileConfig: profileWithAccess({ allowedUsers: ['ou_a', 'ou_b'] }) }));
+    const mentionOff = evaluateRunPolicy(baseInput({ profileConfig: profileWithAccess({ requireMentionInGroup: false }) }));
+
+    expect(base.ok).toBe(true);
+    expect(moreAdmins.ok).toBe(true);
+    expect(moreUsers.ok).toBe(true);
+    expect(mentionOff.ok).toBe(true);
+    if (!base.ok || !moreAdmins.ok || !moreUsers.ok || !mentionOff.ok) {
+      throw new Error('expected run policy to allow');
+    }
+    expect(moreAdmins.policyFingerprint).not.toBe(base.policyFingerprint);
+    expect(moreUsers.policyFingerprint).not.toBe(base.policyFingerprint);
+    expect(mentionOff.policyFingerprint).not.toBe(base.policyFingerprint);
+  });
+
   it('fails closed for unverified folder resource bindings', () => {
     const result = evaluateRunPolicy({
       ...baseInput(),
@@ -213,4 +241,19 @@ function scope(overrides: Partial<ScopeContext> = {}): ScopeContext {
     actorId: 'ou_user',
     ...overrides,
   };
+}
+
+function profileWithAccess(access: Partial<ProfileConfig['access']>) {
+  return createDefaultProfileConfig({
+    agentKind: 'claude',
+    accounts: { app: { id: 'cli_test', secret: '${APP_SECRET}', tenant: 'feishu' } },
+    access: {
+      allowedUsers: [],
+      allowedChats: [],
+      admins: [],
+      requireMentionInGroup: true,
+      ...access,
+    },
+    permissions: { defaultAccess: 'read-only', maxAccess: 'read-only' },
+  });
 }


### PR DESCRIPTION
## Summary

Fixes #151 — `/invite group` mutated the global `access.allowedChats` list, which fed into `policyFingerprint` and therefore the session catalog key. Any unrelated group add/remove split the catalog and broke topic/Codex session resume (the next message started a fresh thread instead of continuing).

Changes:
- Add `scopeAwareAccessDigest` that excludes `allowedChats`, so unrelated group changes no longer change the fingerprint used for catalog continuity.
- Use it in `evaluateRunPolicy` instead of `accessPolicyDigest`.
- Drop the `policyFingerprint` check in `consumeResumeCandidate` so a session can still be resumed after a policy change. Runtime access is still re-enforced on every inbound message, so this does **not** bypass authz.
- In group chats, restrict `/resume` listing to admins instead of hiding it for everyone (avoids leaking session details to non-admins while letting admins recover the current scope).
- Add unit tests for the scope-aware digest and update resume integration tests to the admin-gated behavior.

## Test plan

- `npx tsc --noEmit` — clean
- `npx vitest run` — all tests pass (the 2 resume integration tests were updated to the new admin-gated group behavior; a positive admin test was added)

Closes #151