### PR TITLE
fix: target the current systemd user bus

### DIFF
--- a/src/cli/commands/service.ts
+++ b/src/cli/commands/service.ts
@@ -123,7 +123,11 @@ function formatServiceStderr(stderr: string): string {
  * to the raw stderr (with platform-specific noise stripped) so power
  * users can still see the underlying problem.
  */
-function printServiceFailure(verb: 'started' | 'restarted', stderr: string): void {
+function printServiceFailure(
+  verb: 'started' | 'restarted',
+  stderr: string,
+  profile: string,
+): void {
   const cleaned = formatServiceStderr(stderr);
   const action = verb === 'started' ? '启动' : '重启';
 
@@ -135,6 +139,25 @@ function printServiceFailure(verb: 'started' | 'restarted', stderr: string): voi
     console.error('  2. 或彻底清除注册再启动:');
     console.error('       unregister');
     console.error('       start');
+    console.error('');
+    console.error('原始错误:');
+    console.error(`  ${cleaned}`);
+    return;
+  }
+
+  if (/failed to connect to bus/i.test(cleaned)) {
+    console.error(`✗ bot ${action}失败: systemd 用户服务不可用。`);
+    console.error('');
+    console.error('请先让当前用户拥有持久的 systemd user manager:');
+    console.error('  sudo loginctl enable-linger "$USER"');
+    console.error('');
+    console.error('如果当前终端继承了其他用户的运行目录,请执行:');
+    console.error('  export XDG_RUNTIME_DIR="/run/user/$(id -u)"');
+    console.error('  export DBUS_SESSION_BUS_ADDRESS="unix:path=$XDG_RUNTIME_DIR/bus"');
+    console.error(`  lark-channel-bridge start --profile ${profile}`);
+    console.error('');
+    console.error('也可以先以前台模式运行:');
+    console.error(`  lark-channel-bridge run --profile ${profile}`);
     console.error('');
     console.error('原始错误:');
     console.error(`  ${cleaned}`);
@@ -291,7 +314,7 @@ async function reportConnectAfter(
 
   const r = await fn();
   if (!r.ok) {
-    printServiceFailure(verb, r.stderr);
+    printServiceFailure(verb, r.stderr, profile);
     process.exit(1);
   }
 

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -97,8 +97,43 @@ interface SystemctlResult {
   stdout: string;
 }
 
+/**
+ * `systemctl --user` trusts XDG_RUNTIME_DIR / DBUS_SESSION_BUS_ADDRESS from
+ * the caller.  Shells launched through sudo, containers, remote agents, or a
+ * user switch can retain `/run/user/0` even though the process itself runs as
+ * an unprivileged user.  In that case systemctl tries the root bus and fails
+ * with EACCES instead of discovering the current user's manager.
+ *
+ * Only rewrite the conventional `/run/user/<uid>` form.  A deliberately
+ * custom runtime directory or bus address is preserved.
+ */
+export function systemdUserEnvironment(
+  source: NodeJS.ProcessEnv = process.env,
+  uid: number | undefined = process.getuid?.(),
+): NodeJS.ProcessEnv {
+  const env = { ...source };
+  if (uid === undefined) return env;
+
+  const runtimeDir = `/run/user/${uid}`;
+  if (!env.XDG_RUNTIME_DIR || /^\/run\/user\/\d+\/?$/.test(env.XDG_RUNTIME_DIR)) {
+    env.XDG_RUNTIME_DIR = runtimeDir;
+  }
+
+  if (
+    !env.DBUS_SESSION_BUS_ADDRESS ||
+    /^unix:path=\/run\/user\/\d+\/bus(?:,.*)?$/.test(env.DBUS_SESSION_BUS_ADDRESS)
+  ) {
+    env.DBUS_SESSION_BUS_ADDRESS = `unix:path=${runtimeDir}/bus`;
+  }
+
+  return env;
+}
+
 function runSystemctl(args: string[]): SystemctlResult {
-  const r = spawnSync('systemctl', ['--user', ...args], { encoding: 'utf8' });
+  const r = spawnSync('systemctl', ['--user', ...args], {
+    encoding: 'utf8',
+    env: systemdUserEnvironment(),
+  });
   return {
     ok: r.status === 0,
     stderr: r.stderr ?? '',
@@ -143,6 +178,7 @@ export function restart(profile: string): SystemctlResult {
 export function isActive(profile: string): boolean {
   const r = spawnSync('systemctl', ['--user', 'is-active', systemdUnitName(profile)], {
     stdio: ['ignore', 'ignore', 'ignore'],
+    env: systemdUserEnvironment(),
   });
   return r.status === 0;
 }

--- a/tests/unit/daemon/profile-args.test.ts
+++ b/tests/unit/daemon/profile-args.test.ts
@@ -9,7 +9,7 @@ import {
   windowsTaskName,
 } from '../../../src/daemon/paths';
 import { buildLauncherCmd } from '../../../src/daemon/schtasks';
-import { buildUnit } from '../../../src/daemon/systemd';
+import { buildUnit, systemdUserEnvironment } from '../../../src/daemon/systemd';
 
 describe('profile-scoped daemon paths and arguments', () => {
   it('sanitizes service ids and gives each profile distinct service names and logs', () => {
@@ -68,5 +68,27 @@ describe('profile-scoped daemon paths and arguments', () => {
     expect(buildUnit(inputs)).not.toContain('--profile');
     expect(buildLauncherCmd(inputs)).toContain('run --web-ui');
     expect(buildLauncherCmd(inputs)).not.toContain('--profile');
+  });
+
+  it('targets the current uid when a shell inherited another user systemd bus', () => {
+    const env = systemdUserEnvironment({
+      PATH: '/usr/bin',
+      XDG_RUNTIME_DIR: '/run/user/0',
+      DBUS_SESSION_BUS_ADDRESS: 'unix:path=/run/user/0/bus',
+    }, 1001);
+
+    expect(env.XDG_RUNTIME_DIR).toBe('/run/user/1001');
+    expect(env.DBUS_SESSION_BUS_ADDRESS).toBe('unix:path=/run/user/1001/bus');
+    expect(env.PATH).toBe('/usr/bin');
+  });
+
+  it('preserves deliberate custom systemd bus settings', () => {
+    const env = systemdUserEnvironment({
+      XDG_RUNTIME_DIR: '/tmp/custom-runtime',
+      DBUS_SESSION_BUS_ADDRESS: 'unix:abstract=/tmp/custom-bus',
+    }, 1001);
+
+    expect(env.XDG_RUNTIME_DIR).toBe('/tmp/custom-runtime');
+    expect(env.DBUS_SESSION_BUS_ADDRESS).toBe('unix:abstract=/tmp/custom-bus');
   });
 });


### PR DESCRIPTION
## Summary

- derive the conventional systemd user runtime directory and bus from the effective UID
- correct inherited `/run/user/<other uid>` values while preserving deliberate custom bus settings
- show actionable `loginctl enable-linger`, environment, and foreground-run guidance when the user manager is unavailable

## Context

A process running as UID 1001 inherited `XDG_RUNTIME_DIR=/run/user/0`. `systemctl --user`
therefore tried to connect to root's bus and failed with `Permission denied`, even after
the UID 1001 user manager was enabled. The bridge now targets `/run/user/1001/bus`
automatically in this conventional mismatch case.

## Validation

- `node node_modules/typescript/bin/tsc --noEmit`
- `node node_modules/vitest/vitest.mjs run tests/unit/daemon/profile-args.test.ts`
- live verification: `start --profile agent` succeeded while the parent shell still exposed `/run/user/0`

