### PR TITLE
Feat support grok

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # lark-channel-bridge
 
-A lightweight bot that bridges Feishu / Lark messenger with your local Claude Code or Codex CLI. Run one command, scan a QR code to bind a PersonalAgent app, and talk to your local coding agent from chat.
+A lightweight bot that bridges Feishu / Lark messenger with your local Claude Code, Codex CLI, or Grok CLI. Run one command, scan a QR code to bind a PersonalAgent app, and talk to your local coding agent from chat.
 
 [中文 README](./README.zh.md)
 
@@ -8,7 +8,7 @@ For a product walkthrough, see the [Feishu document](https://larkcommunity.feish
 
 ## What it does
 
-- Forwards Feishu / Lark messages to local Claude Code or Codex CLI. Send a DM directly, or `@bot` in a group.
+- Forwards Feishu / Lark messages to local Claude Code, Codex CLI, or Grok CLI. Send a DM directly, or `@bot` in a group.
 - **Streaming card**: text replies and tool calls update on one Lark card in real time.
 - **COT process messages**: optionally send a process message with agent progress text and tool calls, then send the final answer separately.
 - **Session continuity**: each chat, topic, or document comment thread keeps its own session.
@@ -23,6 +23,7 @@ For a product walkthrough, see the [Feishu document](https://larkcommunity.feish
 - At least one local agent installed and logged in:
   - Claude Code: `claude`, see https://docs.anthropic.com/en/docs/claude-code/quickstart
   - Codex CLI: `codex`, see https://developers.openai.com/codex/cli
+  - Grok CLI: `grok`, see https://x.ai/cli
 - A Feishu / Lark **PersonalAgent** app. The first-run QR wizard can create and bind one for you.
 
 ## Install
@@ -88,13 +89,14 @@ Platform mapping:
 
 Daemon logs are under `~/.lark-channel/profiles/<profile>/logs/daemon/`.
 
-### Multiple profiles: Claude and Codex
+### Multiple profiles: Claude, Codex, and Grok
 
-By default, the bridge starts with the currently selected profile. Use `profile use <name>` to change it. Each profile keeps its own app credentials, sessions, working directories, and logs. Create multiple profiles only when you need to connect multiple PersonalAgent apps, or run Claude and Codex as separate bots:
+By default, the bridge starts with the currently selected profile. Use `profile use <name>` to change it. Each profile keeps its own app credentials, sessions, working directories, and logs. Create multiple profiles only when you need to connect multiple PersonalAgent apps, or run Claude, Codex, and Grok as separate bots:
 
 ```bash
 lark-channel-bridge start --profile claude --agent claude
 lark-channel-bridge start --profile codex --agent codex
+lark-channel-bridge start --profile grok --agent grok
 ```
 
 For example, to restart only the Codex bot:
@@ -109,18 +111,19 @@ lark-channel-bridge status --profile codex
 ### Host CLI
 
 ```text
-lark-channel-bridge run [--profile <name>] [--agent claude|codex] [--workspace <path>] [-c <config>]
-lark-channel-bridge migrate [--profile <name>] [--agent claude|codex]
+lark-channel-bridge run [--profile <name>] [--agent claude|codex|grok] [--workspace <path>] [-c <config>]
+lark-channel-bridge migrate [--profile <name>] [--agent claude|codex|grok]
 lark-channel-bridge ps
 lark-channel-bridge kill <id|#>
 lark-channel-bridge --help
 ```
 
-`profile use <name>` changes the profile used by later default starts. Use these profile management commands when running separate Claude / Codex bots, connecting multiple PersonalAgent apps, or doing scripted deployment:
+`profile use <name>` changes the profile used by later default starts. Use these profile management commands when running separate Claude / Codex / Grok bots, connecting multiple PersonalAgent apps, or doing scripted deployment:
 
 ```bash
 lark-channel-bridge profile create claude --agent claude
 lark-channel-bridge profile create codex --agent codex
+lark-channel-bridge profile create grok --agent grok
 lark-channel-bridge profile list
 lark-channel-bridge profile use <name>
 lark-channel-bridge profile remove <name>

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,6 +1,6 @@
 # lark-channel-bridge
 
-把飞书 / Lark 消息和本地 Claude Code 或 Codex CLI 打通的轻量 bot。用一条命令启动，扫码绑定 PersonalAgent 应用，然后在飞书里和本机编程助手对话，让它读图、处理文件、改代码。
+把飞书 / Lark 消息和本地 Claude Code、Codex CLI 或 Grok CLI 打通的轻量 bot。用一条命令启动，扫码绑定 PersonalAgent 应用，然后在飞书里和本机编程助手对话，让它读图、处理文件、改代码。
 
 [English README](./README.md)
 
@@ -8,7 +8,7 @@
 
 ## 主要功能
 
-- 在飞书私聊直接发消息，或在群里 `@bot`，把任务转给本机 Claude Code / Codex CLI。
+- 在飞书私聊直接发消息，或在群里 `@bot`，把任务转给本机 Claude Code / Codex CLI / Grok CLI。
 - **流式卡片**：文本回复和工具调用实时更新在同一张卡片上。
 - **COT 过程消息**：可选先发一条过程消息展示 agent 的阶段性文本和工具调用，再单独发送最终答案。
 - **会话延续**：每个聊天、话题或文档评论有自己的会话，不会互相串。
@@ -23,6 +23,7 @@
 - 本机至少安装并登录一个 agent：
   - Claude Code：`claude`，安装说明：https://docs.anthropic.com/en/docs/claude-code/quickstart
   - Codex CLI：`codex`，安装说明：https://developers.openai.com/codex/cli
+  - Grok CLI：`grok`，安装说明：https://x.ai/cli
 - 一个飞书 / Lark PersonalAgent 应用。首次启动的扫码向导可以帮你创建并绑定。
 
 ## 安装
@@ -88,13 +89,14 @@ lark-channel-bridge unregister [--profile <name>]
 
 daemon 日志在 `~/.lark-channel/profiles/<profile>/logs/daemon/`。
 
-### 多 profile：分别运行 Claude 和 Codex
+### 多 profile：分别运行 Claude、Codex 和 Grok
 
-默认情况下，bridge 使用当前激活的 profile；可以通过 `profile use <name>` 切换。每个 profile 会维护独立的应用凭据、会话、工作目录和日志。只有在需要同时连接多个 PersonalAgent 应用，或分别运行 Claude 和 Codex 时，才需要创建多个 profile：
+默认情况下，bridge 使用当前激活的 profile；可以通过 `profile use <name>` 切换。每个 profile 会维护独立的应用凭据、会话、工作目录和日志。只有在需要同时连接多个 PersonalAgent 应用，或分别运行 Claude、Codex 和 Grok 时，才需要创建多个 profile：
 
 ```bash
 lark-channel-bridge start --profile claude --agent claude
 lark-channel-bridge start --profile codex --agent codex
+lark-channel-bridge start --profile grok --agent grok
 ```
 
 例如只重启 Codex bot：
@@ -109,18 +111,19 @@ lark-channel-bridge status --profile codex
 ### 宿主 CLI
 
 ```text
-lark-channel-bridge run [--profile <name>] [--agent claude|codex] [--workspace <path>] [-c <config>]
-lark-channel-bridge migrate [--profile <name>] [--agent claude|codex]
+lark-channel-bridge run [--profile <name>] [--agent claude|codex|grok] [--workspace <path>] [-c <config>]
+lark-channel-bridge migrate [--profile <name>] [--agent claude|codex|grok]
 lark-channel-bridge ps
 lark-channel-bridge kill <id|#>
 lark-channel-bridge --help
 ```
 
-`profile use <name>` 会切换后续默认启动使用的 profile。需要同时跑 Claude / Codex 两个 bot、连接多套 PersonalAgent 应用，或做脚本化部署时，再使用这些 profile 管理命令：
+`profile use <name>` 会切换后续默认启动使用的 profile。需要同时跑 Claude / Codex / Grok 多个 bot、连接多套 PersonalAgent 应用，或做脚本化部署时，再使用这些 profile 管理命令：
 
 ```bash
 lark-channel-bridge profile create claude --agent claude
 lark-channel-bridge profile create codex --agent codex
+lark-channel-bridge profile create grok --agent grok
 lark-channel-bridge profile list
 lark-channel-bridge profile use <name>
 lark-channel-bridge profile remove <name>

--- a/package.json
+++ b/package.json
@@ -104,6 +104,8 @@
     "claude",
     "claude-code",
     "codex",
+    "grok",
+    "grok-cli",
     "cli",
     "channel",
     "bridge"

--- a/src/agent/capability.ts
+++ b/src/agent/capability.ts
@@ -1,9 +1,9 @@
 import type { AccessMode } from '../config/permissions';
-import type { ProfileConfig } from '../config/profile-schema';
+import type { AgentKind, ProfileConfig } from '../config/profile-schema';
 import { BRIDGE_SYSTEM_PROMPT } from './bridge-system-prompt';
 
-export type AgentCapabilityId = 'claude' | 'codex';
-export type AgentSessionKind = 'claude-session' | 'codex-thread';
+export type AgentCapabilityId = AgentKind;
+export type AgentSessionKind = 'claude-session' | 'codex-thread' | 'grok-session';
 export type PromptInjectionMode = 'append-system-prompt' | 'stdin-prefix';
 
 export interface AgentCapability {
@@ -55,4 +55,36 @@ export function codexCapability(profile: Pick<ProfileConfig, 'permissions'>): Ag
       maxAccess,
     },
   };
+}
+
+export function grokCapability(profile?: Pick<ProfileConfig, 'permissions'>): AgentCapability {
+  const maxAccess = profile?.permissions.maxAccess ?? 'full';
+  return {
+    agentId: 'grok',
+    sessionKind: 'grok-session',
+    promptInjection: 'stdin-prefix',
+    systemPrompt: BRIDGE_SYSTEM_PROMPT,
+    supportsNativeHistory: true,
+    callback: {
+      marker: '__bridge_cb',
+      legacyMarkers: [],
+    },
+    permissions: {
+      maxAccess,
+    },
+  };
+}
+
+/** Resolve the capability contract for a profile's agent kind. */
+export function capabilityFor(
+  profile: Pick<ProfileConfig, 'agentKind' | 'permissions'>,
+): AgentCapability {
+  if (profile.agentKind === 'codex') return codexCapability(profile);
+  if (profile.agentKind === 'grok') return grokCapability(profile);
+  return claudeCapability(profile);
+}
+
+/** Claude and Grok persist native session IDs; Codex uses thread IDs. */
+export function usesNativeSessionId(agentId: AgentCapabilityId): boolean {
+  return agentId !== 'codex';
 }

--- a/src/agent/capability.ts
+++ b/src/agent/capability.ts
@@ -62,7 +62,7 @@ export function grokCapability(profile?: Pick<ProfileConfig, 'permissions'>): Ag
   return {
     agentId: 'grok',
     sessionKind: 'grok-session',
-    promptInjection: 'stdin-prefix',
+    promptInjection: 'append-system-prompt',
     systemPrompt: BRIDGE_SYSTEM_PROMPT,
     supportsNativeHistory: true,
     callback: {

--- a/src/agent/grok/adapter.ts
+++ b/src/agent/grok/adapter.ts
@@ -1,0 +1,283 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createInterface } from 'node:readline';
+import type { Readable } from 'node:stream';
+import { log } from '../../core/logger';
+import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
+import { SpawnFailed } from '../../runtime/errors';
+import { prefixBridgeSystemPrompt } from '../bridge-system-prompt';
+import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel-env';
+import { checkAgentAvailability, type AgentAvailability } from '../preflight';
+import {
+  CLAUDE_DEFAULT_PERMISSION_MODE,
+  type AgentAdapter,
+  type AgentBotIdentity,
+  type AgentEvent,
+  type AgentRun,
+  type AgentRunOptions,
+} from '../types';
+import { buildGrokArgs } from './argv';
+import { translateGrokEvent } from './stream-json';
+
+export interface GrokAdapterOptions {
+  binary?: string;
+  larkChannel?: LarkChannelEnvContext;
+}
+
+type GrokChild = SpawnedProcessByStdio<null, Readable, Readable>;
+
+export class GrokAdapter implements AgentAdapter {
+  readonly id = 'grok';
+  readonly displayName = 'Grok CLI';
+
+  private readonly binary: string;
+  private readonly larkChannel: LarkChannelEnvContext | undefined;
+  private botIdentity: AgentBotIdentity | undefined;
+
+  constructor(opts: GrokAdapterOptions = {}) {
+    this.binary = opts.binary ?? 'grok';
+    this.larkChannel = opts.larkChannel;
+  }
+
+  setBotIdentity(identity: AgentBotIdentity): void {
+    this.botIdentity = identity;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return (await this.checkAvailability()).ok;
+  }
+
+  async checkAvailability(): Promise<AgentAvailability> {
+    return checkAgentAvailability({
+      agentId: 'grok',
+      agentName: 'Grok CLI',
+      command: this.binary,
+      binaryPath: this.binary,
+    });
+  }
+
+  async prepareRun(): Promise<void> {
+    const availability = await this.checkAvailability();
+    if (!availability.ok) {
+      throw new SpawnFailed(
+        'grok binary check failed',
+        availability.error,
+        availability.diagnostic.code,
+        availability.diagnostic,
+      );
+    }
+  }
+
+  run(opts: AgentRunOptions): AgentRun {
+    if (!opts.cwd) {
+      throw new Error('cwd is required for GrokAdapter.run');
+    }
+
+    // Grok headless mode does not read the prompt from stdin. Put both the
+    // bridge system prompt and the user prompt in a temp file so special
+    // characters never reach argv / cmd.exe.
+    const promptFile = writePromptFile(prefixBridgeSystemPrompt(opts.prompt, this.botIdentity));
+    const args = buildGrokArgs({
+      promptFile: promptFile.path,
+      cwd: opts.cwd,
+      sessionId: opts.sessionId,
+      model: opts.model,
+      permissionMode: opts.permissionMode ?? CLAUDE_DEFAULT_PERMISSION_MODE,
+      sandbox: opts.sandbox,
+    });
+
+    const child = spawnProcess(this.binary, args, {
+      cwd: opts.cwd,
+      env: mergeProcessEnv(process.env, {
+        ...buildLarkChannelEnv(this.larkChannel),
+        GROK_DISABLE_AUTOUPDATER: '1',
+      }),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }) as GrokChild;
+
+    log.info('agent', 'spawn', {
+      pid: child.pid ?? null,
+      cwd: opts.cwd,
+      hasSession: Boolean(opts.sessionId),
+      promptChars: opts.prompt.length,
+      model: opts.model,
+    });
+
+    const stderrChunks: Buffer[] = [];
+    let runtimeError: Error | null = null;
+    let stderrBuffer = '';
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderrChunks.push(chunk);
+      stderrBuffer += chunk.toString('utf8');
+      let nl = stderrBuffer.indexOf('\n');
+      while (nl !== -1) {
+        const line = stderrBuffer.slice(0, nl);
+        stderrBuffer = stderrBuffer.slice(nl + 1);
+        if (line.trim()) log.warn('agent', 'stderr', { line });
+        if (isWindowsCommandNotFoundLine(line)) {
+          runtimeError = new Error(`failed to spawn grok: ${line.trim()}`);
+          child.stdout.destroy();
+          child.kill();
+        }
+        nl = stderrBuffer.indexOf('\n');
+      }
+    });
+
+    child.on('error', (err) => {
+      runtimeError = err;
+      promptFile.cleanup();
+    });
+    child.on('exit', (code, signal) => {
+      log.info('agent', 'exit', { pid: child.pid ?? null, code, signal });
+      promptFile.cleanup();
+    });
+
+    const stopGraceMs = opts.stopGraceMs ?? 5000;
+
+    return {
+      runId: opts.runId,
+      events: createEventStream(child, stderrChunks, () => runtimeError),
+      async stop() {
+        if (child.exitCode !== null || child.signalCode !== null) return;
+        log.info('agent', 'stop-sigterm', { pid: child.pid ?? null, graceMs: stopGraceMs });
+        child.kill('SIGTERM');
+        await new Promise<void>((resolve) => {
+          const timer = setTimeout(() => {
+            if (child.exitCode === null && child.signalCode === null) {
+              log.warn('agent', 'stop-sigkill', {
+                pid: child.pid ?? null,
+                graceMs: stopGraceMs,
+                reason: 'grace-period-expired',
+              });
+              child.kill('SIGKILL');
+            }
+            resolve();
+          }, stopGraceMs);
+          child.once('exit', () => {
+            clearTimeout(timer);
+            resolve();
+          });
+        });
+      },
+      waitForExit(timeoutMs: number): Promise<boolean> {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          return Promise.resolve(true);
+        }
+        return new Promise<boolean>((resolve) => {
+          const onExit = (): void => {
+            clearTimeout(timer);
+            resolve(true);
+          };
+          const timer = setTimeout(() => {
+            child.removeListener('exit', onExit);
+            resolve(false);
+          }, timeoutMs);
+          child.once('exit', onExit);
+        });
+      },
+    };
+  }
+}
+
+async function* createEventStream(
+  child: GrokChild,
+  stderrChunks: Buffer[],
+  getError: () => Error | null,
+): AsyncGenerator<AgentEvent> {
+  if (!child.pid) {
+    const err = getError();
+    yield {
+      type: 'error',
+      message: err ? `failed to spawn grok: ${err.message}` : 'spawn returned no pid',
+      terminationReason: 'failed',
+    };
+    return;
+  }
+
+  const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  let sawStdout = false;
+  let silentExitTimer: ReturnType<typeof setTimeout> | undefined;
+  const closeSilentStdout = (): void => {
+    silentExitTimer = setTimeout(() => {
+      if (!sawStdout && !child.stdout.readableEnded) child.stdout.destroy();
+    }, 50);
+  };
+  child.once('exit', closeSilentStdout);
+  try {
+    for await (const line of rl) {
+      sawStdout = true;
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      yield* translateGrokEvent(parsed);
+    }
+  } finally {
+    if (silentExitTimer) clearTimeout(silentExitTimer);
+    child.removeListener('exit', closeSilentStdout);
+    rl.close();
+  }
+
+  const earlyRuntimeError = getError();
+  if (earlyRuntimeError && child.exitCode === null && child.signalCode === null) {
+    yield {
+      type: 'error',
+      message: `grok runtime error: ${earlyRuntimeError.message}`,
+      terminationReason: 'failed',
+    };
+    return;
+  }
+
+  const exitCode = await new Promise<number | null>((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve(child.exitCode);
+    } else {
+      child.once('exit', (code) => resolve(code));
+    }
+  });
+
+  const runtimeError = getError();
+  if (exitCode !== 0 && exitCode !== null) {
+    const stderr = Buffer.concat(stderrChunks).toString('utf8').trim();
+    const detail = stderr ? `: ${stderr.slice(0, 500)}` : '';
+    yield {
+      type: 'error',
+      message: `grok exited with code ${exitCode}${detail}`,
+      terminationReason: 'failed',
+    };
+  } else if (runtimeError) {
+    yield {
+      type: 'error',
+      message: `grok runtime error: ${runtimeError.message}`,
+      terminationReason: 'failed',
+    };
+  }
+}
+
+function writePromptFile(content: string): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'lark-grok-'));
+  const path = join(dir, 'prompt.md');
+  writeFileSync(path, content, 'utf8');
+  return {
+    path,
+    cleanup: () => {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        // best-effort: the OS will reclaim the temp dir eventually
+      }
+    },
+  };
+}
+
+function isWindowsCommandNotFoundLine(line: string): boolean {
+  return (
+    process.platform === 'win32' &&
+    /is not recognized as an internal or external command|operable program or batch file/i.test(line)
+  );
+}

--- a/src/agent/grok/adapter.ts
+++ b/src/agent/grok/adapter.ts
@@ -6,7 +6,7 @@ import type { Readable } from 'node:stream';
 import { log } from '../../core/logger';
 import { mergeProcessEnv, spawnProcess, type SpawnedProcessByStdio } from '../../platform/spawn';
 import { SpawnFailed } from '../../runtime/errors';
-import { prefixBridgeSystemPrompt } from '../bridge-system-prompt';
+import { buildBridgeSystemPrompt } from '../bridge-system-prompt';
 import { buildLarkChannelEnv, type LarkChannelEnvContext } from '../lark-channel-env';
 import { checkAgentAvailability, type AgentAvailability } from '../preflight';
 import {
@@ -74,10 +74,10 @@ export class GrokAdapter implements AgentAdapter {
       throw new Error('cwd is required for GrokAdapter.run');
     }
 
-    // Grok headless mode does not read the prompt from stdin. Put both the
-    // bridge system prompt and the user prompt in a temp file so special
-    // characters never reach argv / cmd.exe.
-    const promptFile = writePromptFile(prefixBridgeSystemPrompt(opts.prompt, this.botIdentity));
+    // User prompt goes through `--prompt-file` (Grok does not read stdin).
+    // Bridge conventions go through `--rules` so they append to Grok's agent
+    // prompt instead of being mixed into the user turn.
+    const promptFile = writePromptFile(composeUserPrompt(opts.prompt, opts.images));
     const args = buildGrokArgs({
       promptFile: promptFile.path,
       cwd: opts.cwd,
@@ -85,6 +85,7 @@ export class GrokAdapter implements AgentAdapter {
       model: opts.model,
       permissionMode: opts.permissionMode ?? CLAUDE_DEFAULT_PERMISSION_MODE,
       sandbox: opts.sandbox,
+      rules: buildBridgeSystemPrompt(this.botIdentity),
     });
 
     const child = spawnProcess(this.binary, args, {
@@ -101,6 +102,7 @@ export class GrokAdapter implements AgentAdapter {
       cwd: opts.cwd,
       hasSession: Boolean(opts.sessionId),
       promptChars: opts.prompt.length,
+      images: opts.images?.length ?? 0,
       model: opts.model,
     });
 
@@ -196,6 +198,7 @@ async function* createEventStream(
   }
 
   const rl = createInterface({ input: child.stdout, crlfDelay: Infinity });
+  let terminal = false;
   let sawStdout = false;
   let silentExitTimer: ReturnType<typeof setTimeout> | undefined;
   const closeSilentStdout = (): void => {
@@ -215,13 +218,18 @@ async function* createEventStream(
       } catch {
         continue;
       }
-      yield* translateGrokEvent(parsed);
+      for (const event of translateGrokEvent(parsed)) {
+        if (event.type === 'done' || event.type === 'error') terminal = true;
+        yield event;
+      }
     }
   } finally {
     if (silentExitTimer) clearTimeout(silentExitTimer);
     child.removeListener('exit', closeSilentStdout);
     rl.close();
   }
+
+  if (terminal) return;
 
   const earlyRuntimeError = getError();
   if (earlyRuntimeError && child.exitCode === null && child.signalCode === null) {
@@ -259,10 +267,16 @@ async function* createEventStream(
   }
 }
 
+function composeUserPrompt(prompt: string, images: readonly string[] | undefined): string {
+  if (!images?.length) return prompt;
+  const list = images.map((path) => `- ${path}`).join('\n');
+  return `${prompt}\n\n<attached_images>\n${list}\n</attached_images>\n`;
+}
+
 function writePromptFile(content: string): { path: string; cleanup: () => void } {
   const dir = mkdtempSync(join(tmpdir(), 'lark-grok-'));
   const path = join(dir, 'prompt.md');
-  writeFileSync(path, content, 'utf8');
+  writeFileSync(path, content, { encoding: 'utf8', mode: 0o600 });
   return {
     path,
     cleanup: () => {

--- a/src/agent/grok/argv.ts
+++ b/src/agent/grok/argv.ts
@@ -1,0 +1,43 @@
+import type { ClaudePermissionMode } from '../../config/permissions';
+import type { SandboxMode } from '../../config/profile-schema';
+import { CLAUDE_DEFAULT_PERMISSION_MODE } from '../types';
+
+export interface BuildGrokArgsInput {
+  promptFile: string;
+  cwd: string;
+  sessionId?: string;
+  model?: string;
+  permissionMode?: ClaudePermissionMode;
+  sandbox?: SandboxMode;
+}
+
+/**
+ * Map the bridge's Codex-shaped sandbox mode onto a Grok CLI `--sandbox`
+ * profile. Full access omits the flag so Grok uses its default (`off`).
+ */
+export function grokSandboxProfile(sandbox: SandboxMode | undefined): string | undefined {
+  if (sandbox === 'read-only') return 'read-only';
+  if (sandbox === 'workspace-write') return 'workspace';
+  return undefined;
+}
+
+export function buildGrokArgs(input: BuildGrokArgsInput): string[] {
+  const permissionMode = input.permissionMode ?? CLAUDE_DEFAULT_PERMISSION_MODE;
+  const args = [
+    '--prompt-file',
+    input.promptFile,
+    '--output-format',
+    'streaming-messages-json',
+    '--permission-mode',
+    permissionMode,
+    '--cwd',
+    input.cwd,
+    '--no-auto-update',
+    '--verbatim',
+  ];
+  const sandbox = grokSandboxProfile(input.sandbox);
+  if (sandbox) args.push('--sandbox', sandbox);
+  if (input.sessionId) args.push('--resume', input.sessionId);
+  if (input.model) args.push('--model', input.model);
+  return args;
+}

--- a/src/agent/grok/argv.ts
+++ b/src/agent/grok/argv.ts
@@ -9,6 +9,8 @@ export interface BuildGrokArgsInput {
   model?: string;
   permissionMode?: ClaudePermissionMode;
   sandbox?: SandboxMode;
+  /** Appended via `grok --rules`. Omit to leave Grok's default agent prompt. */
+  rules?: string;
 }
 
 /**
@@ -35,8 +37,14 @@ export function buildGrokArgs(input: BuildGrokArgsInput): string[] {
     '--no-auto-update',
     '--verbatim',
   ];
-  const sandbox = grokSandboxProfile(input.sandbox);
-  if (sandbox) args.push('--sandbox', sandbox);
+  if (input.rules) args.push('--rules', input.rules);
+  // A resumed session's sandbox is fixed for its lifetime; passing a different
+  // `--sandbox` is refused. Omit the flag on resume so Grok restores the saved
+  // profile. Fresh runs still map the bridge access mode.
+  if (!input.sessionId) {
+    const sandbox = grokSandboxProfile(input.sandbox);
+    if (sandbox) args.push('--sandbox', sandbox);
+  }
   if (input.sessionId) args.push('--resume', input.sessionId);
   if (input.model) args.push('--model', input.model);
   return args;

--- a/src/agent/grok/stream-json.ts
+++ b/src/agent/grok/stream-json.ts
@@ -1,0 +1,45 @@
+import type { AgentEvent } from '../types';
+import { translateEvent } from '../claude/stream-json';
+
+/**
+ * Grok `--output-format streaming-messages-json` follows the Anthropic
+ * Messages stream-json shape that {@link translateEvent} already understands.
+ * Error `result` subtypes are mapped to a terminal `error` event instead of
+ * a successful `done`.
+ */
+export function* translateGrokEvent(raw: unknown): Generator<AgentEvent> {
+  if (!raw || typeof raw !== 'object') return;
+  const evt = raw as {
+    type?: string;
+    subtype?: string;
+    is_error?: boolean;
+    result?: unknown;
+    errors?: unknown;
+  };
+  if (evt.type === 'result' && isGrokErrorResult(evt)) {
+    yield {
+      type: 'error',
+      message: grokErrorMessage(evt),
+      terminationReason: 'failed',
+    };
+    return;
+  }
+  yield* translateEvent(raw);
+}
+
+function isGrokErrorResult(evt: { subtype?: string; is_error?: boolean }): boolean {
+  if (evt.is_error === true) return true;
+  return typeof evt.subtype === 'string' && evt.subtype.startsWith('error');
+}
+
+function grokErrorMessage(evt: { subtype?: string; result?: unknown; errors?: unknown }): string {
+  if (typeof evt.result === 'string' && evt.result.trim()) return evt.result.trim();
+  if (Array.isArray(evt.errors) && evt.errors.length > 0) {
+    const first = evt.errors[0];
+    if (typeof first === 'string' && first.trim()) return first.trim();
+    if (first && typeof first === 'object' && typeof (first as { message?: unknown }).message === 'string') {
+      return (first as { message: string }).message;
+    }
+  }
+  return `grok run failed (${evt.subtype ?? 'error'})`;
+}

--- a/src/agent/index.ts
+++ b/src/agent/index.ts
@@ -1,3 +1,4 @@
 export type { AgentAdapter, AgentEvent, AgentRun, AgentRunOptions } from './types';
 export { ClaudeAdapter } from './claude/adapter';
 export { CodexAdapter } from './codex/adapter';
+export { GrokAdapter } from './grok/adapter';

--- a/src/agent/models.ts
+++ b/src/agent/models.ts
@@ -43,9 +43,18 @@ const CODEX_MODELS: ModelOption[] = [
   { value: 'o3', label: 'o3' },
 ];
 
+/** Grok CLI models. Forwarded to `grok --model`. */
+const GROK_MODELS: ModelOption[] = [
+  { value: DEFAULT_MODEL, label: '跟随默认（不指定）' },
+  { value: 'grok-4.6', label: 'Grok 4.6（最新）' },
+  { value: 'grok-4.5', label: 'Grok 4.5' },
+];
+
 /** The model picker options for a profile's agent kind. */
 export function supportedModels(agentKind: AgentKind): ModelOption[] {
-  return agentKind === 'codex' ? CODEX_MODELS : CLAUDE_MODELS;
+  if (agentKind === 'codex') return CODEX_MODELS;
+  if (agentKind === 'grok') return GROK_MODELS;
+  return CLAUDE_MODELS;
 }
 
 /** True when the selection means "use the agent default" (no `--model`). */

--- a/src/agent/preflight.ts
+++ b/src/agent/preflight.ts
@@ -1,6 +1,7 @@
+import { isAgentKind, type AgentKind } from '../config/profile-schema';
 import { spawnProcess } from '../platform/spawn';
 
-export type LocalAgentId = 'claude' | 'codex';
+export type LocalAgentId = AgentKind;
 
 export type AgentPreflightErrorCode =
   | 'agent-binary-not-found'
@@ -279,7 +280,7 @@ export function isAgentPreflightDiagnostic(input: unknown): input is AgentPrefli
   return (
     typeof raw.code === 'string' &&
     raw.code.startsWith('agent-') &&
-    (raw.agentId === 'claude' || raw.agentId === 'codex') &&
+    isAgentKind(raw.agentId) &&
     typeof raw.agentName === 'string' &&
     typeof raw.command === 'string'
   );

--- a/src/bot/channel.ts
+++ b/src/bot/channel.ts
@@ -5,7 +5,7 @@ import type {
 } from '@larksuite/channel';
 import { createLarkChannel } from '@larksuite/channel';
 import { dirname, join } from 'node:path';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { capabilityFor } from '../agent/capability';
 import { modelLabel, normalizeModelSelection, resolveModelArg } from '../agent/models';
 import {
   buildAgentPrompt,
@@ -955,10 +955,7 @@ async function runAgentBatch(deps: RunBatchDeps): Promise<void> {
     actorId: firstMsg.senderId,
     ...(threadId ? { threadId } : {}),
   };
-  const capability =
-    controls.profileConfig.agentKind === 'codex'
-      ? codexCapability(controls.profileConfig)
-      : claudeCapability(controls.profileConfig);
+  const capability = capabilityFor(controls.profileConfig);
   const flow = await startRunFlow({
     scopeId: scope,
     scope: scopeContext,

--- a/src/bot/comments.ts
+++ b/src/bot/comments.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import type { CommentEvent, LarkChannel } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { capabilityFor, usesNativeSessionId } from '../agent/capability';
 import type { AgentAdapter, AgentEvent } from '../agent/types';
 import { getAgentStopGraceMs } from '../config/schema';
 import type { Controls } from '../commands';
@@ -186,10 +186,7 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
     : false;
 
   try {
-    const capability =
-      controls.profileConfig.agentKind === 'codex'
-        ? codexCapability(controls.profileConfig)
-        : claudeCapability(controls.profileConfig);
+    const capability = capabilityFor(controls.profileConfig);
     const runTimeoutMs = commentRunTimeoutMs(sessions, runScopeId);
     const threadTimeoutMs = commentRunTimeoutMs(sessions, commentThreadScopeId);
     const commentTimeoutMs = runTimeoutMs !== undefined ? runTimeoutMs : threadTimeoutMs;
@@ -243,8 +240,9 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
           })
         : undefined;
       const sessionId =
-        canResumeAgentSession && capability.agentId === 'claude'
-          ? sessions.resumeFor(docSessionScopeId, cwdRealpath) ??
+        canResumeAgentSession && usesNativeSessionId(capability.agentId)
+          ? catalogEntry?.sessionId ??
+            sessions.resumeFor(docSessionScopeId, cwdRealpath) ??
             sessions.resumeFor(legacyDocSessionScopeId, cwdRealpath)
           : undefined;
       const threadId = capability.agentId === 'codex' ? catalogEntry?.threadId : undefined;
@@ -328,7 +326,7 @@ export async function handleCommentMention(deps: CommentDeps): Promise<void> {
             policy,
             event: e,
           });
-          if (capability.agentId === 'claude' && e.type === 'system' && e.sessionId) {
+          if (usesNativeSessionId(capability.agentId) && e.type === 'system' && e.sessionId) {
             sessions.set(docSessionScopeId, e.sessionId, policy.cwdRealpath);
           }
           switch (e.type) {

--- a/src/bot/run-flow.ts
+++ b/src/bot/run-flow.ts
@@ -148,13 +148,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
         input.profileConfig.agentKind,
         input.profileConfig.preferences.model,
       ),
-      images:
-        input.capability.agentId === 'codex'
-          ? policy.attachments
-              .filter((attachment) => attachment.kind === 'image' && attachment.decision === 'accepted')
-              .map((attachment) => attachment.path)
-              .filter((path): path is string => Boolean(path))
-          : undefined,
+      images: nativeImagePaths(input.capability.agentId, policy.attachments),
       stopGraceMs: input.stopGraceMs,
       observability: input.observability,
     });
@@ -209,4 +203,16 @@ export function recordRunSessionEvent(input: RecordRunSessionEventInput): void {
       threadId: input.event.threadId,
     });
   }
+}
+
+function nativeImagePaths(
+  agentId: AgentCapability['agentId'],
+  attachments: readonly AgentAttachment[],
+): string[] | undefined {
+  if (agentId !== 'codex' && agentId !== 'grok') return undefined;
+  const paths = attachments
+    .filter((attachment) => attachment.kind === 'image' && attachment.decision === 'accepted')
+    .map((attachment) => attachment.path)
+    .filter((path): path is string => Boolean(path));
+  return paths.length > 0 ? paths : undefined;
 }

--- a/src/bot/run-flow.ts
+++ b/src/bot/run-flow.ts
@@ -1,4 +1,4 @@
-import type { AgentCapability } from '../agent/capability';
+import { usesNativeSessionId, type AgentCapability } from '../agent/capability';
 import { resolveModelArg } from '../agent/models';
 import type { AgentEvent } from '../agent/types';
 import type { ProfileConfig } from '../config/profile-schema';
@@ -120,7 +120,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
       cwdRealpath: workspace.cwdRealpath,
       policyFingerprint: policy.policyFingerprint,
     });
-    if (catalogEntry?.agentId === 'claude') {
+    if (catalogEntry && usesNativeSessionId(catalogEntry.agentId)) {
       sessionId = catalogEntry.sessionId;
       resumeFrom = sessionId;
     } else if (catalogEntry?.agentId === 'codex') {
@@ -128,7 +128,7 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
       resumeFrom = threadId;
     }
   }
-  if (!resumeFrom && input.capability.agentId === 'claude') {
+  if (!resumeFrom && usesNativeSessionId(input.capability.agentId)) {
     resumeFrom = input.sessions.resumeFor(input.scopeId, workspace.cwdRealpath);
     sessionId = resumeFrom;
     const stale = input.sessions.getRaw(input.scopeId);
@@ -188,12 +188,12 @@ export async function startRunFlow(input: StartRunFlowInput): Promise<StartRunFl
 
 export function recordRunSessionEvent(input: RecordRunSessionEventInput): void {
   if (input.event.type !== 'system') return;
-  if (input.capability.agentId === 'claude' && input.event.sessionId) {
+  if (usesNativeSessionId(input.capability.agentId) && input.event.sessionId) {
     const cwdRealpath = input.event.cwd ?? input.policy.cwdRealpath;
     input.sessions.set(input.scopeId, input.event.sessionId, cwdRealpath);
     input.sessionCatalog?.upsertActive({
       scopeId: input.scopeId,
-      agentId: 'claude',
+      agentId: input.capability.agentId,
       cwdRealpath,
       policyFingerprint: input.policy.policyFingerprint,
       sessionId: input.event.sessionId,

--- a/src/bot/session-catalog-identity.ts
+++ b/src/bot/session-catalog-identity.ts
@@ -1,5 +1,5 @@
 import type { NormalizedMessage } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { capabilityFor } from '../agent/capability';
 import type { Controls } from '../commands';
 import type { AccessDecision } from '../policy/access';
 import { evaluateRunPolicy } from '../policy/run-policy';
@@ -21,10 +21,7 @@ export async function commandSessionCatalogIdentity(input: {
   if (!requestedCwd) return undefined;
   const workspace = await resolveWorkingDirectory(requestedCwd);
   if (!workspace.ok) return undefined;
-  const capability =
-    input.controls.profileConfig.agentKind === 'codex'
-      ? codexCapability(input.controls.profileConfig)
-      : claudeCapability(input.controls.profileConfig);
+  const capability = capabilityFor(input.controls.profileConfig);
   const policy = evaluateRunPolicy({
     scope: {
       source: 'im',

--- a/src/cli/agent-detection.ts
+++ b/src/cli/agent-detection.ts
@@ -1,8 +1,9 @@
 import { constants } from 'node:fs';
 import { access } from 'node:fs/promises';
 import { delimiter, extname, isAbsolute, join } from 'node:path';
+import type { AgentKind } from '../config/profile-schema';
 
-export type AgentKind = 'claude' | 'codex';
+export type { AgentKind };
 
 export interface DetectedAgent {
   kind: AgentKind;
@@ -48,6 +49,7 @@ export async function detectInstalledAgents(): Promise<DetectedAgent[]> {
   const candidates: Array<{ kind: AgentKind; command: string }> = [
     { kind: 'claude', command: process.env.LARK_CHANNEL_CLAUDE_BIN ?? 'claude' },
     { kind: 'codex', command: process.env.LARK_CHANNEL_CODEX_BIN ?? 'codex' },
+    { kind: 'grok', command: process.env.LARK_CHANNEL_GROK_BIN ?? 'grok' },
   ];
   const detected: DetectedAgent[] = [];
   for (const candidate of candidates) {

--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, readdir, rename, rm, stat } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { createBootstrapCodexConfig } from '../profile-bootstrap';
+import { createBootstrapCodexConfig, createBootstrapGrokConfig } from '../profile-bootstrap';
 import { promptLine } from '../prompt';
 import { stopProcessEntry } from './ps';
 import {
@@ -43,7 +43,9 @@ export async function runMigrate(opts: MigrateOptions): Promise<void> {
   const configPath = opts.config ?? paths.configFile;
   await migrateLegacyPaths();
   await migrateConfigShape(configPath);
-  const agentKind = agentKindFromString(opts.agent) ?? (opts.profile === 'codex' ? 'codex' : undefined);
+  const agentKind =
+    agentKindFromString(opts.agent) ??
+    (opts.profile === 'codex' ? 'codex' : opts.profile === 'grok' ? 'grok' : undefined);
   const needsV2Migration = await hasLegacyProfileConfig(configPath);
   const result = await migrateProfileV2WithActiveBridgePrompt({
     rootDir: dirname(configPath),
@@ -52,6 +54,9 @@ export async function runMigrate(opts: MigrateOptions): Promise<void> {
     ...(agentKind ? { agentKind } : {}),
     ...(needsV2Migration && agentKind === 'codex'
       ? { codex: await createBootstrapCodexConfig(undefined) }
+      : {}),
+    ...(needsV2Migration && agentKind === 'grok'
+      ? { grok: await createBootstrapGrokConfig(undefined) }
       : {}),
   }, opts);
   if (!result) return;

--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -605,7 +605,7 @@ async function maybeResolveProfileRuntime(
 }
 
 function agentDisplay(agentKind: ProcessEntry['agentKind']): { id: string; displayName: string } {
-  return agentKind === 'codex'
-    ? { id: 'codex', displayName: 'Codex CLI' }
-    : { id: 'claude', displayName: 'Claude Code' };
+  if (agentKind === 'codex') return { id: 'codex', displayName: 'Codex CLI' };
+  if (agentKind === 'grok') return { id: 'grok', displayName: 'Grok CLI' };
+  return { id: 'claude', displayName: 'Claude Code' };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -41,7 +41,7 @@ program
   .option('-c, --config <path>', 'path to config file')
   .option('--profile <name>', 'profile name to run')
   .option('--web-ui', 'run the machine-wide supervisor + local web console (hosts all profiles); default is a single-profile headless run')
-  .option('--agent <kind>', 'agent kind for a new profile (claude or codex)')
+  .option('--agent <kind>', 'agent kind for a new profile (claude, codex, or grok)')
   .option('--workspace <path>', 'initial working directory for first-run profile bootstrap')
   .option('--app-id <id>', 'use an existing Lark/Feishu app instead of QR app creation')
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')
@@ -66,7 +66,7 @@ program
   .description('Migrate legacy bridge config/state into the current profile layout')
   .option('-c, --config <path>', 'path to config file')
   .option('--profile <name>', 'target profile name for legacy v1 config migration')
-  .option('--agent <kind>', 'agent kind for legacy v1 profile migration (claude or codex)')
+  .option('--agent <kind>', 'agent kind for legacy v1 profile migration (claude, codex, or grok)')
   .action(async (opts: { config?: string; profile?: string; agent?: string }) => {
     await runMigrate(opts);
   });
@@ -85,7 +85,7 @@ profile
 profile
   .command('create <name>')
   .description('Create a profile from QR registration or existing app credentials')
-  .option('--agent <kind>', 'agent kind (claude or codex)')
+  .option('--agent <kind>', 'agent kind (claude, codex, or grok)')
   .option('--workspace <path>', 'initial working directory for this profile')
   .option('--app-id <id>', 'use an existing Lark/Feishu app instead of QR app creation')
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')
@@ -167,7 +167,7 @@ program
   .description('Install (if needed) and start the bridge as an OS-managed daemon')
   .option('--profile <name>', 'profile name (defaults to active profile)')
   .option('--web-ui', 'run the supervisor + web console as the background service (hosts all profiles) instead of a single profile')
-  .option('--agent <kind>', 'agent kind for first-run profile bootstrap (claude or codex)')
+  .option('--agent <kind>', 'agent kind for first-run profile bootstrap (claude, codex, or grok)')
   .option('--workspace <path>', 'initial working directory for first-run profile bootstrap')
   .option('--app-id <id>', 'use an existing Lark/Feishu app instead of QR app creation')
   .option('--app-secret <secret>', 'App Secret for --app-id; prefer interactive input on shared machines')

--- a/src/cli/profile-bootstrap.ts
+++ b/src/cli/profile-bootstrap.ts
@@ -14,6 +14,7 @@ export interface BootstrapProfileInput {
   workspace?: string;
   defaultWorkspace?: string;
   codexBinaryPath?: string;
+  grokBinaryPath?: string;
   profileDir?: string;
 }
 
@@ -29,12 +30,17 @@ export async function createBootstrapProfileConfig(
     input.agentKind === 'codex'
       ? await createBootstrapCodexConfig(input.codexBinaryPath)
       : undefined;
+  const grok =
+    input.agentKind === 'grok'
+      ? await createBootstrapGrokConfig(input.grokBinaryPath)
+      : undefined;
   const profile = createDefaultProfileConfig({
     agentKind: input.agentKind,
     accounts: input.accounts,
     preferences: input.preferences,
     secrets: input.secrets,
     ...(codex ? { codex } : {}),
+    ...(grok ? { grok } : {}),
   });
   if (workspace) {
     profile.workspaces = {
@@ -67,7 +73,7 @@ export async function createBootstrapCodexConfig(binaryPath: string | undefined)
   } catch (err) {
     const errno = (err as NodeJS.ErrnoException).code;
     throw new AgentPreflightError({
-      code: codexBootstrapBinaryErrorCode(errno),
+      code: bootstrapBinaryErrorCode(errno),
       agentId: 'codex',
       agentName: 'Codex CLI',
       command,
@@ -78,7 +84,26 @@ export async function createBootstrapCodexConfig(binaryPath: string | undefined)
   return { binaryPath: resolvedBinary };
 }
 
-function codexBootstrapBinaryErrorCode(errno: string | undefined) {
+export async function createBootstrapGrokConfig(binaryPath: string | undefined) {
+  const command = binaryPath ?? process.env.LARK_CHANNEL_GROK_BIN ?? 'grok';
+  let resolvedBinary: string;
+  try {
+    resolvedBinary = await resolveExecutablePath(command);
+  } catch (err) {
+    const errno = (err as NodeJS.ErrnoException).code;
+    throw new AgentPreflightError({
+      code: bootstrapBinaryErrorCode(errno),
+      agentId: 'grok',
+      agentName: 'Grok CLI',
+      command,
+      binaryPath: command,
+      errno,
+    });
+  }
+  return { binaryPath: resolvedBinary };
+}
+
+function bootstrapBinaryErrorCode(errno: string | undefined) {
   if (errno === 'EACCES' || errno === 'EPERM') return 'agent-binary-not-executable';
   if (errno === 'ELOOP' || errno === 'ENOTDIR' || errno === 'EINVAL') {
     return 'agent-binary-resolve-failed';

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute } from 'node:path';
 import type { LarkChannel, NormalizedMessage } from '@larksuite/channel';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { capabilityFor, usesNativeSessionId, type AgentCapabilityId } from '../agent/capability';
 import { DEFAULT_MODEL, normalizeModelSelection, supportedModels } from '../agent/models';
 import type { AgentAdapter } from '../agent/types';
 import type { ActiveRuns } from '../bot/active-runs';
@@ -62,6 +62,7 @@ import {
   type RunState,
 } from '../card/run-state';
 import { formatRelTime, listRecentSessions, type SessionSummary } from '../session/history';
+import { listRecentGrokSessions } from '../session/grok-history';
 import {
   listCodexThreadHistory,
   type CodexThreadHistoryEntry,
@@ -141,6 +142,7 @@ export interface CommandContext {
     options: ListCodexThreadHistoryOptions,
   ) => Promise<CodexThreadHistoryEntry[]>;
   claudeHistoryProvider?: (cwd: string, limit: number) => Promise<SessionSummary[]>;
+  grokHistoryProvider?: (cwd: string, limit: number) => Promise<SessionSummary[]>;
   /** Set when invoked from a CardKit 2.0 form submit. Keys are input `name`s. */
   formValue?: Record<string, unknown>;
   /** True when this invocation came from a card button click rather than a
@@ -153,7 +155,7 @@ type Handler = (args: string, ctx: CommandContext) => Promise<void>;
 
 interface ResumeCandidate {
   scopeId: string;
-  agentId: 'claude' | 'codex';
+  agentId: AgentCapabilityId;
   cwdRealpath: string;
   policyFingerprint: string;
   sessionId?: string;
@@ -592,7 +594,10 @@ async function handleResume(args: string, ctx: CommandContext): Promise<void> {
     return;
   }
 
-  const sessions = await listClaudeResumeHistory(ctx, cwd, limit);
+  const sessions =
+    ctx.controls.profileConfig.agentKind === 'grok'
+      ? await listGrokResumeHistory(ctx, cwd, limit)
+      : await listClaudeResumeHistory(ctx, cwd, limit);
   const currentSession = ctx.sessions.getRaw(ctx.scope);
   const identity = ctx.sessionCatalogIdentity;
   const entries = sessions.map((s) => ({
@@ -626,7 +631,7 @@ async function applyResume(sessionId: string, ctx: CommandContext): Promise<void
       } else {
         ctx.sessionCatalog.upsertActive({
           scopeId: ctx.sessionCatalogIdentity.scopeId,
-          agentId: 'claude',
+          agentId: ctx.sessionCatalogIdentity.agentId,
           cwdRealpath: ctx.sessionCatalogIdentity.cwdRealpath,
           policyFingerprint: ctx.sessionCatalogIdentity.policyFingerprint,
           sessionId: resolved.sessionId!,
@@ -646,7 +651,7 @@ async function applyResume(sessionId: string, ctx: CommandContext): Promise<void
       return;
     }
     ctx.activeRuns.interrupt(ctx.scope);
-    if (ctx.sessionCatalogIdentity.agentId === 'claude') {
+    if (usesNativeSessionId(ctx.sessionCatalogIdentity.agentId)) {
       ctx.sessions.set(ctx.scope, sessionId, ctx.sessionCatalogIdentity.cwdRealpath);
     }
     await reply(ctx, RESUME_APPLIED_REPLY);
@@ -699,7 +704,7 @@ function consumeResumeCandidate(
     candidate.agentId !== identity.agentId ||
     candidate.cwdRealpath !== identity.cwdRealpath ||
     candidate.policyFingerprint !== identity.policyFingerprint ||
-    (identity.agentId === 'claude' && !candidate.sessionId) ||
+    (usesNativeSessionId(identity.agentId) && !candidate.sessionId) ||
     (identity.agentId === 'codex' && !candidate.threadId)
   ) {
     return undefined;
@@ -720,6 +725,22 @@ async function listClaudeResumeHistory(
 ): Promise<SessionSummary[]> {
   const provider = ctx.claudeHistoryProvider ?? listRecentSessions;
   return provider(cwd, limit);
+}
+
+async function listGrokResumeHistory(
+  ctx: CommandContext,
+  cwd: string,
+  limit: number,
+): Promise<SessionSummary[]> {
+  const provider = ctx.grokHistoryProvider ?? listRecentGrokSessions;
+  try {
+    return await provider(cwd, limit);
+  } catch (err) {
+    log.warn('session', 'grok-history-failed', {
+      message: err instanceof Error ? err.message : String(err),
+    });
+    return [];
+  }
 }
 
 async function listCodexResumeHistory(
@@ -762,18 +783,18 @@ function selectedResumeCwd(ctx: CommandContext): string | undefined {
 function runtimeAccessStatus(
   profileConfig: ProfileConfig,
 ): { label: string; value: string } {
-  if (profileConfig.agentKind === 'claude') {
+  if (profileConfig.agentKind === 'codex') {
     return {
-      label: 'permission',
-      value: accessToClaudePermissionMode(
-        profileConfig.permissions.defaultAccess,
-        profileConfig.permissions,
-      ),
+      label: 'sandbox',
+      value: `${profileConfig.sandbox.defaultMode}/${profileConfig.sandbox.maxMode}`,
     };
   }
   return {
-    label: 'sandbox',
-    value: `${profileConfig.sandbox.defaultMode}/${profileConfig.sandbox.maxMode}`,
+    label: 'permission',
+    value: accessToClaudePermissionMode(
+      profileConfig.permissions.defaultAccess,
+      profileConfig.permissions,
+    ),
   };
 }
 
@@ -1127,10 +1148,7 @@ async function handleDoctor(args: string, ctx: CommandContext): Promise<void> {
   }
   doctorLastByOperator.set(rateKey, now);
 
-  const capability =
-    ctx.controls.profileConfig.agentKind === 'codex'
-      ? codexCapability(ctx.controls.profileConfig)
-      : claudeCapability(ctx.controls.profileConfig);
+  const capability = capabilityFor(ctx.controls.profileConfig);
   const policy = evaluateRunPolicy({
     scope: {
       source: 'im',

--- a/src/config/migrate-v2.ts
+++ b/src/config/migrate-v2.ts
@@ -11,8 +11,10 @@ import { dirname, join } from 'node:path';
 import { resolveAppPaths } from './app-paths';
 import {
   createDefaultProfileConfig,
+  isAgentKind,
   type AgentKind,
   type CodexConfig,
+  type GrokConfig,
   type RootConfig,
 } from './profile-schema';
 import { markPermissionDefaultsMigration, saveRootConfig } from './profile-store';
@@ -27,6 +29,7 @@ export interface MigrateV2Options {
   workspace?: string;
   agentKind?: AgentKind;
   codex?: CodexConfig;
+  grok?: GrokConfig;
 }
 
 export interface MigrateV2Result {
@@ -129,6 +132,7 @@ export async function migrateV1ToV2(opts: MigrateV2Options = {}): Promise<Migrat
       requireMentionInGroup: legacy.preferences?.requireMentionInGroup,
     },
     ...(agentKind === 'codex' && opts.codex ? { codex: opts.codex } : {}),
+    ...(agentKind === 'grok' && opts.grok ? { grok: opts.grok } : {}),
   });
   if (legacyDefaultWorkspace) {
     profileConfig.workspaces = {
@@ -200,7 +204,7 @@ function activeProcessFromRegistryEntry(entry: RegistryEntry): ActiveBridgeMigra
   if (typeof entry.appId === 'string') active.appId = entry.appId;
   if (typeof entry.tenant === 'string') active.tenant = entry.tenant;
   if (typeof entry.profileName === 'string') active.profileName = entry.profileName;
-  if (entry.agentKind === 'claude' || entry.agentKind === 'codex') active.agentKind = entry.agentKind;
+  if (isAgentKind(entry.agentKind)) active.agentKind = entry.agentKind;
   if (typeof entry.configPath === 'string') active.configPath = entry.configPath;
   if (typeof entry.startedAt === 'string') active.startedAt = entry.startedAt;
   if (typeof entry.version === 'string') active.version = entry.version;

--- a/src/config/profile-schema.ts
+++ b/src/config/profile-schema.ts
@@ -13,7 +13,13 @@ import {
   type PermissionSource,
 } from './permissions';
 
-export type AgentKind = 'claude' | 'codex';
+export const AGENT_KINDS = ['claude', 'codex', 'grok'] as const;
+export type AgentKind = (typeof AGENT_KINDS)[number];
+
+export function isAgentKind(value: unknown): value is AgentKind {
+  return value === 'claude' || value === 'codex' || value === 'grok';
+}
+
 export type SandboxMode = CodexSandboxMode;
 export type { AccessMode, PermissionConfig, PermissionSource };
 
@@ -49,6 +55,12 @@ export interface CodexConfig {
   inheritCodexHome?: boolean;
   ignoreUserConfig?: boolean;
   ignoreRules?: boolean;
+}
+
+export interface GrokConfig {
+  binaryPath: string;
+  realpath?: string;
+  version?: string;
 }
 
 export interface AttachmentConfig {
@@ -160,6 +172,7 @@ export interface ProfileConfig {
   permissions: PermissionConfig;
   permissionSource?: PermissionSource;
   codex?: CodexConfig;
+  grok?: GrokConfig;
   attachments: AttachmentConfig;
   comments: CommentConfig;
   /** In-meeting agent settings. See {@link MeetingConfig}. */
@@ -204,6 +217,7 @@ export interface CreateDefaultProfileConfigInput {
   sandbox?: Partial<SandboxConfig>;
   permissions?: Partial<PermissionConfig>;
   codex?: CodexConfig;
+  grok?: GrokConfig;
   secrets?: SecretsConfig;
 }
 
@@ -239,6 +253,7 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
     sandbox?: Partial<SandboxConfig>;
     permissions?: Partial<PermissionConfig>;
     codex?: CodexConfig & { flags?: unknown };
+    grok?: GrokConfig;
     attachments?: Partial<AttachmentConfig>;
     comments?: unknown;
     meeting?: unknown;
@@ -248,12 +263,15 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
   if (raw.schemaVersion !== 2) {
     throw new Error('profile schemaVersion must be 2');
   }
-  if (raw.agentKind !== 'claude' && raw.agentKind !== 'codex') {
-    throw new Error('agentKind must be claude or codex');
+  if (!isAgentKind(raw.agentKind)) {
+    throw new Error('agentKind must be claude, codex, or grok');
   }
   const accounts = normalizeAccounts(raw.accounts);
   if (raw.agentKind === 'codex' && !raw.codex) {
     throw new Error('codex profile requires codex configuration');
+  }
+  if (raw.agentKind === 'grok' && !raw.grok) {
+    throw new Error('grok profile requires grok configuration');
   }
 
   const preferences = normalizePreferences(raw.preferences);
@@ -284,6 +302,7 @@ export function normalizeProfileConfig(input: unknown): ProfileConfig {
     permissions,
     permissionSource,
     ...(raw.codex ? { codex: normalizeCodex(raw.codex) } : {}),
+    ...(raw.grok ? { grok: normalizeGrok(raw.grok) } : {}),
     attachments: {
       maxCount: numberOr(raw.attachments?.maxCount, 10),
       maxBytes: numberOr(raw.attachments?.maxBytes, 100 * 1024 * 1024),
@@ -389,6 +408,17 @@ function normalizeCodex(input: CodexConfig & { flags?: unknown }): CodexConfig {
     ignoreRules: input.ignoreRules !== false,
   };
   return codex;
+}
+
+function normalizeGrok(input: GrokConfig): GrokConfig {
+  if (!input.binaryPath || typeof input.binaryPath !== 'string') {
+    throw new Error('grok.binaryPath is required');
+  }
+  return {
+    binaryPath: input.binaryPath,
+    ...(typeof input.realpath === 'string' ? { realpath: input.realpath } : {}),
+    ...(typeof input.version === 'string' ? { version: input.version } : {}),
+  };
 }
 
 function normalizeComments(_input: unknown): CommentConfig {

--- a/src/config/profile-store.ts
+++ b/src/config/profile-store.ts
@@ -57,6 +57,7 @@ type StoredProfileConfig = Pick<
   | 'workspaces'
   | 'permissions'
   | 'codex'
+  | 'grok'
   | 'attachments'
   | 'comments'
   | 'meeting'
@@ -96,6 +97,7 @@ function serializeProfileConfig(profile: ProfileConfig): StoredProfileConfig {
     workspaces: profile.workspaces,
     permissions: profile.permissions,
     ...(profile.codex ? { codex: profile.codex } : {}),
+    ...(profile.grok ? { grok: profile.grok } : {}),
     attachments: profile.attachments,
     comments: {},
     meeting: profile.meeting,
@@ -296,7 +298,7 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 export function agentKindFromString(value: string | undefined): AgentKind | undefined {
-  if (value === 'claude' || value === 'codex') return value;
+  if (value === 'claude' || value === 'codex' || value === 'grok') return value;
   if (value === undefined) return undefined;
   throw new Error(`unsupported agent: ${value}`);
 }

--- a/src/meeting/orchestrator.ts
+++ b/src/meeting/orchestrator.ts
@@ -1,6 +1,6 @@
 import type { LarkChannel } from '@larksuite/channel';
 import type { AgentEvent } from '../agent/types';
-import { claudeCapability, codexCapability } from '../agent/capability';
+import { capabilityFor } from '../agent/capability';
 import type { Controls } from '../commands';
 import { log } from '../core/logger';
 import type { RunExecutor } from '../runtime/run-executor';
@@ -295,10 +295,7 @@ async function runMeetingAgent(
 ): Promise<string> {
   const { session, controls } = deps;
   const scopeId = meetingScopeId(session.meetingId);
-  const capability =
-    controls.profileConfig.agentKind === 'codex'
-      ? codexCapability(controls.profileConfig)
-      : claudeCapability(controls.profileConfig);
+  const capability = capabilityFor(controls.profileConfig);
   const result = await startRunFlow({
     scopeId,
     scope: {

--- a/src/runtime/agent-runtime.ts
+++ b/src/runtime/agent-runtime.ts
@@ -1,9 +1,10 @@
 import { ClaudeAdapter } from '../agent/claude/adapter';
 import { CodexAdapter } from '../agent/codex/adapter';
+import { GrokAdapter } from '../agent/grok/adapter';
 import { AgentPreflightError, type AgentAvailability } from '../agent/preflight';
 import type { AgentAdapter } from '../agent/types';
 import type { AppPaths } from '../config/app-paths';
-import type { AgentKind, ProfileConfig } from '../config/profile-schema';
+import { isAgentKind, type AgentKind, type ProfileConfig } from '../config/profile-schema';
 import type { AcquiredRuntimeLock } from './locks';
 
 /**
@@ -49,6 +50,16 @@ export function createRuntimeAgent(
       larkChannel,
     });
   }
+  if (profileConfig.agentKind === 'grok') {
+    const grok = profileConfig.grok;
+    if (!grok?.binaryPath) {
+      throw new Error('grok profile requires grok.binaryPath');
+    }
+    return new GrokAdapter({
+      binary: grok.binaryPath,
+      larkChannel,
+    });
+  }
   return new ClaudeAdapter({ larkChannel });
 }
 
@@ -56,11 +67,12 @@ export async function checkRuntimeAgentAvailability(agent: AgentAdapter): Promis
   if (agent.checkAvailability) return agent.checkAvailability();
   const ok = await agent.isAvailable();
   if (ok) return { ok: true };
+  const agentId: AgentKind = isAgentKind(agent.id) ? agent.id : 'claude';
   const diagnostic = {
     code: 'agent-binary-not-found' as const,
-    agentId: agent.id === 'codex' ? ('codex' as const) : ('claude' as const),
+    agentId,
     agentName: agent.displayName,
-    command: agent.id === 'codex' ? 'codex' : 'claude',
+    command: agentId,
   };
   return { ok: false, diagnostic, error: new AgentPreflightError(diagnostic) };
 }

--- a/src/runtime/locks.ts
+++ b/src/runtime/locks.ts
@@ -2,7 +2,7 @@ import { chmod, mkdir, readFile, unlink, writeFile } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import * as lockfile from 'proper-lockfile';
 import type { AppPaths } from '../config/app-paths';
-import type { AgentKind } from '../config/profile-schema';
+import { isAgentKind, type AgentKind } from '../config/profile-schema';
 
 export type RuntimeLockKind = 'profile' | 'app';
 
@@ -178,7 +178,7 @@ function isRuntimeLockMeta(value: unknown): value is RuntimeLockMeta {
     (meta.kind === 'profile' || meta.kind === 'app') &&
     typeof meta.target === 'string' &&
     typeof meta.profile === 'string' &&
-    (meta.agentKind === 'claude' || meta.agentKind === 'codex') &&
+    isAgentKind(meta.agentKind) &&
     typeof meta.pid === 'number' &&
     typeof meta.startedAt === 'string' &&
     (meta.appId === undefined || typeof meta.appId === 'string')

--- a/src/runtime/profile-runtime.ts
+++ b/src/runtime/profile-runtime.ts
@@ -5,6 +5,7 @@ import { runRegistrationWizard } from '../bot/wizard';
 import { detectInstalledAgents, type DetectedAgent } from '../cli/agent-detection';
 import {
   createBootstrapCodexConfig,
+  createBootstrapGrokConfig,
   createBootstrapProfileConfig,
   resolveBootstrapWorkspace,
 } from '../cli/profile-bootstrap';
@@ -90,6 +91,9 @@ export function createRuntimeProfileConfig(
     ...(input.agentKind === 'codex'
       ? { codex: input.codex ?? { binaryPath: process.env.LARK_CHANNEL_CODEX_BIN ?? 'codex' } }
       : {}),
+    ...(input.agentKind === 'grok'
+      ? { grok: input.grok ?? { binaryPath: process.env.LARK_CHANNEL_GROK_BIN ?? 'grok' } }
+      : {}),
   });
 }
 
@@ -108,7 +112,7 @@ export async function resolveProfileRuntime(
   if (!profile && opts.allowBootstrap) {
     const detected = await detectInstalledAgents();
     if (detected.length === 0) {
-      throw new Error('no supported local agent found; install claude or codex first');
+      throw new Error('no supported local agent found; install claude, codex, or grok first');
     }
     if (detected.length > 1) {
       const selected = await selectDetectedAgent(detected, opts.selectAgent);
@@ -137,6 +141,9 @@ export async function resolveProfileRuntime(
     ...(migrationAgent ? { agentKind: migrationAgent } : {}),
     ...(needsMigration && migrationAgent === 'codex'
       ? { codex: await createBootstrapCodexConfig(undefined) }
+      : {}),
+    ...(needsMigration && migrationAgent === 'grok'
+      ? { grok: await createBootstrapGrokConfig(undefined) }
       : {}),
   }, opts.handleActiveBridgeMigrationConflict);
 
@@ -395,7 +402,9 @@ function resolveBootstrapAgent(
   requestedAgent: AgentKind | undefined,
   profile: string | undefined,
 ): AgentKind | undefined {
-  return requestedAgent ?? (profile === 'codex' ? 'codex' : undefined);
+  if (requestedAgent) return requestedAgent;
+  if (profile === 'codex' || profile === 'grok') return profile;
+  return undefined;
 }
 
 async function hasLegacyConfig(configPath: string): Promise<boolean> {
@@ -568,7 +577,7 @@ function formatAmbiguousAgentSelectionError(
 ): string {
   const lines = detected.map((agent) => `  - ${agent.kind}: ${agent.binaryPath}`);
   return [
-    '检测到多个本地 agent，请使用 --agent <claude|codex> 指定要初始化哪一个。',
+    '检测到多个本地 agent，请使用 --agent <claude|codex|grok> 指定要初始化哪一个。',
     '已检测到：',
     ...lines,
   ].join('\n');
@@ -613,7 +622,9 @@ class UserCancelledError extends Error {
 }
 
 function displayAgentKind(kind: AgentKind): string {
-  return kind === 'claude' ? 'Claude Code' : 'Codex CLI';
+  if (kind === 'codex') return 'Codex CLI';
+  if (kind === 'grok') return 'Grok CLI';
+  return 'Claude Code';
 }
 
 async function maybeMigrateRootPlaintextSecret(

--- a/src/runtime/registry.ts
+++ b/src/runtime/registry.ts
@@ -15,7 +15,7 @@ import { basename, dirname, join } from 'node:path';
 import * as lockfile from 'proper-lockfile';
 import { resolveAppPaths } from '../config/app-paths';
 import { paths } from '../config/paths';
-import type { AgentKind } from '../config/profile-schema';
+import { isAgentKind, type AgentKind } from '../config/profile-schema';
 import type { TenantBrand } from '../config/schema';
 import { writeFileAtomic } from '../platform/atomic-write';
 import { checkRuntimeLock } from './locks';
@@ -64,7 +64,7 @@ function isValidEntry(e: unknown): e is ProcessEntry {
     typeof x.appId === 'string' &&
     (x.tenant === 'feishu' || x.tenant === 'lark') &&
     typeof x.profileName === 'string' &&
-    (x.agentKind === 'claude' || x.agentKind === 'codex') &&
+    isAgentKind(x.agentKind) &&
     typeof x.configPath === 'string' &&
     typeof x.startedAt === 'string' &&
     typeof x.version === 'string'

--- a/src/session/catalog.ts
+++ b/src/session/catalog.ts
@@ -3,7 +3,8 @@ import { open, readFile, rename, mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { paths } from '../config/paths';
 import { log } from '../core/logger';
-import type { AgentCapabilityId } from '../agent/capability';
+import { usesNativeSessionId, type AgentCapabilityId } from '../agent/capability';
+import { isAgentKind } from '../config/profile-schema';
 
 export type CatalogAgentId = AgentCapabilityId;
 export type SessionCatalogStatus = 'active' | 'archived';
@@ -214,7 +215,7 @@ function normalizeEntry(input: unknown): SessionCatalogEntry | undefined {
   if (
     typeof raw.key !== 'string' ||
     typeof raw.scopeId !== 'string' ||
-    (raw.agentId !== 'claude' && raw.agentId !== 'codex') ||
+    !isAgentKind(raw.agentId) ||
     typeof raw.cwdRealpath !== 'string' ||
     typeof raw.policyFingerprint !== 'string' ||
     (raw.status !== 'active' && raw.status !== 'archived') ||
@@ -247,14 +248,17 @@ function matchesIdentity(entry: SessionCatalogEntry, input: SessionCatalogIdenti
 }
 
 function isValidAgentEntry(entry: SessionCatalogEntry): boolean {
-  if (entry.agentId === 'claude') return Boolean(entry.sessionId) && !entry.threadId;
+  if (usesNativeSessionId(entry.agentId)) {
+    return Boolean(entry.sessionId) && !entry.threadId;
+  }
   return Boolean(entry.threadId) && !entry.sessionId;
 }
 
 function assertAgentIdentity(input: UpsertSessionCatalogInput): void {
-  if (input.agentId === 'claude') {
+  if (usesNativeSessionId(input.agentId)) {
     if (!input.sessionId || input.threadId) {
-      throw new Error('Claude catalog entries require sessionId and must not include threadId');
+      const name = input.agentId === 'grok' ? 'Grok' : 'Claude';
+      throw new Error(`${name} catalog entries require sessionId and must not include threadId`);
     }
     return;
   }

--- a/src/session/grok-history.ts
+++ b/src/session/grok-history.ts
@@ -1,0 +1,101 @@
+import { readdir, readFile, stat } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { normalizeSessionPreview } from './preview';
+import type { SessionSummary } from './history';
+
+function grokHome(): string {
+  const override = process.env.GROK_HOME?.trim();
+  return override ? override : join(homedir(), '.grok');
+}
+
+function grokSessionGroupDir(cwd: string): string {
+  return join(grokHome(), 'sessions', encodeURIComponent(cwd));
+}
+
+/** Return the most recent `limit` Grok sessions for the given cwd, newest first. */
+export async function listRecentGrokSessions(cwd: string, limit = 5): Promise<SessionSummary[]> {
+  const dir = grokSessionGroupDir(cwd);
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+
+  const summaries = (
+    await Promise.all(entries.map((name) => readGrokSession(join(dir, name), name)))
+  ).filter((entry): entry is SessionSummary => entry !== undefined);
+
+  return summaries.sort((a, b) => b.mtime - a.mtime).slice(0, limit);
+}
+
+async function readGrokSession(dir: string, name: string): Promise<SessionSummary | undefined> {
+  const summaryPath = join(dir, 'summary.json');
+  let raw: string;
+  try {
+    const st = await stat(summaryPath);
+    if (!st.isFile()) return undefined;
+    raw = await readFile(summaryPath, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw err;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+  if (!parsed || typeof parsed !== 'object') return undefined;
+  const record = parsed as {
+    info?: { id?: unknown };
+    generated_title?: unknown;
+    session_summary?: unknown;
+    last_turn_summary?: unknown;
+    updated_at?: unknown;
+    last_active_at?: unknown;
+    created_at?: unknown;
+    num_messages?: unknown;
+    num_chat_messages?: unknown;
+  };
+  const sessionId =
+    typeof record.info?.id === 'string' && record.info.id.trim()
+      ? record.info.id.trim()
+      : name;
+  if (!sessionId) return undefined;
+  const previewSource =
+    stringField(record.generated_title) ??
+    stringField(record.session_summary) ??
+    stringField(record.last_turn_summary) ??
+    sessionId;
+  const mtime =
+    parseTimestamp(record.updated_at) ??
+    parseTimestamp(record.last_active_at) ??
+    parseTimestamp(record.created_at) ??
+    0;
+  const lineCount =
+    numberField(record.num_chat_messages) ?? numberField(record.num_messages) ?? 0;
+  return {
+    sessionId,
+    mtime,
+    preview: normalizeSessionPreview(previewSource),
+    lineCount,
+  };
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function numberField(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function parseTimestamp(value: unknown): number | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : undefined;
+}

--- a/src/ui/onboard.ts
+++ b/src/ui/onboard.ts
@@ -9,7 +9,7 @@ import {
   withConfigFileLock,
   writeActiveProfile,
 } from '../config/profile-store';
-import type { AgentKind } from '../config/profile-schema';
+import { isAgentKind, type AgentKind } from '../config/profile-schema';
 import { secretKeyForApp, type AppConfig, type TenantBrand } from '../config/schema';
 import { buildEncryptedAccountConfig } from '../config/store';
 import { createBootstrapProfileConfig } from '../cli/profile-bootstrap';
@@ -77,7 +77,7 @@ export interface CreateProfileInput {
  */
 export async function onboardCreate(body: unknown, rootDir?: string) {
   const fv = asRecord(body);
-  const agentKind: AgentKind = fv.agentKind === 'codex' ? 'codex' : 'claude';
+  const agentKind: AgentKind = isAgentKind(fv.agentKind) ? fv.agentKind : 'claude';
   const input: CreateProfileInput = {
     profile: String(fv.profile ?? '').trim() || agentKind,
     agentKind,

--- a/src/ui/qr-register.ts
+++ b/src/ui/qr-register.ts
@@ -3,7 +3,7 @@ import { registerApp } from '@larksuite/channel';
 import { resolveAppPaths } from '../config/app-paths';
 import { loadRootConfig } from '../config/profile-store';
 import type { TenantBrand } from '../config/schema';
-import type { AgentKind } from '../config/profile-schema';
+import { isAgentKind, type AgentKind } from '../config/profile-schema';
 import { validateAppCredentials } from '../utils/feishu-auth';
 import { log } from '../core/logger';
 import { HttpError } from './http';
@@ -152,7 +152,7 @@ export async function finishQrRegistration(
   if (s.status === 'error') throw new HttpError(400, s.error ?? '扫码创建失败');
   if (!s.app) throw new HttpError(409, '尚未完成扫码');
 
-  const agentKind: AgentKind = fv.agentKind === 'codex' ? 'codex' : 'claude';
+  const agentKind: AgentKind = isAgentKind(fv.agentKind) ? fv.agentKind : 'claude';
   const profile = String(fv.profile ?? '').trim() || s.suggestedProfile || agentKind;
   const created = await writeNewProfile(
     { profile, agentKind, appId: s.app.appId, appSecret: s.app.appSecret, tenant: s.app.tenant },

--- a/tests/integration/bot/attachment-run-flow.test.ts
+++ b/tests/integration/bot/attachment-run-flow.test.ts
@@ -1,7 +1,7 @@
 import { realpath } from 'node:fs/promises';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { codexCapability } from '../../../src/agent/capability.js';
+import { codexCapability, grokCapability } from '../../../src/agent/capability.js';
 import { ActiveRuns } from '../../../src/bot/active-runs.js';
 import { ProcessPool } from '../../../src/bot/process-pool.js';
 import { startRunFlow } from '../../../src/bot/run-flow.js';
@@ -61,9 +61,45 @@ describe('attachment run flow', () => {
       images: ['/media/image.png'],
     });
   });
+
+  it('passes accepted image attachment paths to Grok adapter runs', async () => {
+    const h = await createHarness('grok');
+
+    const result = await startRunFlow({
+      scopeId: 'chat-1',
+      scope: { source: 'im', chatId: 'chat-1', actorId: 'ou_user' },
+      prompt: 'inspect attachments',
+      attachments: [
+        {
+          kind: 'image',
+          path: '/media/image.png',
+          requiredness: 'optional',
+          decision: 'accepted',
+        },
+        {
+          kind: 'file',
+          path: '/media/file.txt',
+          requiredness: 'optional',
+          decision: 'accepted',
+        },
+      ],
+      access: { ok: true, reason: 'allowed-user' },
+      capability: grokCapability(h.profileConfig),
+      profileConfig: h.profileConfig,
+      sessions: h.sessions,
+      workspaces: h.workspaces,
+      executor: h.executor,
+      now: 1000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(h.agent.runOptions[0]).toMatchObject({
+      images: ['/media/image.png'],
+    });
+  });
 });
 
-async function createHarness(): Promise<{
+async function createHarness(agentKind: 'codex' | 'grok' = 'codex'): Promise<{
   tmp: TmpProfile;
   agent: FakeAgentAdapter;
   executor: RunExecutor;
@@ -73,8 +109,8 @@ async function createHarness(): Promise<{
 }> {
   const tmp = await createTmpProfile('attachment-run-flow-');
   const agent = new FakeAgentAdapter({
-    id: 'codex',
-    displayName: 'Codex',
+    id: agentKind,
+    displayName: agentKind === 'grok' ? 'Grok CLI' : 'Codex',
     events: [{ type: 'done', terminationReason: 'normal' }],
   });
   const executor = new RunExecutor({
@@ -85,7 +121,7 @@ async function createHarness(): Promise<{
     now: () => 1000,
   });
   const profileConfig = createDefaultProfileConfig({
-    agentKind: 'codex',
+    agentKind,
     accounts: {
       app: {
         id: 'cli_test',
@@ -93,9 +129,9 @@ async function createHarness(): Promise<{
         tenant: 'feishu',
       },
     },
-    codex: {
-      binaryPath: '/usr/local/bin/codex',
-    },
+    ...(agentKind === 'codex'
+      ? { codex: { binaryPath: '/usr/local/bin/codex' } }
+      : { grok: { binaryPath: '/usr/local/bin/grok' } }),
   });
   const workspaces = new WorkspaceStore(join(tmp.profile, 'workspaces.json'));
   workspaces.setCwd('chat-1', tmp.workspace);

--- a/tests/integration/cli/first-run-profile.test.ts
+++ b/tests/integration/cli/first-run-profile.test.ts
@@ -135,9 +135,11 @@ describe('first-run profile bootstrap', () => {
     const oldPath = process.env.PATH;
     const oldClaude = process.env.LARK_CHANNEL_CLAUDE_BIN;
     const oldCodex = process.env.LARK_CHANNEL_CODEX_BIN;
+    const oldGrok = process.env.LARK_CHANNEL_GROK_BIN;
     process.env.PATH = root;
     process.env.LARK_CHANNEL_CLAUDE_BIN = 'missing-claude';
     process.env.LARK_CHANNEL_CODEX_BIN = process.platform === 'win32' ? codex : 'codex';
+    process.env.LARK_CHANNEL_GROK_BIN = 'missing-grok';
     try {
       await expect(detectInstalledAgents()).resolves.toEqual([
         { kind: 'codex', binaryPath: codex },
@@ -153,6 +155,11 @@ describe('first-run profile bootstrap', () => {
         delete process.env.LARK_CHANNEL_CODEX_BIN;
       } else {
         process.env.LARK_CHANNEL_CODEX_BIN = oldCodex;
+      }
+      if (oldGrok === undefined) {
+        delete process.env.LARK_CHANNEL_GROK_BIN;
+      } else {
+        process.env.LARK_CHANNEL_GROK_BIN = oldGrok;
       }
     }
   });

--- a/tests/process/grok-adapter.test.ts
+++ b/tests/process/grok-adapter.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 import { GrokAdapter } from '../../src/agent/grok/adapter.js';
 import { buildGrokArgs } from '../../src/agent/grok/argv.js';
-import { prefixBridgeSystemPrompt } from '../../src/agent/bridge-system-prompt.js';
+import { buildBridgeSystemPrompt } from '../../src/agent/bridge-system-prompt.js';
 import type { AgentEvent } from '../../src/agent/types.js';
 
 interface FakeBinary {
@@ -51,12 +51,14 @@ describe('GrokAdapter process contract', () => {
         promptFile: record.promptFile,
         cwd: fake.dir,
         permissionMode: 'acceptEdits',
+        rules: record.rules ?? undefined,
       }),
     );
     expect(record.argv).not.toContain('hello');
-    expect(record.prompt).toBe(prefixBridgeSystemPrompt('hello', undefined));
-    expect(record.prompt).toContain('lark-channel-bridge 运行约定');
-    expect(record.prompt).toContain('__bridge_cb');
+    expect(record.prompt).toBe('hello');
+    expect(record.rules).toBe(buildBridgeSystemPrompt(undefined));
+    expect(record.rules).toContain('lark-channel-bridge 运行约定');
+    expect(record.rules).toContain('__bridge_cb');
     expect(record.argv).not.toContain('--resume');
     expect(record.argv).not.toContain('--model');
   });
@@ -111,6 +113,7 @@ describe('GrokAdapter process contract', () => {
       cwd: fake.dir,
       sessionId: 'sess-old',
       model: 'grok-4.6',
+      sandbox: 'workspace-write',
     });
 
     expect(await collect(run.events)).toEqual([
@@ -118,6 +121,28 @@ describe('GrokAdapter process contract', () => {
     ]);
     const record = await readRecord(fake.recordPath);
     expect(record.argv.slice(-4)).toEqual(['--resume', 'sess-old', '--model', 'grok-4.6']);
+    expect(record.argv).not.toContain('--sandbox');
+  });
+
+  it('lists attached image paths in the prompt file', async () => {
+    const fake = await createFakeGrok({
+      lines: [{ type: 'result', session_id: 'sess-img' }],
+    });
+    cleanup.push(fake.dir);
+    const imagePath = join(fake.dir, 'photo.png');
+
+    const run = new GrokAdapter({ binary: fake.path }).run({
+      runId: 'run-images',
+      prompt: 'look',
+      cwd: fake.dir,
+      images: [imagePath],
+    });
+
+    await collect(run.events);
+    const record = await readRecord(fake.recordPath);
+    expect(record.prompt).toContain('look');
+    expect(record.prompt).toContain('<attached_images>');
+    expect(record.prompt).toContain(imagePath);
   });
 
   it('includes stderr when the process exits non-zero', async () => {
@@ -141,6 +166,33 @@ describe('GrokAdapter process contract', () => {
         message: 'grok exited with code 42: boom',
         terminationReason: 'failed',
       },
+    ]);
+  });
+
+  it('does not emit a second error when the stream already ended with a result error', async () => {
+    const fake = await createFakeGrok({
+      lines: [
+        {
+          type: 'result',
+          subtype: 'error_during_execution',
+          is_error: true,
+          result: 'boom',
+          session_id: 'sess-err',
+        },
+      ],
+      stderr: 'ignored\n',
+      exitCode: 1,
+    });
+    cleanup.push(fake.dir);
+
+    const run = new GrokAdapter({ binary: fake.path }).run({
+      runId: 'run-result-error',
+      prompt: 'fail',
+      cwd: fake.dir,
+    });
+
+    expect(await collect(run.events)).toEqual([
+      { type: 'error', message: 'boom', terminationReason: 'failed' },
     ]);
   });
 
@@ -175,10 +227,13 @@ async function createFakeGrok(options: {
       'const pfIdx = argv.indexOf("--prompt-file");',
       'const promptFile = pfIdx !== -1 ? argv[pfIdx + 1] : "";',
       'const prompt = promptFile ? readFileSync(promptFile, "utf8") : "";',
+      'const rulesIdx = argv.indexOf("--rules");',
+      'const rules = rulesIdx !== -1 ? argv[rulesIdx + 1] : null;',
       `writeFileSync(${JSON.stringify(recordPath)}, JSON.stringify({`,
       '  argv,',
       '  prompt,',
       '  promptFile,',
+      '  rules,',
       '  cwd: process.cwd(),',
       '  env: {',
       '    LARK_CHANNEL: process.env.LARK_CHANNEL,',
@@ -206,6 +261,7 @@ async function readRecord(path: string): Promise<{
   argv: string[];
   prompt: string;
   promptFile: string;
+  rules: string | null;
   cwd: string;
   env: {
     LARK_CHANNEL?: string;
@@ -220,6 +276,7 @@ async function readRecord(path: string): Promise<{
     argv: string[];
     prompt: string;
     promptFile: string;
+    rules: string | null;
     cwd: string;
     env: {
       LARK_CHANNEL?: string;

--- a/tests/process/grok-adapter.test.ts
+++ b/tests/process/grok-adapter.test.ts
@@ -1,0 +1,233 @@
+import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { GrokAdapter } from '../../src/agent/grok/adapter.js';
+import { buildGrokArgs } from '../../src/agent/grok/argv.js';
+import { prefixBridgeSystemPrompt } from '../../src/agent/bridge-system-prompt.js';
+import type { AgentEvent } from '../../src/agent/types.js';
+
+interface FakeBinary {
+  path: string;
+  dir: string;
+  recordPath: string;
+}
+
+describe('GrokAdapter process contract', () => {
+  const cleanup: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      cleanup.splice(0).map((dir) =>
+        rm(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 25 }),
+      ),
+    );
+  });
+
+  it('spawns a fresh run with prompt-file, streaming-messages-json, and bridge prompt', async () => {
+    const fake = await createFakeGrok({
+      lines: [{ type: 'result', session_id: 'sess-fresh' }],
+    });
+    cleanup.push(fake.dir);
+
+    const run = new GrokAdapter({ binary: fake.path }).run({
+      runId: 'run-fresh',
+      prompt: 'hello',
+      cwd: fake.dir,
+      permissionMode: 'acceptEdits',
+    });
+
+    expect(run.runId).toBe('run-fresh');
+    expect(await collect(run.events)).toEqual([
+      { type: 'done', sessionId: 'sess-fresh', terminationReason: 'normal' },
+    ]);
+    const record = await readRecord(fake.recordPath);
+
+    expect(await realpath(record.cwd)).toBe(await realpath(fake.dir));
+    expect(record.env.LARK_CHANNEL).toBe('1');
+    expect(record.env.GROK_DISABLE_AUTOUPDATER).toBe('1');
+    expect(record.argv).toEqual(
+      buildGrokArgs({
+        promptFile: record.promptFile,
+        cwd: fake.dir,
+        permissionMode: 'acceptEdits',
+      }),
+    );
+    expect(record.argv).not.toContain('hello');
+    expect(record.prompt).toBe(prefixBridgeSystemPrompt('hello', undefined));
+    expect(record.prompt).toContain('lark-channel-bridge 运行约定');
+    expect(record.prompt).toContain('__bridge_cb');
+    expect(record.argv).not.toContain('--resume');
+    expect(record.argv).not.toContain('--model');
+  });
+
+  it('injects the active bridge profile env into spawned runs', async () => {
+    const fake = await createFakeGrok({
+      lines: [{ type: 'result', session_id: 'sess-profile' }],
+    });
+    cleanup.push(fake.dir);
+    const rootDir = join(fake.dir, 'channel-home');
+    const configPath = join(rootDir, 'config.custom.json');
+    const larkCliConfigDir = join(rootDir, 'profiles', 'grok-dev', 'lark-cli');
+    const larkCliSourceConfigFile = join(rootDir, 'profiles', 'grok-dev', 'lark-cli-source', 'config.json');
+
+    const run = new GrokAdapter({
+      binary: fake.path,
+      larkChannel: {
+        profile: 'grok-dev',
+        rootDir,
+        configPath,
+        larkCliConfigDir,
+        larkCliSourceConfigFile,
+      },
+    }).run({
+      runId: 'run-profile-env',
+      prompt: 'profile',
+      cwd: fake.dir,
+    });
+
+    await collect(run.events);
+    const record = await readRecord(fake.recordPath);
+
+    expect(record.env).toMatchObject({
+      LARK_CHANNEL: '1',
+      LARK_CHANNEL_PROFILE: 'grok-dev',
+      LARK_CHANNEL_HOME: rootDir,
+      LARK_CHANNEL_CONFIG: larkCliSourceConfigFile,
+      LARKSUITE_CLI_CONFIG_DIR: larkCliConfigDir,
+      GROK_DISABLE_AUTOUPDATER: '1',
+    });
+  });
+
+  it('passes resume and model after the base CLI contract', async () => {
+    const fake = await createFakeGrok({
+      lines: [{ type: 'result', session_id: 'sess-resumed' }],
+    });
+    cleanup.push(fake.dir);
+
+    const run = new GrokAdapter({ binary: fake.path }).run({
+      runId: 'run-resume',
+      prompt: 'continue',
+      cwd: fake.dir,
+      sessionId: 'sess-old',
+      model: 'grok-4.6',
+    });
+
+    expect(await collect(run.events)).toEqual([
+      { type: 'done', sessionId: 'sess-resumed', terminationReason: 'normal' },
+    ]);
+    const record = await readRecord(fake.recordPath);
+    expect(record.argv.slice(-4)).toEqual(['--resume', 'sess-old', '--model', 'grok-4.6']);
+  });
+
+  it('includes stderr when the process exits non-zero', async () => {
+    const fake = await createFakeGrok({
+      lines: [{ type: 'assistant', message: { content: [{ type: 'text', text: 'before failure' }] } }],
+      stderr: 'boom\n',
+      exitCode: 42,
+    });
+    cleanup.push(fake.dir);
+
+    const run = new GrokAdapter({ binary: fake.path }).run({
+      runId: 'run-fail',
+      prompt: 'fail',
+      cwd: fake.dir,
+    });
+
+    expect(await collect(run.events)).toEqual([
+      { type: 'text', delta: 'before failure' },
+      {
+        type: 'error',
+        message: 'grok exited with code 42: boom',
+        terminationReason: 'failed',
+      },
+    ]);
+  });
+
+  it('requires cwd to be resolved by policy before spawning', () => {
+    expect(() =>
+      new GrokAdapter({ binary: 'unused' }).run({ runId: 'run-no-cwd', prompt: 'hi' }),
+    ).toThrow(/cwd is required/);
+  });
+});
+
+async function collect(events: AsyncIterable<AgentEvent>): Promise<AgentEvent[]> {
+  const out: AgentEvent[] = [];
+  for await (const event of events) out.push(event);
+  return out;
+}
+
+async function createFakeGrok(options: {
+  lines: unknown[];
+  stderr?: string;
+  exitCode?: number;
+  exitDelayMs?: number;
+}): Promise<FakeBinary> {
+  const dir = await mkdtemp(join(tmpdir(), 'grok-adapter-test-'));
+  const path = join(dir, 'fake-grok.mjs');
+  const recordPath = join(dir, 'argv.json');
+  await writeFile(
+    path,
+    [
+      '#!/usr/bin/env node',
+      'import { writeFileSync, readFileSync } from "node:fs";',
+      'const argv = process.argv.slice(2);',
+      'const pfIdx = argv.indexOf("--prompt-file");',
+      'const promptFile = pfIdx !== -1 ? argv[pfIdx + 1] : "";',
+      'const prompt = promptFile ? readFileSync(promptFile, "utf8") : "";',
+      `writeFileSync(${JSON.stringify(recordPath)}, JSON.stringify({`,
+      '  argv,',
+      '  prompt,',
+      '  promptFile,',
+      '  cwd: process.cwd(),',
+      '  env: {',
+      '    LARK_CHANNEL: process.env.LARK_CHANNEL,',
+      '    LARK_CHANNEL_PROFILE: process.env.LARK_CHANNEL_PROFILE,',
+      '    LARK_CHANNEL_HOME: process.env.LARK_CHANNEL_HOME,',
+      '    LARK_CHANNEL_CONFIG: process.env.LARK_CHANNEL_CONFIG,',
+      '    LARKSUITE_CLI_CONFIG_DIR: process.env.LARKSUITE_CLI_CONFIG_DIR,',
+      '    GROK_DISABLE_AUTOUPDATER: process.env.GROK_DISABLE_AUTOUPDATER,',
+      '  },',
+      '}));',
+      `const lines = ${JSON.stringify(options.lines)};`,
+      'for (const line of lines) console.log(JSON.stringify(line));',
+      options.stderr ? `process.stderr.write(${JSON.stringify(options.stderr)});` : '',
+      `setTimeout(() => process.exit(${options.exitCode ?? 0}), ${options.exitDelayMs ?? 0});`,
+    ]
+      .filter(Boolean)
+      .join('\n'),
+    'utf8',
+  );
+  await chmod(path, 0o755);
+  return { path, dir, recordPath };
+}
+
+async function readRecord(path: string): Promise<{
+  argv: string[];
+  prompt: string;
+  promptFile: string;
+  cwd: string;
+  env: {
+    LARK_CHANNEL?: string;
+    LARK_CHANNEL_PROFILE?: string;
+    LARK_CHANNEL_HOME?: string;
+    LARK_CHANNEL_CONFIG?: string;
+    LARKSUITE_CLI_CONFIG_DIR?: string;
+    GROK_DISABLE_AUTOUPDATER?: string;
+  };
+}> {
+  return JSON.parse(await readFile(path, 'utf8')) as {
+    argv: string[];
+    prompt: string;
+    promptFile: string;
+    cwd: string;
+    env: {
+      LARK_CHANNEL?: string;
+      LARK_CHANNEL_PROFILE?: string;
+      LARK_CHANNEL_HOME?: string;
+      LARK_CHANNEL_CONFIG?: string;
+      LARKSUITE_CLI_CONFIG_DIR?: string;
+      GROK_DISABLE_AUTOUPDATER?: string;
+    };
+  };
+}

--- a/tests/unit/agent/adapter-system-prompt-wiring.test.ts
+++ b/tests/unit/agent/adapter-system-prompt-wiring.test.ts
@@ -117,7 +117,7 @@ describe('CodexAdapter system prompt wiring', () => {
 });
 
 describe('GrokAdapter system prompt wiring', () => {
-  it('prefixes the identity-aware bridge system prompt into --prompt-file', () => {
+  it('appends the identity-aware bridge system prompt via --rules', () => {
     const child = fakeChild();
     spawnMock.spawnProcess.mockReturnValue(child);
     const adapter = new GrokAdapter({ binary: '/usr/local/bin/grok' });
@@ -125,9 +125,8 @@ describe('GrokAdapter system prompt wiring', () => {
 
     adapter.run({ runId: 'r1', prompt: 'hi', cwd: '/tmp' });
 
-    expect(promptFileContent()).toBe(
-      prefixBridgeSystemPrompt('hi', { openId: 'ou_bot_self', name: 'Bridge' }),
-    );
+    expect(promptFileContent()).toBe('hi');
+    expect(rulesArg()).toBe(buildBridgeSystemPrompt({ openId: 'ou_bot_self', name: 'Bridge' }));
   });
 
   it('falls back to the base system prompt when no identity was set', () => {
@@ -137,15 +136,27 @@ describe('GrokAdapter system prompt wiring', () => {
 
     adapter.run({ runId: 'r1', prompt: 'hi', cwd: '/tmp' });
 
-    expect(promptFileContent()).toBe(prefixBridgeSystemPrompt('hi', undefined));
+    expect(promptFileContent()).toBe('hi');
+    expect(rulesArg()).toBe(buildBridgeSystemPrompt(undefined));
   });
 
+  function grokArgs(): string[] {
+    return spawnMock.spawnProcess.mock.calls[0]?.[1] as string[];
+  }
+
   function promptFileContent(): string {
-    const args = spawnMock.spawnProcess.mock.calls[0]?.[1] as string[];
+    const args = grokArgs();
     const flagIndex = args.indexOf('--prompt-file');
     expect(flagIndex).toBeGreaterThan(-1);
     expect(args).toContain('streaming-messages-json');
     return readFileSync(args[flagIndex + 1] as string, 'utf8');
+  }
+
+  function rulesArg(): string {
+    const args = grokArgs();
+    const flagIndex = args.indexOf('--rules');
+    expect(flagIndex).toBeGreaterThan(-1);
+    return args[flagIndex + 1] as string;
   }
 });
 

--- a/tests/unit/agent/adapter-system-prompt-wiring.test.ts
+++ b/tests/unit/agent/adapter-system-prompt-wiring.test.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../src/agent/bridge-system-prompt';
 import { ClaudeAdapter } from '../../../src/agent/claude/adapter';
 import { CodexAdapter } from '../../../src/agent/codex/adapter';
+import { GrokAdapter } from '../../../src/agent/grok/adapter';
 
 interface FakeChild extends EventEmitter {
   pid: number;
@@ -113,6 +114,39 @@ describe('CodexAdapter system prompt wiring', () => {
     const stdin = await readAll(child.stdin);
     expect(stdin).toBe(prefixBridgeSystemPrompt('hi', undefined));
   });
+});
+
+describe('GrokAdapter system prompt wiring', () => {
+  it('prefixes the identity-aware bridge system prompt into --prompt-file', () => {
+    const child = fakeChild();
+    spawnMock.spawnProcess.mockReturnValue(child);
+    const adapter = new GrokAdapter({ binary: '/usr/local/bin/grok' });
+    adapter.setBotIdentity({ openId: 'ou_bot_self', name: 'Bridge' });
+
+    adapter.run({ runId: 'r1', prompt: 'hi', cwd: '/tmp' });
+
+    expect(promptFileContent()).toBe(
+      prefixBridgeSystemPrompt('hi', { openId: 'ou_bot_self', name: 'Bridge' }),
+    );
+  });
+
+  it('falls back to the base system prompt when no identity was set', () => {
+    const child = fakeChild();
+    spawnMock.spawnProcess.mockReturnValue(child);
+    const adapter = new GrokAdapter({ binary: '/usr/local/bin/grok' });
+
+    adapter.run({ runId: 'r1', prompt: 'hi', cwd: '/tmp' });
+
+    expect(promptFileContent()).toBe(prefixBridgeSystemPrompt('hi', undefined));
+  });
+
+  function promptFileContent(): string {
+    const args = spawnMock.spawnProcess.mock.calls[0]?.[1] as string[];
+    const flagIndex = args.indexOf('--prompt-file');
+    expect(flagIndex).toBeGreaterThan(-1);
+    expect(args).toContain('streaming-messages-json');
+    return readFileSync(args[flagIndex + 1] as string, 'utf8');
+  }
 });
 
 async function readAll(stream: PassThrough): Promise<string> {

--- a/tests/unit/agent/capability.test.ts
+++ b/tests/unit/agent/capability.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { BRIDGE_SYSTEM_PROMPT } from '../../../src/agent/bridge-system-prompt';
-import { claudeCapability, codexCapability } from '../../../src/agent/capability';
+import {
+  capabilityFor,
+  claudeCapability,
+  codexCapability,
+  grokCapability,
+  usesNativeSessionId,
+} from '../../../src/agent/capability';
 import { createDefaultProfileConfig } from '../../../src/config/profile-schema';
 
 describe('agent capability contract', () => {
@@ -71,5 +77,42 @@ describe('agent capability contract', () => {
     });
 
     expect(codexCapability(profile).permissions.maxAccess).toBe('read-only');
+  });
+
+  it('defines Grok capability with native sessions and prompt-file injection', () => {
+    const capability = grokCapability();
+
+    expect(capability).toMatchObject({
+      agentId: 'grok',
+      sessionKind: 'grok-session',
+      promptInjection: 'stdin-prefix',
+      supportsNativeHistory: true,
+      systemPrompt: BRIDGE_SYSTEM_PROMPT,
+      callback: {
+        marker: '__bridge_cb',
+        legacyMarkers: [],
+      },
+    });
+    expect(usesNativeSessionId('grok')).toBe(true);
+    expect(usesNativeSessionId('claude')).toBe(true);
+    expect(usesNativeSessionId('codex')).toBe(false);
+  });
+
+  it('routes capabilityFor to the matching agent kind', () => {
+    const grok = createDefaultProfileConfig({
+      agentKind: 'grok',
+      accounts: {
+        app: {
+          id: 'cli_test',
+          secret: '${APP_SECRET}',
+          tenant: 'feishu',
+        },
+      },
+      grok: { binaryPath: '/usr/local/bin/grok' },
+    });
+    expect(capabilityFor(grok).agentId).toBe('grok');
+    expect(capabilityFor({ agentKind: 'claude', permissions: grok.permissions }).agentId).toBe(
+      'claude',
+    );
   });
 });

--- a/tests/unit/agent/capability.test.ts
+++ b/tests/unit/agent/capability.test.ts
@@ -79,13 +79,13 @@ describe('agent capability contract', () => {
     expect(codexCapability(profile).permissions.maxAccess).toBe('read-only');
   });
 
-  it('defines Grok capability with native sessions and prompt-file injection', () => {
+  it('defines Grok capability with native sessions and appended system prompt', () => {
     const capability = grokCapability();
 
     expect(capability).toMatchObject({
       agentId: 'grok',
       sessionKind: 'grok-session',
-      promptInjection: 'stdin-prefix',
+      promptInjection: 'append-system-prompt',
       supportsNativeHistory: true,
       systemPrompt: BRIDGE_SYSTEM_PROMPT,
       callback: {

--- a/tests/unit/agent/grok-argv.test.ts
+++ b/tests/unit/agent/grok-argv.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { buildGrokArgs, grokSandboxProfile } from '../../../src/agent/grok/argv.js';
+
+describe('buildGrokArgs', () => {
+  it('emits a headless prompt-file contract with default permission mode', () => {
+    expect(
+      buildGrokArgs({
+        promptFile: '/tmp/prompt.md',
+        cwd: '/repo',
+      }),
+    ).toEqual([
+      '--prompt-file',
+      '/tmp/prompt.md',
+      '--output-format',
+      'streaming-messages-json',
+      '--permission-mode',
+      'bypassPermissions',
+      '--cwd',
+      '/repo',
+      '--no-auto-update',
+      '--verbatim',
+    ]);
+  });
+
+  it('appends resume, model, and mapped sandbox after the base flags', () => {
+    expect(
+      buildGrokArgs({
+        promptFile: '/tmp/prompt.md',
+        cwd: '/repo',
+        sessionId: 'sess-1',
+        model: 'grok-4.6',
+        permissionMode: 'acceptEdits',
+        sandbox: 'workspace-write',
+      }),
+    ).toEqual([
+      '--prompt-file',
+      '/tmp/prompt.md',
+      '--output-format',
+      'streaming-messages-json',
+      '--permission-mode',
+      'acceptEdits',
+      '--cwd',
+      '/repo',
+      '--no-auto-update',
+      '--verbatim',
+      '--sandbox',
+      'workspace',
+      '--resume',
+      'sess-1',
+      '--model',
+      'grok-4.6',
+    ]);
+  });
+
+  it('maps sandbox modes onto Grok profiles and omits full access', () => {
+    expect(grokSandboxProfile('read-only')).toBe('read-only');
+    expect(grokSandboxProfile('workspace-write')).toBe('workspace');
+    expect(grokSandboxProfile('danger-full-access')).toBeUndefined();
+    expect(grokSandboxProfile(undefined)).toBeUndefined();
+  });
+});

--- a/tests/unit/agent/grok-argv.test.ts
+++ b/tests/unit/agent/grok-argv.test.ts
@@ -22,15 +22,14 @@ describe('buildGrokArgs', () => {
     ]);
   });
 
-  it('appends resume, model, and mapped sandbox after the base flags', () => {
+  it('appends rules and mapped sandbox on a fresh run', () => {
     expect(
       buildGrokArgs({
         promptFile: '/tmp/prompt.md',
         cwd: '/repo',
-        sessionId: 'sess-1',
-        model: 'grok-4.6',
         permissionMode: 'acceptEdits',
         sandbox: 'workspace-write',
+        rules: 'bridge rules',
       }),
     ).toEqual([
       '--prompt-file',
@@ -43,13 +42,23 @@ describe('buildGrokArgs', () => {
       '/repo',
       '--no-auto-update',
       '--verbatim',
+      '--rules',
+      'bridge rules',
       '--sandbox',
       'workspace',
-      '--resume',
-      'sess-1',
-      '--model',
-      'grok-4.6',
     ]);
+  });
+
+  it('omits --sandbox on resume so Grok restores the session profile', () => {
+    const args = buildGrokArgs({
+      promptFile: '/tmp/prompt.md',
+      cwd: '/repo',
+      sessionId: 'sess-1',
+      model: 'grok-4.6',
+      sandbox: 'workspace-write',
+    });
+    expect(args).not.toContain('--sandbox');
+    expect(args.slice(-4)).toEqual(['--resume', 'sess-1', '--model', 'grok-4.6']);
   });
 
   it('maps sandbox modes onto Grok profiles and omits full access', () => {

--- a/tests/unit/agent/grok-stream-json.test.ts
+++ b/tests/unit/agent/grok-stream-json.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { translateGrokEvent } from '../../../src/agent/grok/stream-json.js';
+
+describe('Grok streaming-messages-json translator', () => {
+  it('reuses the Messages stream-json shape for init, text, and success', () => {
+    expect([
+      ...translateGrokEvent({
+        type: 'system',
+        subtype: 'init',
+        session_id: 'sess-1',
+        cwd: '/repo',
+        model: 'grok-4.6',
+      }),
+    ]).toEqual([
+      { type: 'system', sessionId: 'sess-1', cwd: '/repo', model: 'grok-4.6' },
+    ]);
+
+    expect([
+      ...translateGrokEvent({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'hello' }] },
+      }),
+    ]).toEqual([{ type: 'text', delta: 'hello' }]);
+
+    expect([
+      ...translateGrokEvent({
+        type: 'result',
+        subtype: 'success',
+        session_id: 'sess-1',
+        usage: { input_tokens: 10, output_tokens: 4, cache_read_input_tokens: 1 },
+        total_cost_usd: 0.01,
+      }),
+    ]).toEqual([
+      { type: 'usage', inputTokens: 10, outputTokens: 4, cachedInputTokens: 1, costUsd: 0.01 },
+      { type: 'done', sessionId: 'sess-1', terminationReason: 'normal' },
+    ]);
+  });
+
+  it('maps error result subtypes to a terminal error event', () => {
+    expect([
+      ...translateGrokEvent({
+        type: 'result',
+        subtype: 'error_during_execution',
+        is_error: true,
+        result: 'boom',
+        session_id: 'sess-1',
+      }),
+    ]).toEqual([
+      { type: 'error', message: 'boom', terminationReason: 'failed' },
+    ]);
+  });
+});

--- a/tests/unit/agent/models.test.ts
+++ b/tests/unit/agent/models.test.ts
@@ -12,11 +12,15 @@ describe('agent model catalog', () => {
   it('offers a distinct catalog per agent kind, each led by the default sentinel', () => {
     const claude = supportedModels('claude');
     const codex = supportedModels('codex');
+    const grok = supportedModels('grok');
     expect(claude[0]?.value).toBe(DEFAULT_MODEL);
     expect(codex[0]?.value).toBe(DEFAULT_MODEL);
+    expect(grok[0]?.value).toBe(DEFAULT_MODEL);
     expect(claude.map((m) => m.value)).toContain('claude-opus-4-8');
     expect(codex.map((m) => m.value)).toContain('gpt-5-codex');
+    expect(grok.map((m) => m.value)).toContain('grok-4.6');
     expect(claude.map((m) => m.value)).not.toContain('gpt-5-codex');
+    expect(grok.map((m) => m.value)).not.toContain('gpt-5-codex');
   });
 
   it('treats unset and the default sentinel as "use agent default"', () => {

--- a/tests/unit/cli/start-agent-factory.test.ts
+++ b/tests/unit/cli/start-agent-factory.test.ts
@@ -100,9 +100,31 @@ describe('start runtime agent factory', () => {
     expect(sup).toContain('releaseRuntimeLocks(this.locks)');
   });
 
+  it('creates GrokAdapter from a grok profile binary path', () => {
+    const profile = createDefaultProfileConfig({
+      agentKind: 'grok',
+      accounts: appAccount(),
+      grok: { binaryPath: '/usr/local/bin/grok' },
+    });
+    const agent = createRuntimeAgent(profile, { profileDir: tmpdir() });
+
+    expect(agent.id).toBe('grok');
+    expect(agent.displayName).toBe('Grok CLI');
+  });
+
+  it('seeds a default Grok binary when bootstrapping a new Grok profile', () => {
+    const profile = createRuntimeProfileConfig({
+      agentKind: 'grok',
+      accounts: appAccount(),
+    });
+
+    expect(profile.grok?.binaryPath).toBe('grok');
+  });
+
   it('rejects reconnect when a profile changes agent kind in place', () => {
     expect(() => assertReconnectAgentKindUnchanged('claude', 'codex')).toThrow(/agent kind/i);
     expect(() => assertReconnectAgentKindUnchanged('codex', 'codex')).not.toThrow();
+    expect(() => assertReconnectAgentKindUnchanged('grok', 'claude')).toThrow(/agent kind/i);
   });
 });
 

--- a/tests/unit/config/profile-schema.test.ts
+++ b/tests/unit/config/profile-schema.test.ts
@@ -96,6 +96,28 @@ describe('profile schema', () => {
     ).toThrow(/codex/i);
   });
 
+  it('requires grok configuration when agentKind is grok', () => {
+    expect(() =>
+      normalizeProfileConfig({
+        schemaVersion: 2,
+        agentKind: 'grok',
+        accounts: { app },
+      }),
+    ).toThrow(/grok/i);
+
+    const cfg = createDefaultProfileConfig({
+      agentKind: 'grok',
+      accounts: { app },
+      grok: { binaryPath: '/usr/local/bin/grok' },
+    });
+    expect(cfg.agentKind).toBe('grok');
+    expect(cfg.grok).toEqual({ binaryPath: '/usr/local/bin/grok' });
+    expect(cfg.permissions).toMatchObject({
+      defaultAccess: 'full',
+      maxAccess: 'full',
+    });
+  });
+
   it('rejects sandbox defaults that exceed max capability as a permission error', () => {
     expect(() =>
       normalizeProfileConfig({

--- a/tests/unit/runtime/profile-runtime.test.ts
+++ b/tests/unit/runtime/profile-runtime.test.ts
@@ -238,9 +238,11 @@ describe('profile runtime resolver', () => {
     const oldPath = process.env.PATH;
     const oldClaude = process.env.LARK_CHANNEL_CLAUDE_BIN;
     const oldCodex = process.env.LARK_CHANNEL_CODEX_BIN;
+    const oldGrok = process.env.LARK_CHANNEL_GROK_BIN;
     process.env.PATH = bin;
     delete process.env.LARK_CHANNEL_CLAUDE_BIN;
     delete process.env.LARK_CHANNEL_CODEX_BIN;
+    delete process.env.LARK_CHANNEL_GROK_BIN;
 
     try {
       let error: Error | undefined;
@@ -262,7 +264,7 @@ describe('profile runtime resolver', () => {
       expect(message).toContain(claude);
       expect(message).toContain('codex');
       expect(message).toContain(codex);
-      expect(message).toContain('--agent <claude|codex>');
+      expect(message).toContain('--agent <claude|codex|grok>');
     } finally {
       process.env.PATH = oldPath;
       if (oldClaude === undefined) {
@@ -275,6 +277,11 @@ describe('profile runtime resolver', () => {
       } else {
         process.env.LARK_CHANNEL_CODEX_BIN = oldCodex;
       }
+      if (oldGrok === undefined) {
+        delete process.env.LARK_CHANNEL_GROK_BIN;
+      } else {
+        process.env.LARK_CHANNEL_GROK_BIN = oldGrok;
+      }
     }
   });
 
@@ -286,9 +293,11 @@ describe('profile runtime resolver', () => {
     const oldPath = process.env.PATH;
     const oldClaude = process.env.LARK_CHANNEL_CLAUDE_BIN;
     const oldCodex = process.env.LARK_CHANNEL_CODEX_BIN;
+    const oldGrok = process.env.LARK_CHANNEL_GROK_BIN;
     process.env.PATH = bin;
     delete process.env.LARK_CHANNEL_CLAUDE_BIN;
     delete process.env.LARK_CHANNEL_CODEX_BIN;
+    delete process.env.LARK_CHANNEL_GROK_BIN;
 
     try {
       const runtime = await withTty(true, true, () =>
@@ -316,6 +325,11 @@ describe('profile runtime resolver', () => {
         delete process.env.LARK_CHANNEL_CODEX_BIN;
       } else {
         process.env.LARK_CHANNEL_CODEX_BIN = oldCodex;
+      }
+      if (oldGrok === undefined) {
+        delete process.env.LARK_CHANNEL_GROK_BIN;
+      } else {
+        process.env.LARK_CHANNEL_GROK_BIN = oldGrok;
       }
     }
   });

--- a/tests/unit/session/catalog.test.ts
+++ b/tests/unit/session/catalog.test.ts
@@ -44,6 +44,14 @@ describe('agent-aware session catalog', () => {
       threadId: 'thread-1',
       now: 2000,
     });
+    catalog.upsertActive({
+      scopeId: 'chat-1',
+      agentId: 'grok',
+      cwdRealpath: '/repo',
+      policyFingerprint: 'fp-1',
+      sessionId: 'grok-1',
+      now: 3000,
+    });
 
     expect(
       catalog.activeFor({
@@ -61,6 +69,14 @@ describe('agent-aware session catalog', () => {
         policyFingerprint: 'fp-1',
       }),
     ).toMatchObject({ threadId: 'thread-1', agentId: 'codex' });
+    expect(
+      catalog.activeFor({
+        scopeId: 'chat-1',
+        agentId: 'grok',
+        cwdRealpath: '/repo',
+        policyFingerprint: 'fp-1',
+      }),
+    ).toMatchObject({ sessionId: 'grok-1', agentId: 'grok' });
     await catalog.flush();
   });
 
@@ -87,6 +103,16 @@ describe('agent-aware session catalog', () => {
         now: 1000,
       }),
     ).toThrow(/Codex.*threadId/i);
+    expect(() =>
+      catalog.upsertActive({
+        scopeId: 'chat-1',
+        agentId: 'grok',
+        cwdRealpath: '/repo',
+        policyFingerprint: 'fp-1',
+        threadId: 'thread-wrong',
+        now: 1000,
+      }),
+    ).toThrow(/Grok.*sessionId/i);
 
     await catalog.replaceForTest([
       {

--- a/tests/unit/session/grok-history.test.ts
+++ b/tests/unit/session/grok-history.test.ts
@@ -1,0 +1,70 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { listRecentGrokSessions } from '../../../src/session/grok-history.js';
+
+describe('listRecentGrokSessions', () => {
+  const cleanup: string[] = [];
+  const previousHome = process.env.GROK_HOME;
+
+  afterEach(async () => {
+    if (previousHome === undefined) delete process.env.GROK_HOME;
+    else process.env.GROK_HOME = previousHome;
+    await Promise.all(
+      cleanup.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+    );
+  });
+
+  it('returns an empty list when the grok session group is missing', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'grok-home-'));
+    cleanup.push(home);
+    process.env.GROK_HOME = home;
+    await expect(listRecentGrokSessions('/missing/cwd')).resolves.toEqual([]);
+  });
+
+  it('reads summary.json entries for the encoded working directory', async () => {
+    const home = await mkdtemp(join(tmpdir(), 'grok-home-'));
+    cleanup.push(home);
+    process.env.GROK_HOME = home;
+    const cwd = '/repo/app';
+    const group = join(home, 'sessions', encodeURIComponent(cwd));
+    const newer = join(group, 'sess-new');
+    const older = join(group, 'sess-old');
+    await mkdir(newer, { recursive: true });
+    await mkdir(older, { recursive: true });
+    await writeFile(
+      join(older, 'summary.json'),
+      JSON.stringify({
+        info: { id: 'sess-old' },
+        generated_title: 'Older task',
+        updated_at: '2026-01-01T00:00:00Z',
+        num_chat_messages: 2,
+      }),
+    );
+    await writeFile(
+      join(newer, 'summary.json'),
+      JSON.stringify({
+        info: { id: 'sess-new' },
+        generated_title: 'Newer task',
+        updated_at: '2026-02-01T00:00:00Z',
+        num_chat_messages: 8,
+      }),
+    );
+
+    await expect(listRecentGrokSessions(cwd, 5)).resolves.toEqual([
+      {
+        sessionId: 'sess-new',
+        mtime: Date.parse('2026-02-01T00:00:00Z'),
+        preview: 'Newer task',
+        lineCount: 8,
+      },
+      {
+        sessionId: 'sess-old',
+        mtime: Date.parse('2026-01-01T00:00:00Z'),
+        preview: 'Older task',
+        lineCount: 2,
+      },
+    ]);
+  });
+});

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type AgentKind = "claude" | "codex";
+export type AgentKind = "claude" | "codex" | "grok";
 export type ProfileMode = "personal" | "team";
 export type LarkCliIdentity = "bot-only" | "user-default";
 export type MessageReply = "card" | "markdown" | "text";

--- a/web/src/views/OnboardWizard.tsx
+++ b/web/src/views/OnboardWizard.tsx
@@ -133,6 +133,7 @@ export function OnboardWizard({ onCreated }: { onCreated: (profile: string) => v
             <SelectContent>
               <SelectItem value="claude">Claude Code</SelectItem>
               <SelectItem value="codex">Codex</SelectItem>
+              <SelectItem value="grok">Grok CLI</SelectItem>
             </SelectContent>
           </Select>
         </div>


### PR DESCRIPTION
## Summary

  This PR adds Grok CLI as a first-class local agent alongside Claude Code and Codex CLI.

  ## What changed

  - Adds `grok` detection and profile bootstrap, including `LARK_CHANNEL_GROK_BIN`.
  - Introduces `GrokAdapter` for headless runs, process lifecycle management, stderr/error
  handling, and Lark bridge environment injection.
  - Streams Grok’s `streaming-messages-json` output into existing agent events, including
  partial messages for real-time card updates.
  - Adds native image input via `--prompt-json` content blocks; images are base64-encoded
  before being passed to Grok, so workspace sandboxing cannot block access to the bridge media
  cache.
  - Adds Grok-specific CLI arguments: rules injection, model selection, permission mode,
  sandbox mapping, resume support, and disabled auto-update.
  - Extends profile schema, migration, runtime registry, service commands, CLI options,
  onboarding UI, capability selection, and model picker to recognize `grok`.
  - Adds Grok session persistence and `/resume` history from `~/.grok/sessions`.
  - Updates English and Chinese README documentation with Grok setup and multi-profile
  examples.
  - Adds unit, process, integration, and regression coverage for Grok behavior.

  ## Limitations

  - A resumed Grok session keeps its original sandbox profile; the bridge intentionally omits
  `--sandbox` on resume because the Grok CLI rejects changing it mid-session. Start a new
  session to apply a changed access mode.
  - Native image prompts are encoded into the CLI argument payload, so very large image sets
  may be constrained by the operating system’s command-line size limit.

  ## Testing

  - `pnpm typecheck` passes
  - `pnpm test` passes (108 files, 711 tests)
  - `pnpm build` passes

  ## Example

  ```bash
  lark-channel-bridge profile create grok --agent grok
  lark-channel-bridge start --profile grok --agent grok