### PR TITLE
fix: resend replies after trigger withdrawal

### DIFF
--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -1171,10 +1171,12 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
           fallback: async (state) => {
             if (controls.profileConfig.agentKind === 'codex') return;
             if (renderText(filterForPrefs(state)).trim() === '') return;
-            await channel.send(
+            await sendWithWithdrawnReplyFallback(
+              channel,
               chatId,
               { card: renderCard(filterForPrefs(state), cardRenderOptions) },
               sendOpts,
+              scope,
             );
           },
         });
@@ -1237,7 +1239,13 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
             if (controls.profileConfig.agentKind === 'codex') return;
             const body = renderText(filterForPrefs(state));
             if (body.trim()) {
-              await channel.send(chatId, { markdown: body }, sendOpts);
+              await sendWithWithdrawnReplyFallback(
+                channel,
+                chatId,
+                { markdown: body },
+                sendOpts,
+                scope,
+              );
             }
           },
         });
@@ -1460,33 +1468,76 @@ async function sendFinalReply(input: {
     return;
   }
 
-  if (input.replyMode === 'card') {
-    const result = await input.channel.send(
-      input.chatId,
-      { card: renderCard(input.state, input.cardRenderOptions) },
-      input.sendOpts,
-    );
-    requireMessageReceipt(result, 'card');
-    log.info('outbound', 'sent', outboundLogFields(input, 'card', body, result));
-  } else if (input.replyMode === 'markdown') {
-    if (body.trim()) {
-      const result = await input.channel.send(
-        input.chatId,
-        { markdown: body },
-        input.sendOpts,
-      );
-      requireMessageReceipt(result, 'markdown');
-      log.info('outbound', 'sent', outboundLogFields(input, 'markdown', body, result));
-    }
-  } else if (body.trim()) {
-    const result = await input.channel.send(
-      input.chatId,
-      { markdown: body },
-      input.sendOpts,
-    );
-    requireMessageReceipt(result, 'text');
-    log.info('outbound', 'sent', outboundLogFields(input, 'text', body, result));
+  const type = input.replyMode === 'card' ? 'card' : input.replyMode;
+  const content =
+    type === 'card'
+      ? { card: renderCard(input.state, input.cardRenderOptions) }
+      : { markdown: body };
+  const delivery = await sendWithWithdrawnReplyFallback(
+    input.channel,
+    input.chatId,
+    content,
+    input.sendOpts,
+    input.scope,
+  );
+  requireMessageReceipt(delivery.result, type);
+  log.info(
+    'outbound',
+    'sent',
+    outboundLogFields({ ...input, sendOpts: delivery.sendOpts }, type, body, delivery.result),
+  );
+}
+
+type ReplySendOptions = { replyTo: string; replyInThread?: boolean };
+
+async function sendWithWithdrawnReplyFallback(
+  channel: LarkChannel,
+  chatId: string,
+  content: Parameters<LarkChannel['send']>[1],
+  sendOpts: ReplySendOptions,
+  scope: string,
+): Promise<{
+  result: Awaited<ReturnType<LarkChannel['send']>>;
+  sendOpts?: ReplySendOptions;
+}> {
+  try {
+    return {
+      result: await channel.send(chatId, content, sendOpts),
+      sendOpts,
+    };
+  } catch (err) {
+    if (!isWithdrawnReplyTargetError(err)) throw err;
+    log.warn('outbound', 'reply-target-withdrawn-fallback', {
+      scope,
+      replyTo: sendOpts.replyTo,
+      replyInThread: sendOpts.replyInThread === true,
+    });
+    return { result: await channel.send(chatId, content) };
   }
+}
+
+function isWithdrawnReplyTargetError(err: unknown): boolean {
+  const candidates: unknown[] = [err];
+  const seen = new Set<unknown>();
+
+  while (candidates.length > 0) {
+    const candidate = candidates.pop();
+    if (candidate === undefined || candidate === null || seen.has(candidate)) continue;
+    seen.add(candidate);
+
+    if (typeof candidate === 'string') {
+      if (/\bmessage\b[^\n]*(?:withdrawn|recalled)\b/i.test(candidate)) return true;
+      continue;
+    }
+    if (candidate instanceof Error) {
+      candidates.push(candidate.message, candidate.cause);
+    }
+    if (typeof candidate !== 'object') continue;
+
+    const value = candidate as Record<string, unknown>;
+    candidates.push(value.message, value.msg, value.error, value.data, value.response);
+  }
+  return false;
 }
 
 function requireMessageReceipt(result: { messageId?: string }, type: string): void {

--- a/tests/integration/bot/markdown-stream-startup-failure.test.ts
+++ b/tests/integration/bot/markdown-stream-startup-failure.test.ts
@@ -359,6 +359,70 @@ describe('markdown stream startup failures', () => {
     ).toBe(true);
   });
 
+  it('retries a withdrawn reply target as a fresh message after stream fallback', async () => {
+    let sendAttempts = 0;
+    const h = await createHarness({
+      agentKind: 'claude',
+      events: [
+        { type: 'text', delta: 'ANSWER_AFTER_WITHDRAWAL' },
+        { type: 'done', terminationReason: 'normal' },
+      ],
+      stream: async () => {
+        throw new Error('The message was withdrawn.');
+      },
+      send: async () => {
+        sendAttempts += 1;
+        if (sendAttempts === 1) {
+          throw Object.assign(new Error('Request failed with status code 400'), {
+            response: { data: { message: 'The message was withdrawn.' } },
+          });
+        }
+        return { messageId: 'om_fresh_fallback' };
+      },
+    });
+    const warn = vi.spyOn(log, 'warn').mockImplementation(() => {});
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(message('om_withdrawn', 'run'));
+    await waitFor(() => h.channel.sent.length === 2);
+
+    expect(h.channel.sent[0]?.options).toMatchObject({ replyTo: 'om_withdrawn' });
+    expect(h.channel.sent[1]?.options).toBeUndefined();
+    expect(lastMarkdown(h.channel)).toContain('ANSWER_AFTER_WITHDRAWAL');
+    expect(
+      warn.mock.calls.some(
+        (call) =>
+          call[0] === 'outbound' &&
+          call[1] === 'reply-target-withdrawn-fallback' &&
+          (call[2] as { replyTo?: string } | undefined)?.replyTo === 'om_withdrawn',
+      ),
+    ).toBe(true);
+  });
+
+  it('does not retry unrelated final reply failures without the reply target', async () => {
+    const h = await createHarness({
+      events: [
+        { type: 'final_text', content: 'FINAL_PERMISSION_FAILURE' },
+        { type: 'done', terminationReason: 'normal' },
+      ],
+      send: async () => {
+        throw new Error('Forbidden');
+      },
+    });
+    const fail = vi.spyOn(log, 'fail').mockImplementation(() => {});
+    await startTestBridge(h);
+
+    await h.channel.handlers.message?.(message('om_forbidden', 'run'));
+    await waitFor(() =>
+      fail.mock.calls.some(
+        (call) => call[1] instanceof Error && call[1].message === 'Forbidden',
+      ),
+    );
+
+    expect(h.channel.sent).toHaveLength(1);
+    expect(h.channel.sent[0]?.options).toMatchObject({ replyTo: 'om_forbidden' });
+  });
+
   it('does not record delivery when the final send has no message receipt', async () => {
     const fail = vi.spyOn(log, 'fail').mockImplementation(() => {});
     const info = vi.spyOn(log, 'info').mockImplementation(() => {});


### PR DESCRIPTION
## Summary

- retry an agent reply without `replyTo` when Feishu reports that the trigger message was withdrawn or recalled
- apply the fallback to Claude stream fallbacks and dedicated final replies in card, markdown, and text modes
- preserve existing behavior for permission, format, network, and other unrelated delivery failures
- log the fallback explicitly while avoiding a misleading `replyTo` field on the successful fresh send

## Why

When a user withdraws the message that started a run, Feishu can return `The message was withdrawn.` without a numeric error code. The channel SDK consequently misses its target-revoked fallback, and the completed agent answer is never delivered.

The bridge now adds a narrow defensive fallback around its run-reply sends: it recognizes only errors that explicitly describe a message as withdrawn/recalled, removes both `replyTo` and `replyInThread`, and retries once as a fresh chat message.

Closes #260.

## Tests

- `pnpm vitest run tests/integration/bot/markdown-stream-startup-failure.test.ts` — 13/13 passed
- `pnpm typecheck` — passed
- `pnpm build` — passed
- full `pnpm test` — 688/690 passed locally; the two unrelated failures require `LARKSUITE_CLI_CONFIG_DIR` / profile secrets to be absent, but this bridge-bound development shell intentionally injects them. GitHub Actions will exercise the full suite in clean Linux, macOS, and Windows environments.
