### PR TITLE
fix: prevent recursive EIO log storms

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ The legacy `sandbox` field is still readable for old configs. After the bridge s
 | `~/.lark-channel/registry/processes.json` | Local process registry |
 | `~/.lark-channel/registry/locks/` | Profile and app locks |
 
-Set `LARK_CHANNEL_HOME=/path/to/state` to move all local bridge state. `LARK_CHANNEL_LOG_DAYS` overrides log retention.
+Set `LARK_CHANNEL_HOME=/path/to/state` to move all local bridge state. `LARK_CHANNEL_LOG_DAYS` overrides log retention. Each daily structured log is hard-capped at 128 MiB by default; set `LARK_CHANNEL_LOG_MAX_BYTES` to override the byte limit (values below 1 MiB are raised to 1 MiB).
 
 ## Access control
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -234,7 +234,7 @@ bridge 会检查所选目录存在、是目录，并且不是 `/`、Home 根、�
 | `~/.lark-channel/registry/processes.json` | 本机进程注册表 |
 | `~/.lark-channel/registry/locks/` | profile lock 和 app lock |
 
-设置 `LARK_CHANNEL_HOME=/path/to/state` 可以迁移整棵本地状态目录。`LARK_CHANNEL_LOG_DAYS` 可以调整日志保留天数。
+设置 `LARK_CHANNEL_HOME=/path/to/state` 可以迁移整棵本地状态目录。`LARK_CHANNEL_LOG_DAYS` 可以调整日志保留天数。结构化日志默认按日最多写入 128 MiB；可通过 `LARK_CHANNEL_LOG_MAX_BYTES` 调整字节上限（低于 1 MiB 的值会提升为 1 MiB）。
 
 ## 访问控制
 

--- a/src/cli/commands/start.ts
+++ b/src/cli/commands/start.ts
@@ -20,6 +20,7 @@ import {
 import type { AppConfig } from '../../config/schema';
 import { isComplete } from '../../config/schema';
 import { configureLogger, gcOldLogs, log, reportError } from '../../core/logger';
+import { createProcessErrorHandlers } from '../../core/process-errors';
 import { loadTelemetryAdapter, telemetry } from '../../core/telemetry';
 import { gcMediaCache } from '../../media/cache';
 import { startUiServer } from '../../ui/server';
@@ -66,19 +67,16 @@ import { WorkspaceStore } from '../../workspace/store';
 // prefer v4 avoids that whole class of issue.
 dns.setDefaultResultOrder('ipv4first');
 
-// Process-level safety net: never let a stray SDK call / axios timeout
-// take the whole bot down. Most outbound calls (channel.send / rawClient.*)
-// are async; if any callsite misses a try/catch (or fires an update after
-// its enclosing scope returned), the rejection bubbles to here. Log and
-// keep the bot alive — losing a single reply is better than crashing.
-process.on('unhandledRejection', (reason) => {
-  log.fail('process', reason, { kind: 'unhandledRejection' });
-  reportError(reason, { kind: 'unhandledRejection' });
+// Keep a missed asynchronous call-site catch observable without taking down
+// the bot. A truly uncaught exception is fatal: continuing after one is unsafe,
+// and a failed terminal write must not recursively log forever.
+const processErrorHandlers = createProcessErrorHandlers({
+  logFailure: (err, kind) => log.fail('process', err, { kind }),
+  reportError: (err, kind) => reportError(err, { kind }),
+  exit: (code) => process.exit(code),
 });
-process.on('uncaughtException', (err) => {
-  log.fail('process', err, { kind: 'uncaughtException' });
-  reportError(err, { kind: 'uncaughtException' });
-});
+process.on('unhandledRejection', processErrorHandlers.unhandledRejection);
+process.on('uncaughtException', processErrorHandlers.uncaughtException);
 
 const MEDIA_GC_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 

--- a/src/core/logger.ts
+++ b/src/core/logger.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
-import { createWriteStream, mkdirSync, type WriteStream } from 'node:fs';
+import { createWriteStream, mkdirSync, statSync, type WriteStream } from 'node:fs';
 import { open, readdir, rm, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { telemetry } from './telemetry';
@@ -7,6 +7,8 @@ import { telemetry } from './telemetry';
 export interface LoggerOptions {
   logsDir?: string;
   retentionDays: number;
+  /** Hard ceiling for one profile's daily JSONL file. */
+  maxFileBytes: number;
   now: () => Date;
 }
 
@@ -14,9 +16,16 @@ const DEFAULT_RETENTION_DAYS = Math.max(
   1,
   Number(process.env.LARK_CHANNEL_LOG_DAYS ?? 30) || 30,
 );
+const DEFAULT_MAX_FILE_BYTES = (() => {
+  const configured = Number(process.env.LARK_CHANNEL_LOG_MAX_BYTES);
+  return Number.isFinite(configured) && configured > 0
+    ? Math.max(1024 * 1024, Math.floor(configured))
+    : 128 * 1024 * 1024;
+})();
 
 let loggerOptions: LoggerOptions = {
   retentionDays: DEFAULT_RETENTION_DAYS,
+  maxFileBytes: DEFAULT_MAX_FILE_BYTES,
   now: () => new Date(),
 };
 
@@ -66,6 +75,10 @@ const als = new AsyncLocalStorage<LogContext>();
 
 let stream: WriteStream | null = null;
 let currentDate = '';
+let currentBytes = 0;
+let streamBackpressured = false;
+let fileSinkDisabledDate = '';
+let consoleSinkDisabled = false;
 
 function todayKey(): string {
   return formatLocalDateKey(loggerOptions.now());
@@ -83,21 +96,59 @@ function getStream(): WriteStream | null {
   const dir = logsDir();
   if (!dir) return null;
   const today = todayKey();
-  if (stream && currentDate === today) return stream;
-  if (stream) {
-    try {
-      stream.end();
-    } catch {
-      /* noop */
+  if (currentDate !== today) {
+    if (stream) {
+      try {
+        stream.end();
+      } catch {
+        /* noop */
+      }
+      stream = null;
     }
+    streamBackpressured = false;
+    currentBytes = 0;
+    fileSinkDisabledDate = '';
+    currentDate = today;
   }
+  if (fileSinkDisabledDate === today) return null;
+  if (stream) return stream;
   try {
     mkdirSync(dir, { recursive: true });
-    stream = createWriteStream(join(dir, logFileName(today)), { flags: 'a' });
-    currentDate = today;
-    return stream;
+    const path = join(dir, logFileName(today));
+    try {
+      currentBytes = statSync(path).size;
+    } catch {
+      currentBytes = 0;
+    }
+    if (currentBytes >= loggerOptions.maxFileBytes) {
+      fileSinkDisabledDate = today;
+      return null;
+    }
+    const next = createWriteStream(path, { flags: 'a' });
+    stream = next;
+    next.on('error', () => {
+      // A WriteStream reports open/write failures asynchronously. Never leave
+      // an unhandled `error` event capable of reaching the process-level fatal
+      // handler, and do not spin reopening the same broken sink on every log.
+      if (stream === next) {
+        streamBackpressured = false;
+        fileSinkDisabledDate = today;
+      }
+    });
+    return next;
   } catch {
+    fileSinkDisabledDate = today;
     return null;
+  }
+}
+
+function disableFileSink(target: WriteStream, date: string): void {
+  streamBackpressured = false;
+  fileSinkDisabledDate = date;
+  try {
+    target.end();
+  } catch {
+    /* logging failures must never affect runtime behavior */
   }
 }
 
@@ -253,11 +304,26 @@ function emit(level: Level, phase: string, event: string, fields: LogFields = {}
   const externalEntry = sanitizeLogEntry(entry, EXTERNAL_SANITIZE);
   const telemetrySafe = telemetryPayloadFromEntry(externalEntry);
   const s = getStream();
-  if (s) {
-    try {
-      s.write(`${JSON.stringify(entry)}\n`);
-    } catch {
-      /* swallow disk errors — logging should never crash the bot */
+  if (s && !streamBackpressured) {
+    const payload = `${JSON.stringify(entry)}\n`;
+    const payloadBytes = Buffer.byteLength(payload);
+    const date = currentDate;
+    if (currentBytes + payloadBytes > loggerOptions.maxFileBytes) {
+      disableFileSink(s, date);
+    } else {
+      try {
+        currentBytes += payloadBytes;
+        if (!s.write(payload)) {
+          // WriteStream otherwise accepts an unbounded number of queued writes.
+          // Drop subsequent file entries until the kernel/file sink catches up.
+          streamBackpressured = true;
+          s.once('drain', () => {
+            if (stream === s) streamBackpressured = false;
+          });
+        }
+      } catch {
+        disableFileSink(s, date);
+      }
     }
   }
 
@@ -294,7 +360,15 @@ function emit(level: Level, phase: string, event: string, fields: LogFields = {}
   if (!showOnStdout) return;
 
   const fn = level === 'error' ? console.error : level === 'warn' ? console.warn : console.log;
-  fn(formatStdout(level, phase, event, telemetrySafe.ctx, telemetrySafe.fields));
+  if (consoleSinkDisabled) return;
+  try {
+    fn(formatStdout(level, phase, event, telemetrySafe.ctx, telemetrySafe.fields));
+  } catch {
+    // A detached terminal/PTY can make console.error throw EIO/EPIPE. Disable
+    // the human sink after its first failure so logging cannot recursively
+    // trigger the process-level uncaughtException handler.
+    consoleSinkDisabled = true;
+  }
 }
 
 function telemetryPayloadFromEntry(entry: Record<string, unknown>): {
@@ -490,9 +564,14 @@ export function configureLogger(opts: Partial<LoggerOptions>): void {
   }
   stream = null;
   currentDate = '';
+  currentBytes = 0;
+  streamBackpressured = false;
+  fileSinkDisabledDate = '';
+  consoleSinkDisabled = false;
   loggerOptions = {
     ...(opts.logsDir !== undefined ? { logsDir: opts.logsDir } : { logsDir: loggerOptions.logsDir }),
     retentionDays: Math.max(1, opts.retentionDays ?? loggerOptions.retentionDays),
+    maxFileBytes: Math.max(1, opts.maxFileBytes ?? loggerOptions.maxFileBytes),
     now: opts.now ?? loggerOptions.now,
   };
 }
@@ -502,6 +581,9 @@ export async function closeLogger(): Promise<void> {
   if (!s) return;
   stream = null;
   currentDate = '';
+  currentBytes = 0;
+  streamBackpressured = false;
+  fileSinkDisabledDate = '';
   await new Promise<void>((resolve) => {
     let settled = false;
     const done = (): void => {
@@ -524,9 +606,20 @@ export function getLoggerConfig(): LoggerOptions {
 
 export async function flushLogger(): Promise<void> {
   const s = stream;
-  if (!s) return;
+  if (!s || s.closed || s.destroyed) return;
   await new Promise<void>((resolve) => {
-    s.write('', () => resolve());
+    let settled = false;
+    const done = (): void => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    s.once('error', done);
+    try {
+      s.write('', done);
+    } catch {
+      done();
+    }
   });
 }
 

--- a/src/core/process-errors.ts
+++ b/src/core/process-errors.ts
@@ -1,0 +1,51 @@
+export interface ProcessErrorHandlerDeps {
+  logFailure: (err: unknown, kind: 'unhandledRejection' | 'uncaughtException') => void;
+  reportError: (err: unknown, kind: 'unhandledRejection' | 'uncaughtException') => void;
+  exit: (code: number) => void;
+}
+
+/**
+ * Build the process-level safety handlers without binding them to the real
+ * process object, so the fatal path can be regression-tested safely.
+ *
+ * An unhandled rejection is recorded and the bridge stays alive, preserving
+ * the existing behavior for missed asynchronous call-site catches. An
+ * uncaught exception is different: Node cannot guarantee runtime consistency,
+ * and attempting to log through a failed stdout/stderr used to recursively
+ * emit another uncaught exception. Record it at most once and terminate so an
+ * external supervisor can restart a clean process.
+ */
+export function createProcessErrorHandlers(deps: ProcessErrorHandlerDeps): {
+  unhandledRejection: (reason: unknown) => void;
+  uncaughtException: (err: unknown) => void;
+} {
+  let fatalHandled = false;
+
+  const record = (
+    err: unknown,
+    kind: 'unhandledRejection' | 'uncaughtException',
+  ): void => {
+    try {
+      deps.logFailure(err, kind);
+    } catch {
+      // The error reporter must never become a second fatal exception.
+    }
+    try {
+      deps.reportError(err, kind);
+    } catch {
+      // Optional telemetry is best-effort on a fatal path.
+    }
+  };
+
+  return {
+    unhandledRejection(reason): void {
+      record(reason, 'unhandledRejection');
+    },
+    uncaughtException(err): void {
+      if (fatalHandled) return;
+      fatalHandled = true;
+      record(err, 'uncaughtException');
+      deps.exit(1);
+    },
+  };
+}

--- a/tests/unit/core/process-errors.test.ts
+++ b/tests/unit/core/process-errors.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createProcessErrorHandlers } from '../../../src/core/process-errors.js';
+
+describe('process error handlers', () => {
+  it('records an unhandled rejection without exiting', () => {
+    const logFailure = vi.fn();
+    const reportError = vi.fn();
+    const exit = vi.fn();
+    const handlers = createProcessErrorHandlers({ logFailure, reportError, exit });
+    const reason = new Error('async failure');
+
+    handlers.unhandledRejection(reason);
+
+    expect(logFailure).toHaveBeenCalledWith(reason, 'unhandledRejection');
+    expect(reportError).toHaveBeenCalledWith(reason, 'unhandledRejection');
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('records an uncaught exception once and exits once even if reporting throws', () => {
+    const logFailure = vi.fn(() => {
+      throw Object.assign(new Error('write EIO'), { code: 'EIO' });
+    });
+    const reportError = vi.fn(() => {
+      throw new Error('telemetry failed');
+    });
+    const exit = vi.fn();
+    const handlers = createProcessErrorHandlers({ logFailure, reportError, exit });
+    const fatal = new Error('fatal');
+
+    expect(() => handlers.uncaughtException(fatal)).not.toThrow();
+    expect(() => handlers.uncaughtException(new Error('recursive'))).not.toThrow();
+
+    expect(logFailure).toHaveBeenCalledTimes(1);
+    expect(logFailure).toHaveBeenCalledWith(fatal, 'uncaughtException');
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/unit/observability/logger.test.ts
+++ b/tests/unit/observability/logger.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, stat, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -20,6 +20,7 @@ const cleanups: Array<() => Promise<void>> = [];
 describe('profile logger observability', () => {
   afterEach(async () => {
     await closeLogger();
+    configureLogger({ maxFileBytes: 128 * 1024 * 1024 });
     await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
   });
 
@@ -46,6 +47,59 @@ describe('profile logger observability', () => {
       agent: 'claude',
     });
     expect(JSON.parse(text.trim()).ts).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/);
+  });
+
+  it('disables terminal output after console.error throws without breaking file logging', async () => {
+    const tmp = await createTmpProfile('logger-console-eio-');
+    cleanups.push(tmp.cleanup);
+    const logsDir = join(tmp.profile, 'logs');
+    configureLogger({
+      logsDir,
+      now: () => new Date('2026-05-25T12:34:56.000Z'),
+    });
+    const eio = Object.assign(new Error('write EIO'), { code: 'EIO' });
+    const stderr = vi.spyOn(console, 'error').mockImplementation(() => {
+      throw eio;
+    });
+
+    expect(() => log.fail('process', eio, { kind: 'uncaughtException' })).not.toThrow();
+    expect(() => log.fail('process', eio, { kind: 'uncaughtException' })).not.toThrow();
+    await flushLogger();
+
+    expect(stderr).toHaveBeenCalledTimes(1);
+    const lines = (await readFile(join(logsDir, 'bridge-20260525.jsonl'), 'utf8'))
+      .trim()
+      .split('\n');
+    expect(lines).toHaveLength(2);
+    expect(lines.map((line) => JSON.parse(line))).toEqual([
+      expect.objectContaining({ err: 'write EIO', kind: 'uncaughtException' }),
+      expect.objectContaining({ err: 'write EIO', kind: 'uncaughtException' }),
+    ]);
+    stderr.mockRestore();
+  });
+
+  it('hard-caps a daily JSONL file', async () => {
+    const tmp = await createTmpProfile('logger-size-cap-');
+    cleanups.push(tmp.cleanup);
+    const logsDir = join(tmp.profile, 'logs');
+    const path = join(logsDir, 'bridge-20260525.jsonl');
+    configureLogger({
+      logsDir,
+      maxFileBytes: 600,
+      now: () => new Date('2026-05-25T12:34:56.000Z'),
+    });
+
+    for (let i = 0; i < 100; i++) {
+      log.info('test', 'bounded', { i, value: 'x'.repeat(80) });
+    }
+    await closeLogger();
+
+    const size = (await stat(path)).size;
+    expect(size).toBeGreaterThan(0);
+    expect(size).toBeLessThanOrEqual(600);
+    const lines = (await readFile(path, 'utf8')).trim().split('\n');
+    expect(lines.length).toBeLessThan(100);
+    expect(lines.every((line) => JSON.parse(line).event === 'bounded')).toBe(true);
   });
 
   it('prints topic scope, message id, run, COT, outbound, and fallback context on stdout', () => {


### PR DESCRIPTION
## Summary

- stop writing to a console or JSONL sink after `EIO` / `EPIPE`
- respect file-stream backpressure and cap each daily bridge log at 128 MiB by default
- centralize process-level rejection/exception handling so error reporting cannot recursively crash
- document `LARK_CHANNEL_LOG_MAX_BYTES` and cover the failure paths with tests

## Impact

When a detached or broken terminal returns `EIO`, the previous `uncaughtException`
handler logs to the same failed stream. That can recurse indefinitely and generate
an unbounded JSONL log. A real incident produced roughly 80 GiB of logs and exhausted
the host. Raw incident logs are intentionally not attached because they may contain
Lark resource identifiers and environment metadata.

## Validation

- `node node_modules/typescript/bin/tsc --noEmit`
- `node node_modules/vitest/vitest.mjs run tests/unit/observability/logger.test.ts tests/unit/core/process-errors.test.ts`
- Web UI + tsup production build

